### PR TITLE
feat: MCP bridge — expose A2A agents as MCP tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/waku-a2a-transport",
     "crates/waku-a2a-node",
     "crates/waku-a2a-cli",
+    "crates/waku-a2a-mcp",
 ]
 
 [workspace.dependencies]

--- a/crates/waku-a2a-mcp/Cargo.toml
+++ b/crates/waku-a2a-mcp/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "waku-a2a-mcp"
+version = "0.1.0"
+edition = "2021"
+description = "MCP server bridge — expose Logos Messaging A2A agents as MCP tools"
+
+[[bin]]
+name = "waku-a2a-mcp"
+path = "src/main.rs"
+
+[dependencies]
+waku-a2a-core = { path = "../waku-a2a-core" }
+waku-a2a-node = { path = "../waku-a2a-node" }
+waku-a2a-transport = { path = "../waku-a2a-transport" }
+rmcp = { version = "0.17", features = ["server", "transport-io"] }
+rmcp-macros = "0.17"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/crates/waku-a2a-mcp/README.md
+++ b/crates/waku-a2a-mcp/README.md
@@ -1,0 +1,69 @@
+# waku-a2a-mcp — MCP Bridge for Logos Messaging
+
+Expose agents on the Logos/Waku decentralized network as [MCP](https://modelcontextprotocol.io) tools,
+usable from Claude Desktop, Cursor, VS Code, and any MCP-compatible host.
+
+## Architecture
+
+```
+MCP Host (Claude Desktop)
+    │ stdio (JSON-RPC)
+    ▼
+┌──────────────────┐
+│  waku-a2a-mcp    │  ← this crate
+│  (MCP Server)    │
+└────────┬─────────┘
+         │ HTTP REST
+         ▼
+┌──────────────────┐
+│   nwaku node     │
+│  (Waku network)  │
+└────────┬─────────┘
+         │ Waku relay
+         ▼
+┌──────────────────┐
+│  Agent Fleet     │
+│  (echo, RAG, …)  │
+└──────────────────┘
+```
+
+## MCP Tools Exposed
+
+| Tool | Description |
+|------|-------------|
+| `discover_agents` | Scan the Waku network for announced A2A agents |
+| `send_to_agent` | Send a message/task to a specific agent by name |
+| `list_cached_agents` | List agents from last discovery (no network call) |
+
+## Usage
+
+### Standalone
+```bash
+cargo run -p waku-a2a-mcp -- --waku-url http://localhost:8645
+```
+
+### Claude Desktop config (`claude_desktop_config.json`)
+```json
+{
+  "mcpServers": {
+    "logos-agents": {
+      "command": "waku-a2a-mcp",
+      "args": ["--waku-url", "http://localhost:8645"]
+    }
+  }
+}
+```
+
+### OpenClaw / Cursor
+Add to your MCP server config pointing to the binary.
+
+## Options
+
+- `--waku-url <URL>` — nwaku REST API endpoint (default: `http://localhost:8645`)
+- `--timeout <SECS>` — max wait for agent responses (default: 30)
+
+## Dependencies
+
+- [rmcp](https://crates.io/crates/rmcp) — Official Rust MCP SDK
+- waku-a2a-node — A2A protocol layer
+- nwaku — Waku network node (must be running)

--- a/crates/waku-a2a-mcp/src/main.rs
+++ b/crates/waku-a2a-mcp/src/main.rs
@@ -1,0 +1,274 @@
+//! MCP Bridge Server for Logos Messaging A2A
+//!
+//! Exposes discovered Waku A2A agents as MCP tools.
+//! Each agent on the network becomes a callable tool in Claude Desktop, Cursor, etc.
+//!
+//! Architecture:
+//!   MCP Host (Claude) → stdio → waku-a2a-mcp → Waku → Agent Fleet
+//!
+//! Usage:
+//!   waku-a2a-mcp --waku-url http://localhost:8645
+//!
+//! In Claude Desktop's config:
+//!   { "mcpServers": { "logos-agents": { "command": "waku-a2a-mcp", "args": ["--waku-url", "http://..."] } } }
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use clap::Parser;
+use rmcp::{
+    handler::server::tool::ToolRouter,
+    model::*,
+    tool, tool_handler, tool_router,
+    transport::stdio,
+    ErrorData as McpError, ServerHandler, ServiceExt,
+};
+use tokio::sync::RwLock;
+use tracing_subscriber::EnvFilter;
+
+use waku_a2a_core::{AgentCard, Part, TaskState};
+use waku_a2a_node::WakuA2ANode;
+use waku_a2a_transport::nwaku::NwakuTransport;
+
+#[derive(Parser)]
+#[command(name = "waku-a2a-mcp", about = "MCP bridge for Logos A2A agents")]
+struct Cli {
+    /// nwaku REST API URL
+    #[arg(long, default_value = "http://localhost:8645")]
+    waku_url: String,
+
+    /// How long (seconds) to wait for agent responses
+    #[arg(long, default_value_t = 30)]
+    timeout: u64,
+}
+
+/// Cached snapshot of discovered agents.
+type AgentRegistry = Arc<RwLock<Vec<AgentCard>>>;
+
+/// The MCP server that bridges to A2A over Waku.
+#[derive(Clone)]
+struct LogosA2ABridge {
+    node: Arc<RwLock<WakuA2ANode<NwakuTransport>>>,
+    agents: AgentRegistry,
+    timeout_secs: u64,
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router]
+impl LogosA2ABridge {
+    fn new(waku_url: &str, timeout_secs: u64) -> Self {
+        let transport = NwakuTransport::new(waku_url);
+        let node = WakuA2ANode::new(
+            "mcp-bridge",
+            "MCP bridge — proxies tool calls to Logos A2A agents",
+            vec!["mcp-bridge".into()],
+            transport,
+        );
+
+        Self {
+            node: Arc::new(RwLock::new(node)),
+            agents: Arc::new(RwLock::new(Vec::new())),
+            timeout_secs,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Discover all agents currently advertising on the Waku network.
+    /// Returns their names, descriptions, and capabilities.
+    #[tool(description = "Discover agents on the Logos messaging network. Returns a list of agent names, descriptions, and capabilities. Call this first to see what agents are available.")]
+    async fn discover_agents(&self) -> Result<CallToolResult, McpError> {
+        let node = self.node.read().await;
+        let cards = node.discover().await.map_err(|e| McpError {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: format!("Discovery failed: {e}"),
+            data: None,
+        })?;
+
+        let mut agents = self.agents.write().await;
+        *agents = cards.clone();
+
+        if cards.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No agents found on the network. Make sure nwaku is running and agents are announced.",
+            )]));
+        }
+
+        let summary: Vec<String> = cards
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                format!(
+                    "{}. **{}** (v{}) — {}\n   Capabilities: [{}]\n   Public key: {}...",
+                    i + 1,
+                    c.name,
+                    c.version,
+                    c.description,
+                    c.capabilities.join(", "),
+                    &c.public_key[..16]
+                )
+            })
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Found {} agent(s):\n\n{}",
+            cards.len(),
+            summary.join("\n\n")
+        ))]))
+    }
+
+    /// Send a task/message to a specific agent by name and wait for a response.
+    #[tool(
+        description = "Send a message to a Logos agent by name. The agent will process it and return a response. Call discover_agents first to see available agents.",
+        params(
+            agent_name = "Name of the target agent (from discover_agents)",
+            message = "The message/task to send to the agent"
+        )
+    )]
+    async fn send_to_agent(
+        &self,
+        agent_name: String,
+        message: String,
+    ) -> Result<CallToolResult, McpError> {
+        // Find the agent
+        let agents = self.agents.read().await;
+        let card = agents.iter().find(|c| c.name == agent_name).cloned();
+        drop(agents);
+
+        let card = card.ok_or_else(|| McpError {
+            code: ErrorCode::INVALID_PARAMS,
+            message: format!(
+                "Agent '{agent_name}' not found. Call discover_agents first to refresh the list."
+            ),
+            data: None,
+        })?;
+
+        // Send the task
+        let node = self.node.read().await;
+        let task = node
+            .send_text(&card.public_key, &message)
+            .await
+            .map_err(|e| McpError {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: format!("Failed to send task: {e}"),
+                data: None,
+            })?;
+
+        // Poll for response
+        let deadline =
+            tokio::time::Instant::now() + tokio::time::Duration::from_secs(self.timeout_secs);
+        let task_id = task.id.clone();
+
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Timeout waiting for response from '{agent_name}' (task {}). The agent may still be processing.",
+                    task_id
+                ))]));
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+            let tasks = node.poll_tasks().await.map_err(|e| McpError {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: format!("Poll failed: {e}"),
+                data: None,
+            })?;
+
+            if let Some(response) = tasks.iter().find(|t| t.id == task_id) {
+                match response.state {
+                    TaskState::Completed => {
+                        let text = response
+                            .result
+                            .as_ref()
+                            .map(|m| {
+                                m.parts
+                                    .iter()
+                                    .map(|p| match p {
+                                        Part::Text { text } => text.as_str(),
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            })
+                            .unwrap_or_else(|| "(no result body)".into());
+
+                        return Ok(CallToolResult::success(vec![Content::text(format!(
+                            "Response from '{agent_name}':\n\n{text}"
+                        ))]));
+                    }
+                    TaskState::Failed => {
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "Agent '{agent_name}' reported task failed (task {})",
+                            task_id
+                        ))]));
+                    }
+                    _ => continue, // Still working
+                }
+            }
+        }
+    }
+
+    /// List the currently cached agents (no network call).
+    #[tool(description = "List agents from the last discovery (cached). Use discover_agents to refresh.")]
+    async fn list_cached_agents(&self) -> Result<CallToolResult, McpError> {
+        let agents = self.agents.read().await;
+        if agents.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No cached agents. Call discover_agents first.",
+            )]));
+        }
+
+        let names: Vec<String> = agents
+            .iter()
+            .map(|c| format!("• {} — {}", c.name, c.description))
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(names.join("\n"))]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for LogosA2ABridge {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(
+                "Logos Messaging A2A Bridge — discover and communicate with agents on the \
+                 Logos/Waku decentralized network. Call discover_agents first, then send_to_agent \
+                 to interact with specific agents."
+                    .into(),
+            ),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let cli = Cli::parse();
+
+    tracing::info!(
+        "Starting Logos A2A MCP bridge (waku: {}, timeout: {}s)",
+        cli.waku_url,
+        cli.timeout
+    );
+
+    let bridge = LogosA2ABridge::new(&cli.waku_url, cli.timeout);
+
+    // Announce ourselves on the network
+    {
+        let node = bridge.node.read().await;
+        if let Err(e) = node.announce().await {
+            tracing::warn!("Failed to announce bridge on network: {e}");
+        }
+    }
+
+    // Serve over stdio (standard MCP transport)
+    let service = bridge.serve(stdio()).await?;
+    service.waiting().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Add waku-a2a-mcp crate — MCP server bridging tool calls to Logos A2A agents over Waku.

3 tools: discover_agents, send_to_agent, list_cached_agents
Uses rmcp 0.17 official SDK, stdio transport.

Needs build verification on crib.

Refs #6