### PR TITLE
feat: A2A-spec HTTP/JSON-RPC server (#47)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,10 +151,153 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-test"
+version = "16.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e3a443d2608936a02a222da7b746eb412fede7225b3030b64fe9be99eab8dc"
+dependencies = [
+ "anyhow",
+ "assert-json-diff",
+ "auto-future",
+ "axum 0.7.9",
+ "bytes",
+ "bytesize 1.3.3",
+ "cookie",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
+]
 
 [[package]]
 name = "base-x"
@@ -301,6 +454,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "bytesize"
@@ -506,6 +665,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +876,21 @@ dependencies = [
  "const-oid",
  "zeroize",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1157,7 +1341,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1218,6 +1402,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1233,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1244,7 +1439,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -1254,6 +1449,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -1266,9 +1467,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1283,7 +1485,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1320,7 +1522,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -1742,6 +1944,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-messaging-a2a-http"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.8",
+ "axum-test",
+ "clap",
+ "logos-messaging-a2a-core",
+ "logos-messaging-a2a-node",
+ "logos-messaging-a2a-transport",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "logos-messaging-a2a-mcp"
 version = "0.1.0"
 dependencies = [
@@ -1836,6 +2057,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +2079,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1965,6 +2208,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -2170,12 +2419,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -2463,7 +2728,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2494,6 +2759,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reserve-port"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2574,6 +2848,22 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "mime",
+ "mime_guess",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2889,6 +3179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,7 +3387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c860b5a3b9c2ab7b32f752a13c92051740b9a18b441edfca2b491a32eb02440"
 dependencies = [
  "bindgen 0.72.1",
- "bytesize",
+ "bytesize 2.3.1",
  "cc",
  "dirs",
  "flate2",
@@ -3263,6 +3564,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3743,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3422,7 +3755,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "iri-string",
  "pin-project-lite",
@@ -3449,6 +3782,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3515,6 +3849,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4168,6 +4508,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/logos-messaging-a2a-mcp",
     "crates/lmao-ffi",
     "crates/logos-messaging-a2a-ffi",
+    "crates/logos-messaging-a2a-http",
 ]
 # The demo enables the `logos-core` feature which requires liblogos_core.so at
 # link time. Excluding it from the workspace prevents feature unification from

--- a/crates/logos-messaging-a2a-http/Cargo.toml
+++ b/crates/logos-messaging-a2a-http/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "logos-messaging-a2a-http"
+version = "0.1.0"
+edition = "2021"
+description = "A2A-spec HTTP/JSON-RPC server for Logos Messaging agents"
+
+[[bin]]
+name = "logos-messaging-a2a-http"
+path = "src/main.rs"
+
+[dependencies]
+logos-messaging-a2a-core = { path = "../logos-messaging-a2a-core" }
+logos-messaging-a2a-node = { path = "../logos-messaging-a2a-node" }
+logos-messaging-a2a-transport = { path = "../logos-messaging-a2a-transport" }
+axum = "0.8"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tower-http = { version = "0.6", features = ["cors"] }
+
+[dev-dependencies]
+axum-test = "16"

--- a/crates/logos-messaging-a2a-http/src/main.rs
+++ b/crates/logos-messaging-a2a-http/src/main.rs
@@ -1,0 +1,487 @@
+//! A2A-spec HTTP/JSON-RPC server for Logos Messaging agents.
+//!
+//! Implements the [Google A2A specification](https://google.github.io/A2A/)
+//! JSON-RPC interface over HTTP, backed by a `WakuA2ANode` for transport.
+//!
+//! # Endpoints
+//!
+//! - `POST /` — JSON-RPC dispatch (`tasks/send`, `tasks/get`)
+//! - `GET /.well-known/agent.json` — AgentCard discovery
+//!
+//! # Usage
+//!
+//! ```bash
+//! logos-messaging-a2a-http --waku-url http://localhost:8645 --port 3000
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Json},
+    routing::{get, post},
+    Router,
+};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tower_http::cors::CorsLayer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use logos_messaging_a2a_core::{Part, Task, TaskState};
+use logos_messaging_a2a_node::WakuA2ANode;
+use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
+
+// ── CLI ──────────────────────────────────────────────────────────────────
+
+#[derive(Parser)]
+#[command(
+    name = "logos-messaging-a2a-http",
+    about = "A2A-spec HTTP server for Logos Messaging agents"
+)]
+struct Cli {
+    /// nwaku REST API URL
+    #[arg(long, default_value = "http://localhost:8645")]
+    waku_url: String,
+
+    /// HTTP server port
+    #[arg(long, default_value_t = 3000)]
+    port: u16,
+
+    /// Timeout in seconds for waiting on task responses
+    #[arg(long, default_value_t = 30)]
+    timeout: u64,
+}
+
+// ── JSON-RPC types ───────────────────────────────────────────────────────
+
+/// JSON-RPC 2.0 request.
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+    pub id: serde_json::Value,
+}
+
+/// JSON-RPC 2.0 response.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+    pub id: serde_json::Value,
+}
+
+/// JSON-RPC error object.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcResponse {
+    fn success(id: serde_json::Value, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    fn error(id: serde_json::Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+            id,
+        }
+    }
+}
+
+// ── JSON-RPC error codes ─────────────────────────────────────────────────
+
+const PARSE_ERROR: i32 = -32700;
+const METHOD_NOT_FOUND: i32 = -32601;
+const INVALID_PARAMS: i32 = -32602;
+const INTERNAL_ERROR: i32 = -32603;
+/// x402: Payment Required (used by payment middleware, reserved here).
+pub const PAYMENT_REQUIRED: i32 = -32402;
+
+// ── Request/Response types for A2A methods ───────────────────────────────
+
+/// Parameters for `tasks/send`.
+#[derive(Debug, Deserialize)]
+pub struct TaskSendParams {
+    /// Target agent public key (hex)
+    pub to: String,
+    /// Message text
+    pub message: String,
+    /// Optional session ID for multi-turn conversations
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+/// Parameters for `tasks/get`.
+#[derive(Debug, Deserialize)]
+pub struct TaskGetParams {
+    /// Task ID to query
+    pub task_id: String,
+}
+
+/// Serializable task response.
+#[derive(Debug, Serialize)]
+pub struct TaskResponse {
+    pub id: String,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+}
+
+impl From<&Task> for TaskResponse {
+    fn from(task: &Task) -> Self {
+        let result_text = task.result.as_ref().map(|m| {
+            m.parts
+                .iter()
+                .map(|p| match p {
+                    Part::Text { text } => text.as_str(),
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        });
+        Self {
+            id: task.id.clone(),
+            state: format!("{:?}", task.state).to_lowercase(),
+            result: result_text,
+        }
+    }
+}
+
+// ── App state ────────────────────────────────────────────────────────────
+
+pub struct AppState {
+    pub node: RwLock<WakuA2ANode<LogosMessagingTransport>>,
+    pub timeout: Duration,
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────
+
+/// `GET /.well-known/agent.json` — A2A agent card discovery.
+pub async fn agent_card(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let node = state.node.read().await;
+    Json(serde_json::to_value(&node.card).unwrap_or_default())
+}
+
+/// `POST /` — JSON-RPC dispatch.
+pub async fn jsonrpc_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    // Parse the JSON-RPC request
+    let req: JsonRpcRequest = match serde_json::from_value(req) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::OK,
+                Json(JsonRpcResponse::error(
+                    serde_json::Value::Null,
+                    PARSE_ERROR,
+                    format!("Parse error: {e}"),
+                )),
+            );
+        }
+    };
+
+    if req.jsonrpc != "2.0" {
+        return (
+            StatusCode::OK,
+            Json(JsonRpcResponse::error(
+                req.id,
+                PARSE_ERROR,
+                "Invalid JSON-RPC version (expected \"2.0\")",
+            )),
+        );
+    }
+
+    let response = match req.method.as_str() {
+        "tasks/send" => handle_tasks_send(&state, req.id.clone(), req.params).await,
+        "tasks/get" => handle_tasks_get(&state, req.id.clone(), req.params).await,
+        "agent/authenticatedExtendedCard" => {
+            let node = state.node.read().await;
+            let card = serde_json::to_value(&node.card).unwrap_or_default();
+            JsonRpcResponse::success(req.id, card)
+        }
+        _ => JsonRpcResponse::error(
+            req.id,
+            METHOD_NOT_FOUND,
+            format!("Method '{}' not found", req.method),
+        ),
+    };
+
+    (StatusCode::OK, Json(response))
+}
+
+async fn handle_tasks_send(
+    state: &AppState,
+    id: serde_json::Value,
+    params: serde_json::Value,
+) -> JsonRpcResponse {
+    let params: TaskSendParams = match serde_json::from_value(params) {
+        Ok(p) => p,
+        Err(e) => {
+            return JsonRpcResponse::error(
+                id,
+                INVALID_PARAMS,
+                format!("Invalid params: {e}"),
+            );
+        }
+    };
+
+    let node = state.node.read().await;
+
+    // Send the task (with optional session)
+    let task = if let Some(ref sid) = params.session_id {
+        match node.send_in_session(sid, &params.message).await {
+            Ok(t) => t,
+            Err(e) => {
+                return JsonRpcResponse::error(id, INTERNAL_ERROR, format!("Send failed: {e}"));
+            }
+        }
+    } else {
+        match node.send_text(&params.to, &params.message).await {
+            Ok(t) => t,
+            Err(e) => {
+                return JsonRpcResponse::error(id, INTERNAL_ERROR, format!("Send failed: {e}"));
+            }
+        }
+    };
+
+    let task_id = task.id.clone();
+
+    // Wait for response with timeout
+    let deadline = tokio::time::Instant::now() + state.timeout;
+
+    loop {
+        if tokio::time::Instant::now() > deadline {
+            return JsonRpcResponse::success(
+                id,
+                serde_json::json!({
+                    "id": task_id,
+                    "state": "submitted",
+                    "result": null,
+                    "timeout": true
+                }),
+            );
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let tasks = match node.poll_tasks().await {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+
+        if let Some(response) = tasks.iter().find(|t| t.id == task_id) {
+            match response.state {
+                TaskState::Completed | TaskState::Failed => {
+                    let resp = TaskResponse::from(response);
+                    return JsonRpcResponse::success(
+                        id,
+                        serde_json::to_value(resp).unwrap_or_default(),
+                    );
+                }
+                _ => continue,
+            }
+        }
+    }
+}
+
+async fn handle_tasks_get(
+    state: &AppState,
+    id: serde_json::Value,
+    params: serde_json::Value,
+) -> JsonRpcResponse {
+    let params: TaskGetParams = match serde_json::from_value(params) {
+        Ok(p) => p,
+        Err(e) => {
+            return JsonRpcResponse::error(
+                id,
+                INVALID_PARAMS,
+                format!("Invalid params: {e}"),
+            );
+        }
+    };
+
+    let node = state.node.read().await;
+    let tasks = match node.poll_tasks().await {
+        Ok(t) => t,
+        Err(e) => {
+            return JsonRpcResponse::error(id, INTERNAL_ERROR, format!("Poll failed: {e}"));
+        }
+    };
+
+    match tasks.iter().find(|t| t.id == params.task_id) {
+        Some(task) => {
+            let resp = TaskResponse::from(task);
+            JsonRpcResponse::success(id, serde_json::to_value(resp).unwrap_or_default())
+        }
+        None => JsonRpcResponse::error(
+            id,
+            INVALID_PARAMS,
+            format!("Task '{}' not found", params.task_id),
+        ),
+    }
+}
+
+/// Build the axum router.
+pub fn build_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/.well-known/agent.json", get(agent_card))
+        .route("/", post(jsonrpc_handler))
+        .layer(CorsLayer::permissive())
+        .with_state(state)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let cli = Cli::parse();
+
+    tracing::info!(
+        "Starting A2A HTTP server (waku: {}, port: {}, timeout: {}s)",
+        cli.waku_url,
+        cli.port,
+        cli.timeout
+    );
+
+    let transport = LogosMessagingTransport::new(&cli.waku_url);
+    let node = WakuA2ANode::new(
+        "http-server",
+        "A2A HTTP/JSON-RPC server — standard HTTP interface to Logos agents",
+        vec!["http-server".into()],
+        transport,
+    );
+
+    // Announce on network
+    if let Err(e) = node.announce().await {
+        tracing::warn!("Failed to announce on network: {e}");
+    }
+
+    let state = Arc::new(AppState {
+        node: RwLock::new(node),
+        timeout: Duration::from_secs(cli.timeout),
+    });
+
+    let app = build_router(state);
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", cli.port)).await?;
+    tracing::info!("Listening on 0.0.0.0:{}", cli.port);
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsonrpc_response_success_serialization() {
+        let resp = JsonRpcResponse::success(
+            serde_json::json!(1),
+            serde_json::json!({"status": "ok"}),
+        );
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["jsonrpc"], "2.0");
+        assert_eq!(json["result"]["status"], "ok");
+        assert!(json.get("error").is_none());
+        assert_eq!(json["id"], 1);
+    }
+
+    #[test]
+    fn jsonrpc_response_error_serialization() {
+        let resp = JsonRpcResponse::error(
+            serde_json::json!("abc"),
+            METHOD_NOT_FOUND,
+            "not found",
+        );
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["jsonrpc"], "2.0");
+        assert!(json.get("result").is_none());
+        assert_eq!(json["error"]["code"], METHOD_NOT_FOUND);
+        assert_eq!(json["error"]["message"], "not found");
+        assert_eq!(json["id"], "abc");
+    }
+
+    #[test]
+    fn task_response_from_completed_task() {
+        let task = Task::new("0xfrom", "0xto", "hello");
+        let mut task = task;
+        task.state = TaskState::Completed;
+        task.result = Some(logos_messaging_a2a_core::Message {
+            role: "agent".into(),
+            parts: vec![Part::Text { text: "world".into() }],
+        });
+        let resp = TaskResponse::from(&task);
+        assert_eq!(resp.state, "completed");
+        assert_eq!(resp.result, Some("world".into()));
+    }
+
+    #[test]
+    fn task_response_from_submitted_task() {
+        let task = Task::new("0xfrom", "0xto", "hello");
+        let resp = TaskResponse::from(&task);
+        assert_eq!(resp.state, "submitted");
+        assert_eq!(resp.result, None);
+    }
+
+    #[test]
+    fn parse_task_send_params() {
+        let json = serde_json::json!({
+            "to": "0xabc",
+            "message": "hello",
+            "session_id": "sess-1"
+        });
+        let params: TaskSendParams = serde_json::from_value(json).unwrap();
+        assert_eq!(params.to, "0xabc");
+        assert_eq!(params.message, "hello");
+        assert_eq!(params.session_id, Some("sess-1".into()));
+    }
+
+    #[test]
+    fn parse_task_send_params_no_session() {
+        let json = serde_json::json!({
+            "to": "0xabc",
+            "message": "hello"
+        });
+        let params: TaskSendParams = serde_json::from_value(json).unwrap();
+        assert_eq!(params.session_id, None);
+    }
+
+    #[test]
+    fn parse_task_get_params() {
+        let json = serde_json::json!({"task_id": "task-123"});
+        let params: TaskGetParams = serde_json::from_value(json).unwrap();
+        assert_eq!(params.task_id, "task-123");
+    }
+
+    #[test]
+    fn payment_required_code() {
+        assert_eq!(PAYMENT_REQUIRED, -32402);
+    }
+}

--- a/logos-core-module/result
+++ b/logos-core-module/result
@@ -1,0 +1,1 @@
+/nix/store/63awq7z69claivfylz5pazx7d0pahjwc-lmao-core-module-0.1.0


### PR DESCRIPTION
New crate `logos-messaging-a2a-http` implementing the Google A2A spec JSON-RPC interface over HTTP.

## What
- `POST /` — JSON-RPC dispatch (`tasks/send`, `tasks/get`, `agent/authenticatedExtendedCard`)
- `GET /.well-known/agent.json` — AgentCard discovery (A2A spec)
- Session support for multi-turn conversations via `session_id`
- CORS enabled, configurable timeout, CLI flags for waku URL + port
- `PAYMENT_REQUIRED` error code reserved for future x402 middleware (#38)

## Tests
8 unit tests: JSON-RPC serialization, param parsing, task response mapping. All 93 workspace tests pass.

## Usage
```bash
logos-messaging-a2a-http --waku-url http://localhost:8645 --port 3000

# Discover
curl http://localhost:3000/.well-known/agent.json

# Send task
curl -X POST http://localhost:3000 -H "Content-Type: application/json" -d \x27{"jsonrpc":"2.0","method":"tasks/send","params":{"to":"0xagent","message":"hello"},"id":1}\x27
```

Closes #47