### PR TITLE
feat: AgentRegistry trait + InMemoryRegistry + node integration (#4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,11 +2263,13 @@ name = "logos-messaging-a2a-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "hex",
  "k256 0.13.4",
  "logos-messaging-a2a-crypto",
  "serde",
  "serde_json",
+ "tokio",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,42 @@ The `PeerMap` lazily evicts expired entries. Call `peers().evict_expired()` to
 clean up, or just rely on `get()` / `find_by_capability()` which skip expired
 entries automatically.
 
+## Persistent Agent Registry (LEZ)
+
+While presence broadcasts provide ephemeral discovery, the **Agent Registry**
+trait enables persistent, on-chain agent discovery via LEZ (the Logos Execution
+Zone). Agents register their `AgentCard` once, and it remains discoverable even
+when the agent is offline.
+
+```rust
+use logos_messaging_a2a_core::registry::{AgentRegistry, InMemoryRegistry};
+use logos_messaging_a2a_node::WakuA2ANode;
+use logos_messaging_a2a_transport::memory::InMemoryTransport;
+use std::sync::Arc;
+
+let transport = InMemoryTransport::new();
+let registry = Arc::new(InMemoryRegistry::new());
+
+let node = WakuA2ANode::new("echo", "Echo agent", vec!["echo".into()], transport)
+    .with_registry(registry.clone());
+
+// Register once — persists across restarts
+node.register_in_registry().await?;
+
+// discover_all() merges Waku presence + registry results
+let all_agents = node.discover_all().await?;
+```
+
+The `AgentRegistry` trait is backend-agnostic:
+
+| Backend | Status | Description |
+|---------|--------|-------------|
+| `InMemoryRegistry` | ✅ Ready | In-process mock for testing |
+| LEZ (SPELbook) | 🔜 Planned | On-chain PDA accounts via SPEL framework |
+
+Discovery merges both sources, with the registry as source of truth when an
+agent appears in both. Self-entries are excluded from results.
+
 ## x402 Payment Flow
 
 LMAO supports [x402-style](https://www.x402.org/) payment gating: agents can

--- a/crates/logos-messaging-a2a-core/Cargo.toml
+++ b/crates/logos-messaging-a2a-core/Cargo.toml
@@ -11,3 +11,7 @@ uuid = { workspace = true }
 k256 = { workspace = true }
 hex = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/logos-messaging-a2a-core/src/lib.rs
+++ b/crates/logos-messaging-a2a-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod envelope;
 pub mod presence;
+pub mod registry;
 pub mod task;
 pub mod topics;
 

--- a/crates/logos-messaging-a2a-core/src/registry.rs
+++ b/crates/logos-messaging-a2a-core/src/registry.rs
@@ -1,0 +1,306 @@
+//! Agent registry trait for persistent on-chain discovery.
+//!
+//! While Waku presence broadcasts provide ephemeral, real-time agent
+//! discovery, the [`AgentRegistry`] trait defines a persistent store
+//! where agents register themselves for long-lived discoverability.
+//!
+//! The primary implementation target is the LEZ on-chain program registry
+//! (SPELbook), where `AgentCard`s are stored as PDA accounts. This module
+//! provides the trait and a test-friendly in-memory implementation.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Discovery layer:
+//!   Waku presence (ephemeral) ──┐
+//!                                ├──► merged agent list
+//!   LEZ registry (persistent) ──┘
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use logos_messaging_a2a_core::registry::InMemoryRegistry;
+//! use logos_messaging_a2a_core::registry::AgentRegistry;
+//! use logos_messaging_a2a_core::AgentCard;
+//!
+//! # async fn example() -> Result<(), logos_messaging_a2a_core::registry::RegistryError> {
+//! let registry = InMemoryRegistry::new();
+//! let card = AgentCard {
+//!     name: "echo-agent".into(),
+//!     description: "Echoes messages".into(),
+//!     version: "0.1.0".into(),
+//!     capabilities: vec!["echo".into()],
+//!     public_key: "deadbeef".into(),
+//!     intro_bundle: None,
+//! };
+//! registry.register(card.clone()).await?;
+//! let agents = registry.list().await?;
+//! assert_eq!(agents.len(), 1);
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::AgentCard;
+use std::fmt;
+
+/// Errors returned by registry operations.
+#[derive(Debug)]
+pub enum RegistryError {
+    /// Agent with this public key is not registered.
+    NotFound(String),
+    /// Only the original registrant can update/deregister.
+    Unauthorized(String),
+    /// Agent with this public key is already registered.
+    AlreadyRegistered(String),
+    /// Network or backend failure.
+    Backend(String),
+}
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RegistryError::NotFound(key) => write!(f, "agent not found: {}", key),
+            RegistryError::Unauthorized(msg) => write!(f, "unauthorized: {}", msg),
+            RegistryError::AlreadyRegistered(key) => {
+                write!(f, "agent already registered: {}", key)
+            }
+            RegistryError::Backend(msg) => write!(f, "registry backend error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+/// Persistent agent registry for on-chain or off-chain discovery.
+///
+/// Implementors provide durable storage of [`AgentCard`]s. The primary
+/// target is LEZ (via SPELbook PDA accounts), but any persistent store
+/// (database, file, etc.) can implement this trait.
+#[async_trait::async_trait]
+pub trait AgentRegistry: Send + Sync {
+    /// Register an agent. Returns error if already registered.
+    async fn register(&self, card: AgentCard) -> Result<(), RegistryError>;
+
+    /// Update an existing registration. Returns error if not found.
+    async fn update(&self, card: AgentCard) -> Result<(), RegistryError>;
+
+    /// Remove an agent from the registry.
+    async fn deregister(&self, public_key: &str) -> Result<(), RegistryError>;
+
+    /// Look up a specific agent by public key.
+    async fn get(&self, public_key: &str) -> Result<AgentCard, RegistryError>;
+
+    /// List all registered agents.
+    async fn list(&self) -> Result<Vec<AgentCard>, RegistryError>;
+
+    /// Search agents by capability tag.
+    async fn find_by_capability(&self, capability: &str) -> Result<Vec<AgentCard>, RegistryError>;
+}
+
+/// In-memory agent registry for testing and local development.
+///
+/// Not persistent — data is lost when the process exits.
+pub struct InMemoryRegistry {
+    agents: std::sync::RwLock<std::collections::HashMap<String, AgentCard>>,
+}
+
+impl InMemoryRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            agents: std::sync::RwLock::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentRegistry for InMemoryRegistry {
+    async fn register(&self, card: AgentCard) -> Result<(), RegistryError> {
+        let mut agents = self.agents.write().unwrap();
+        if agents.contains_key(&card.public_key) {
+            return Err(RegistryError::AlreadyRegistered(card.public_key));
+        }
+        agents.insert(card.public_key.clone(), card);
+        Ok(())
+    }
+
+    async fn update(&self, card: AgentCard) -> Result<(), RegistryError> {
+        let mut agents = self.agents.write().unwrap();
+        if !agents.contains_key(&card.public_key) {
+            return Err(RegistryError::NotFound(card.public_key));
+        }
+        agents.insert(card.public_key.clone(), card);
+        Ok(())
+    }
+
+    async fn deregister(&self, public_key: &str) -> Result<(), RegistryError> {
+        let mut agents = self.agents.write().unwrap();
+        agents
+            .remove(public_key)
+            .ok_or_else(|| RegistryError::NotFound(public_key.to_string()))?;
+        Ok(())
+    }
+
+    async fn get(&self, public_key: &str) -> Result<AgentCard, RegistryError> {
+        let agents = self.agents.read().unwrap();
+        agents
+            .get(public_key)
+            .cloned()
+            .ok_or_else(|| RegistryError::NotFound(public_key.to_string()))
+    }
+
+    async fn list(&self) -> Result<Vec<AgentCard>, RegistryError> {
+        let agents = self.agents.read().unwrap();
+        Ok(agents.values().cloned().collect())
+    }
+
+    async fn find_by_capability(&self, capability: &str) -> Result<Vec<AgentCard>, RegistryError> {
+        let agents = self.agents.read().unwrap();
+        Ok(agents
+            .values()
+            .filter(|c| c.capabilities.iter().any(|cap| cap == capability))
+            .cloned()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_card(name: &str, pubkey: &str, caps: Vec<&str>) -> AgentCard {
+        AgentCard {
+            name: name.to_string(),
+            description: format!("{} agent", name),
+            version: "0.1.0".to_string(),
+            capabilities: caps.into_iter().map(String::from).collect(),
+            public_key: pubkey.to_string(),
+            intro_bundle: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn register_and_get() {
+        let reg = InMemoryRegistry::new();
+        let card = test_card("echo", "aabb", vec!["echo"]);
+        reg.register(card.clone()).await.unwrap();
+        let got = reg.get("aabb").await.unwrap();
+        assert_eq!(got, card);
+    }
+
+    #[tokio::test]
+    async fn register_duplicate_fails() {
+        let reg = InMemoryRegistry::new();
+        let card = test_card("echo", "aabb", vec!["echo"]);
+        reg.register(card.clone()).await.unwrap();
+        let err = reg.register(card).await.unwrap_err();
+        assert!(matches!(err, RegistryError::AlreadyRegistered(_)));
+    }
+
+    #[tokio::test]
+    async fn update_existing() {
+        let reg = InMemoryRegistry::new();
+        let card = test_card("echo", "aabb", vec!["echo"]);
+        reg.register(card).await.unwrap();
+
+        let updated = test_card("echo-v2", "aabb", vec!["echo", "translate"]);
+        reg.update(updated.clone()).await.unwrap();
+
+        let got = reg.get("aabb").await.unwrap();
+        assert_eq!(got.name, "echo-v2");
+        assert_eq!(got.capabilities.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_nonexistent_fails() {
+        let reg = InMemoryRegistry::new();
+        let card = test_card("ghost", "ccdd", vec!["spook"]);
+        let err = reg.update(card).await.unwrap_err();
+        assert!(matches!(err, RegistryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn deregister_removes() {
+        let reg = InMemoryRegistry::new();
+        let card = test_card("echo", "aabb", vec!["echo"]);
+        reg.register(card).await.unwrap();
+        reg.deregister("aabb").await.unwrap();
+        let err = reg.get("aabb").await.unwrap_err();
+        assert!(matches!(err, RegistryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn deregister_nonexistent_fails() {
+        let reg = InMemoryRegistry::new();
+        let err = reg.deregister("nope").await.unwrap_err();
+        assert!(matches!(err, RegistryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn list_all_agents() {
+        let reg = InMemoryRegistry::new();
+        reg.register(test_card("a", "11", vec!["x"])).await.unwrap();
+        reg.register(test_card("b", "22", vec!["y"])).await.unwrap();
+        reg.register(test_card("c", "33", vec!["x", "y"]))
+            .await
+            .unwrap();
+        let all = reg.list().await.unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn find_by_capability_filters() {
+        let reg = InMemoryRegistry::new();
+        reg.register(test_card("a", "11", vec!["translate"]))
+            .await
+            .unwrap();
+        reg.register(test_card("b", "22", vec!["echo"]))
+            .await
+            .unwrap();
+        reg.register(test_card("c", "33", vec!["translate", "echo"]))
+            .await
+            .unwrap();
+
+        let translators = reg.find_by_capability("translate").await.unwrap();
+        assert_eq!(translators.len(), 2);
+
+        let echoers = reg.find_by_capability("echo").await.unwrap();
+        assert_eq!(echoers.len(), 2);
+
+        let none = reg.find_by_capability("nonexistent").await.unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_nonexistent_fails() {
+        let reg = InMemoryRegistry::new();
+        let err = reg.get("missing").await.unwrap_err();
+        assert!(matches!(err, RegistryError::NotFound(_)));
+    }
+
+    #[test]
+    fn registry_error_display() {
+        let e1 = RegistryError::NotFound("abc".into());
+        assert!(e1.to_string().contains("abc"));
+        let e2 = RegistryError::Unauthorized("no".into());
+        assert!(e2.to_string().contains("no"));
+        let e3 = RegistryError::AlreadyRegistered("xyz".into());
+        assert!(e3.to_string().contains("xyz"));
+        let e4 = RegistryError::Backend("timeout".into());
+        assert!(e4.to_string().contains("timeout"));
+    }
+
+    #[test]
+    fn default_creates_empty_registry() {
+        let reg = InMemoryRegistry::default();
+        let agents = reg.agents.read().unwrap();
+        assert!(agents.is_empty());
+    }
+}

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -2,6 +2,7 @@ pub mod presence;
 
 use anyhow::{Context, Result};
 use k256::ecdsa::SigningKey;
+use logos_messaging_a2a_core::registry::AgentRegistry;
 pub use logos_messaging_a2a_core::Task as TaskType;
 use logos_messaging_a2a_core::{
     topics, A2AEnvelope, AgentCard, Message, PresenceAnnouncement, Task,
@@ -120,6 +121,8 @@ pub struct WakuA2ANode<T: Transport> {
     peer_map: presence::PeerMap,
     /// Persistent subscription to the presence topic (lazy-initialized).
     presence_rx: tokio::sync::Mutex<Option<mpsc::Receiver<Vec<u8>>>>,
+    /// Optional persistent agent registry (e.g. LEZ on-chain).
+    registry: Option<Arc<dyn AgentRegistry>>,
 }
 
 impl<T: Transport> WakuA2ANode<T> {
@@ -158,6 +161,7 @@ impl<T: Transport> WakuA2ANode<T> {
             seen_tx_hashes: std::sync::Mutex::new(HashSet::new()),
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
+            registry: None,
         }
     }
 
@@ -204,6 +208,7 @@ impl<T: Transport> WakuA2ANode<T> {
             seen_tx_hashes: std::sync::Mutex::new(HashSet::new()),
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
+            registry: None,
         }
     }
 
@@ -247,6 +252,7 @@ impl<T: Transport> WakuA2ANode<T> {
             seen_tx_hashes: std::sync::Mutex::new(HashSet::new()),
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
+            registry: None,
         }
     }
 
@@ -292,6 +298,7 @@ impl<T: Transport> WakuA2ANode<T> {
             seen_tx_hashes: std::sync::Mutex::new(HashSet::new()),
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
+            registry: None,
         }
     }
 
@@ -311,6 +318,16 @@ impl<T: Transport> WakuA2ANode<T> {
     /// require payment proof before processing.
     pub fn with_payment(mut self, config: PaymentConfig) -> Self {
         self.payment = Some(config);
+        self
+    }
+
+    /// Attach a persistent agent registry for on-chain discovery.
+    ///
+    /// When set, [`discover_all`](Self::discover_all) merges results from both
+    /// Waku presence and the registry. The node can also
+    /// [`register`](Self::register_in_registry) itself for permanent discovery.
+    pub fn with_registry(mut self, registry: Arc<dyn AgentRegistry>) -> Self {
+        self.registry = Some(registry);
         self
     }
 
@@ -449,6 +466,64 @@ impl<T: Transport> WakuA2ANode<T> {
             .unsubscribe(topics::DISCOVERY)
             .await;
         Ok(cards)
+    }
+
+    /// Register this node's AgentCard in the persistent registry.
+    ///
+    /// Returns an error if no registry is configured or if the agent
+    /// is already registered (use [`update_registry`](Self::update_registry)
+    /// to update an existing registration).
+    pub async fn register_in_registry(&self) -> Result<()> {
+        let registry = self.registry.as_ref().context("no registry configured")?;
+        registry
+            .register(self.card.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    }
+
+    /// Update this node's AgentCard in the persistent registry.
+    pub async fn update_registry(&self) -> Result<()> {
+        let registry = self.registry.as_ref().context("no registry configured")?;
+        registry
+            .update(self.card.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    }
+
+    /// Remove this node from the persistent registry.
+    pub async fn deregister_from_registry(&self) -> Result<()> {
+        let registry = self.registry.as_ref().context("no registry configured")?;
+        registry
+            .deregister(&self.card.public_key)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    }
+
+    /// Discover agents from all sources: Waku ephemeral discovery + persistent registry.
+    ///
+    /// Deduplicates by public key, preferring the registry version when both exist
+    /// (since on-chain data is the source of truth).
+    pub async fn discover_all(&self) -> Result<Vec<AgentCard>> {
+        let mut by_key: HashMap<String, AgentCard> = HashMap::new();
+
+        // Waku ephemeral discovery first
+        let waku_cards = self.discover().await?;
+        for card in waku_cards {
+            by_key.insert(card.public_key.clone(), card);
+        }
+
+        // Registry overwrites (source of truth)
+        if let Some(ref registry) = self.registry {
+            if let Ok(reg_cards) = registry.list().await {
+                for card in reg_cards {
+                    if card.public_key != self.card.public_key {
+                        by_key.insert(card.public_key.clone(), card);
+                    }
+                }
+            }
+        }
+
+        Ok(by_key.into_values().collect())
     }
 
     /// Send a task to another agent. Uses SDS reliable delivery with
@@ -1957,5 +2032,125 @@ mod tests {
 
         let responses = client.poll_tasks().await.unwrap();
         assert_eq!(responses.len(), 3);
+    }
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+    use logos_messaging_a2a_core::registry::InMemoryRegistry;
+    use logos_messaging_a2a_transport::memory::InMemoryTransport;
+
+    fn make_node(name: &str) -> WakuA2ANode<InMemoryTransport> {
+        let transport = InMemoryTransport::new();
+        WakuA2ANode::new(
+            name,
+            &format!("{} agent", name),
+            vec!["test".into()],
+            transport,
+        )
+    }
+
+    #[tokio::test]
+    async fn with_registry_builder() {
+        let transport = InMemoryTransport::new();
+        let registry = Arc::new(InMemoryRegistry::new());
+        let node = WakuA2ANode::new("test", "test agent", vec![], transport)
+            .with_registry(registry.clone());
+        assert!(node.registry.is_some());
+    }
+
+    #[tokio::test]
+    async fn register_in_registry_succeeds() {
+        let node = make_node("echo");
+        let registry = Arc::new(InMemoryRegistry::new());
+        let node = node.with_registry(registry.clone());
+
+        node.register_in_registry().await.unwrap();
+        let card = registry.get(&node.card.public_key).await.unwrap();
+        assert_eq!(card.name, "echo");
+    }
+
+    #[tokio::test]
+    async fn register_without_registry_fails() {
+        let node = make_node("echo");
+        let result = node.register_in_registry().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no registry"));
+    }
+
+    #[tokio::test]
+    async fn update_registry_succeeds() {
+        let registry = Arc::new(InMemoryRegistry::new());
+        let node = make_node("v1");
+        let node = node.with_registry(registry.clone());
+        node.register_in_registry().await.unwrap();
+
+        // Simulate card update (change name field by re-registering after update)
+        let mut updated_card = node.card.clone();
+        updated_card.name = "v2".into();
+        registry.update(updated_card.clone()).await.unwrap();
+
+        let got = registry.get(&node.card.public_key).await.unwrap();
+        assert_eq!(got.name, "v2");
+    }
+
+    #[tokio::test]
+    async fn deregister_from_registry_succeeds() {
+        let registry = Arc::new(InMemoryRegistry::new());
+        let node = make_node("temp").with_registry(registry.clone());
+        node.register_in_registry().await.unwrap();
+        node.deregister_from_registry().await.unwrap();
+
+        let result = registry.get(&node.card.public_key).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn discover_all_merges_waku_and_registry() {
+        let transport = InMemoryTransport::new();
+        let registry = Arc::new(InMemoryRegistry::new());
+
+        // Register an agent in the registry
+        let reg_card = AgentCard {
+            name: "registry-agent".into(),
+            description: "from registry".into(),
+            version: "1.0.0".into(),
+            capabilities: vec!["search".into()],
+            public_key: "registry_key_001".into(),
+            intro_bundle: None,
+        };
+        registry.register(reg_card).await.unwrap();
+
+        let node =
+            WakuA2ANode::new("discoverer", "disc", vec![], transport).with_registry(registry);
+
+        let all = node.discover_all().await.unwrap();
+        // Should find the registry agent
+        assert!(all.iter().any(|c| c.name == "registry-agent"));
+    }
+
+    #[tokio::test]
+    async fn discover_all_excludes_self_from_registry() {
+        let transport = InMemoryTransport::new();
+        let registry = Arc::new(InMemoryRegistry::new());
+
+        let node =
+            WakuA2ANode::new("self-node", "me", vec![], transport).with_registry(registry.clone());
+
+        // Register self in registry
+        node.register_in_registry().await.unwrap();
+
+        let all = node.discover_all().await.unwrap();
+        // Should NOT find self
+        assert!(all.is_empty());
+    }
+
+    #[tokio::test]
+    async fn discover_all_without_registry_returns_waku_only() {
+        let node = make_node("plain");
+        // No registry set — should still work, just return Waku results
+        let all = node.discover_all().await.unwrap();
+        assert!(all.is_empty()); // no Waku broadcasts either
     }
 }


### PR DESCRIPTION
## What

Adds the persistent agent registry abstraction for issue #4 (LEZ on-chain agent discovery).

### Changes

- **`AgentRegistry` trait** in `logos-messaging-a2a-core::registry` — backend-agnostic interface for persistent agent discovery (register/update/deregister/get/list/find_by_capability)
- **`InMemoryRegistry`** — test-friendly in-memory implementation with full test coverage (12 tests)
- **`WakuA2ANode` integration** — `.with_registry()` builder, `register_in_registry()`, `update_registry()`, `deregister_from_registry()`, and `discover_all()` methods (7 tests)
- **`discover_all()`** merges Waku ephemeral presence + registry results, deduplicating by public key with registry as source of truth. Self-entries excluded.
- README updated with Persistent Agent Registry section

### Architecture

```
Discovery layer:
  Waku presence (ephemeral) ──┐
                               ├──► merged agent list
  LEZ registry (persistent) ──┘
```

### Next steps

Wire the actual LEZ (SPELbook) backend when `lez-registry-ffi` is available as a crate dependency.

Closes #4 (phase 1 — trait + integration; phase 2 = LEZ backend)