### PR TITLE
feat: LogosCoreDeliveryTransport — native Logos Core messaging transport

### DIFF
--- a/crates/logos-messaging-a2a-transport/Cargo.toml
+++ b/crates/logos-messaging-a2a-transport/Cargo.toml
@@ -3,16 +3,17 @@ name = "logos-messaging-a2a-transport"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["rest"]
+rest = ["reqwest"]
+logos-core = ["base64"]
+
 [dependencies]
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, optional = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-
-# TODO (Issue #18): Replace nwaku REST fallback with logos-delivery-rust-bindings FFI
-# Blocked: waku-bindings pins exact versions (once_cell=1.17.1, serde=1.0.163) via rln 0.3.4
-# that conflict with workspace deps. Needs upstream fix.
-# waku-bindings = { git = "https://github.com/logos-messaging/logos-delivery-rust-bindings" }
+base64 = { version = "0.22", optional = true }

--- a/crates/logos-messaging-a2a-transport/build.rs
+++ b/crates/logos-messaging-a2a-transport/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    #[cfg(feature = "logos-core")]
+    {
+        println!("cargo:rustc-link-lib=logos_core");
+        if let Ok(dir) = std::env::var("LOGOS_CORE_LIB_DIR") {
+            println!("cargo:rustc-link-search={}", dir);
+        }
+    }
+}

--- a/crates/logos-messaging-a2a-transport/src/lib.rs
+++ b/crates/logos-messaging-a2a-transport/src/lib.rs
@@ -3,15 +3,23 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 pub mod memory;
+#[cfg(feature = "rest")]
 pub mod nwaku_rest;
 pub mod sds;
+
+#[cfg(feature = "logos-core")]
+mod logos_core;
+#[cfg(feature = "logos-core")]
+pub mod logos_core_transport;
+#[cfg(feature = "logos-core")]
+pub use logos_core_transport::LogosCoreDeliveryTransport;
 
 /// Swappable transport trait — real nwaku in production, in-memory mock in tests.
 ///
 /// Implementations:
-/// - `LogosMessagingTransport`: nwaku REST API (requires running nwaku node)
+/// - `LogosMessagingTransport`: nwaku REST API (requires running nwaku node, `rest` feature)
+/// - `LogosCoreDeliveryTransport`: Logos Core IPC via delivery_module (`logos-core` feature)
 /// - `InMemoryTransport`: in-process mock for testing (no external deps)
-/// - Native waku-bindings transport: TODO (Issue #18) — libwaku FFI via logos-delivery-rust-bindings
 #[async_trait]
 pub trait Transport: Send + Sync + 'static {
     /// Publish a payload to a content topic.

--- a/crates/logos-messaging-a2a-transport/src/logos_core.rs
+++ b/crates/logos-messaging-a2a-transport/src/logos_core.rs
@@ -1,0 +1,148 @@
+//! FFI bindings for Logos Core plugin IPC.
+//!
+//! Wraps `logos_core_call_plugin_method_async` and `logos_core_register_event_listener`
+//! from the Logos Core C API into safe async Rust helpers.
+
+use std::ffi::{c_char, c_void, CString};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+use std::sync::{Arc, Mutex};
+
+/// Callback signature matching `AsyncCallback` in the Logos Core C API.
+type AsyncCallback = extern "C" fn(result: *const c_char, user_data: *mut c_void);
+
+extern "C" {
+    fn logos_core_call_plugin_method_async(
+        plugin_name: *const c_char,
+        method_name: *const c_char,
+        params_json: *const c_char,
+        callback: AsyncCallback,
+        user_data: *mut c_void,
+    );
+
+    fn logos_core_register_event_listener(
+        plugin_name: *const c_char,
+        event_name: *const c_char,
+        callback: AsyncCallback,
+        user_data: *mut c_void,
+    );
+}
+
+/// Shared state between the future and the FFI callback.
+struct CallState {
+    result: Option<String>,
+    waker: Option<Waker>,
+}
+
+/// Future that resolves when the FFI callback fires.
+struct CallFuture {
+    state: Arc<Mutex<CallState>>,
+}
+
+impl Future for CallFuture {
+    type Output = String;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.state.lock().unwrap();
+        if let Some(result) = state.result.take() {
+            Poll::Ready(result)
+        } else {
+            state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+/// FFI trampoline: called from C when the async plugin method completes.
+extern "C" fn call_trampoline(result: *const c_char, user_data: *mut c_void) {
+    let state = unsafe { Arc::from_raw(user_data as *const Mutex<CallState>) };
+    let result_str = if result.is_null() {
+        String::new()
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(result) }
+            .to_string_lossy()
+            .into_owned()
+    };
+    let mut guard = state.lock().unwrap();
+    guard.result = Some(result_str);
+    if let Some(waker) = guard.waker.take() {
+        waker.wake();
+    }
+}
+
+/// Call a Logos Core plugin method asynchronously.
+///
+/// `params` is a JSON array of `[{"name":"x","value":"y","type":"string"}, ...]`.
+pub async fn call_plugin_method(plugin: &str, method: &str, params: &str) -> String {
+    let state = Arc::new(Mutex::new(CallState {
+        result: None,
+        waker: None,
+    }));
+
+    let plugin_c = CString::new(plugin).expect("plugin name contains null byte");
+    let method_c = CString::new(method).expect("method name contains null byte");
+    let params_c = CString::new(params).expect("params contain null byte");
+
+    let state_ptr = Arc::into_raw(Arc::clone(&state)) as *mut c_void;
+
+    unsafe {
+        logos_core_call_plugin_method_async(
+            plugin_c.as_ptr(),
+            method_c.as_ptr(),
+            params_c.as_ptr(),
+            call_trampoline,
+            state_ptr,
+        );
+    }
+
+    CallFuture { state }.await
+}
+
+/// State for a persistent event listener (fires multiple times).
+pub struct EventListenerState {
+    pub sender: tokio::sync::mpsc::UnboundedSender<String>,
+}
+
+/// FFI trampoline for event listeners: forwards each event to an mpsc channel.
+extern "C" fn event_trampoline(result: *const c_char, user_data: *mut c_void) {
+    let state = unsafe { &*(user_data as *const EventListenerState) };
+    let result_str = if result.is_null() {
+        String::new()
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(result) }
+            .to_string_lossy()
+            .into_owned()
+    };
+    let _ = state.sender.send(result_str);
+}
+
+/// Register a persistent event listener on a Logos Core plugin.
+///
+/// Returns an `UnboundedReceiver<String>` that yields each event payload as JSON.
+/// The returned `Box` must be kept alive for the listener to remain active.
+pub fn register_event_listener(
+    plugin: &str,
+    event: &str,
+) -> (
+    tokio::sync::mpsc::UnboundedReceiver<String>,
+    Box<EventListenerState>,
+) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let state = Box::new(EventListenerState { sender: tx });
+    let state_ptr: *const EventListenerState = &*state;
+
+    let plugin_c = CString::new(plugin).expect("plugin name contains null byte");
+    let event_c = CString::new(event).expect("event name contains null byte");
+
+    unsafe {
+        logos_core_register_event_listener(
+            plugin_c.as_ptr(),
+            event_c.as_ptr(),
+            event_trampoline,
+            state_ptr as *mut c_void,
+        );
+    }
+
+    (rx, state)
+}

--- a/crates/logos-messaging-a2a-transport/src/logos_core_transport.rs
+++ b/crates/logos-messaging-a2a-transport/src/logos_core_transport.rs
@@ -1,0 +1,174 @@
+//! Logos Core delivery-module transport — native IPC via `logos_core_call_plugin_method_async`.
+//!
+//! Communicates with the `delivery_module` plugin through Logos Core's C IPC layer
+//! instead of the nwaku REST API. Requires the `logos-core` feature and linking
+//! against `liblogos_core`.
+
+use crate::logos_core;
+use crate::Transport;
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use base64::Engine;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+const PLUGIN: &str = "delivery_module";
+
+/// Build a Logos Core params JSON array from name/value pairs (all string-typed).
+fn params_json(pairs: &[(&str, &str)]) -> String {
+    let entries: Vec<String> = pairs
+        .iter()
+        .map(|(name, value)| {
+            format!(
+                r#"{{"name":"{}","value":"{}","type":"string"}}"#,
+                name, value
+            )
+        })
+        .collect();
+    format!("[{}]", entries.join(","))
+}
+
+/// Transport implementation backed by Logos Core IPC to the `delivery_module` plugin.
+///
+/// Uses `logos_core_call_plugin_method_async` for publish/subscribe/unsubscribe and
+/// `logos_core_register_event_listener` for receiving messages via the `messageReceived` event.
+pub struct LogosCoreDeliveryTransport {
+    subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>>,
+    /// Keep the event listener state alive so the FFI callback pointer stays valid.
+    _event_listener_state: Box<logos_core::EventListenerState>,
+}
+
+impl LogosCoreDeliveryTransport {
+    /// Create and start a new delivery-module transport.
+    ///
+    /// Calls `createNode(cfg)` then `start()` on the delivery_module plugin, and
+    /// registers a global `messageReceived` event listener that fans out to per-topic channels.
+    pub async fn new(cfg: &str) -> Result<Self> {
+        // createNode
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "createNode",
+            &params_json(&[("cfg", cfg)]),
+        )
+        .await;
+        if result != "true" {
+            bail!("delivery_module createNode failed: {}", result);
+        }
+
+        // start
+        let result =
+            logos_core::call_plugin_method(PLUGIN, "start", "[]").await;
+        if result != "true" {
+            bail!("delivery_module start failed: {}", result);
+        }
+
+        let subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        // Register global messageReceived event listener
+        let (mut event_rx, event_state) =
+            logos_core::register_event_listener(PLUGIN, "messageReceived");
+
+        let subs = Arc::clone(&subscriptions);
+        tokio::spawn(async move {
+            while let Some(event_json) = event_rx.recv().await {
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event_json) {
+                    let topic = val
+                        .get("contentTopic")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let payload_b64 = val
+                        .get("payload")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+
+                    let payload = match base64::engine::general_purpose::STANDARD
+                        .decode(payload_b64)
+                    {
+                        Ok(p) => p,
+                        Err(_) => continue,
+                    };
+
+                    let guard = subs.lock().unwrap();
+                    if let Some(tx) = guard.get(topic) {
+                        let _ = tx.send(payload);
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            subscriptions,
+            _event_listener_state: event_state,
+        })
+    }
+}
+
+#[async_trait]
+impl Transport for LogosCoreDeliveryTransport {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+        let payload_b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "send",
+            &params_json(&[("contentTopic", topic), ("payload", &payload_b64)]),
+        )
+        .await;
+
+        // send() returns a QExpected<QString>; a non-error result is success
+        if result.starts_with("error") || result.starts_with("Error") {
+            bail!("delivery_module send failed: {}", result);
+        }
+        Ok(())
+    }
+
+    async fn subscribe(&self, topic: &str) -> Result<mpsc::Receiver<Vec<u8>>> {
+        // Tell the delivery module to subscribe to this content topic
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "subscribe",
+            &params_json(&[("contentTopic", topic)]),
+        )
+        .await;
+        if result != "true" {
+            bail!("delivery_module subscribe failed: {}", result);
+        }
+
+        // Create a channel for this topic and register it for event fan-out
+        let (tx, rx_unbounded) = mpsc::unbounded_channel();
+        self.subscriptions
+            .lock()
+            .unwrap()
+            .insert(topic.to_string(), tx);
+
+        // Bridge unbounded → bounded channel (matching Transport trait signature)
+        let (btx, brx) = mpsc::channel(256);
+        tokio::spawn(async move {
+            let mut rx_unbounded = rx_unbounded;
+            while let Some(msg) = rx_unbounded.recv().await {
+                if btx.send(msg).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(brx)
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<()> {
+        // Remove the channel first so no more events are routed
+        self.subscriptions.lock().unwrap().remove(topic);
+
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "unsubscribe",
+            &params_json(&[("contentTopic", topic)]),
+        )
+        .await;
+        if result != "true" {
+            bail!("delivery_module unsubscribe failed: {}", result);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LogosCoreDeliveryTransport` implementing the `Transport` trait via Logos Core IPC (`logos_core_call_plugin_method_async`) to the `delivery_module` plugin
- Add FFI bindings (`logos_core.rs`) for `logos_core_call_plugin_method_async` and `logos_core_register_event_listener` with async callback bridge
- Gate REST transport behind `rest` feature (default) and new transport behind `logos-core` feature with `base64` dep
- Add `build.rs` for `logos-core` feature to link `liblogos_core`
- Remove "TODO (Issue #18)" from doc comments, add `LogosCoreDeliveryTransport` to trait docs

## Test plan
- [x] `cargo build` (default features) — clean
- [x] `cargo check -p logos-messaging-a2a-transport --features logos-core` — clean
- [x] `cargo test -p logos-messaging-a2a-transport` — all 15 existing tests pass
- [ ] Integration test with actual Logos Core + delivery_module (requires native lib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)