### PR TITLE
feat: signed presence announcements with secp256k1 verification

### DIFF
--- a/crates/logos-messaging-a2a-core/src/presence.rs
+++ b/crates/logos-messaging-a2a-core/src/presence.rs
@@ -1,3 +1,6 @@
+use anyhow::{Context, Result};
+use k256::ecdsa::signature::Verifier;
+use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 /// Presence announcement broadcast on the well-known presence topic.
@@ -21,6 +24,57 @@ pub struct PresenceAnnouncement {
     /// fields, proving the announcement comes from the claimed `agent_id`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<Vec<u8>>,
+}
+
+impl PresenceAnnouncement {
+    /// Deterministic serialization of all fields except `signature`.
+    ///
+    /// Produces a canonical JSON object with keys in a fixed order so that
+    /// both signer and verifier hash identical bytes.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        // Build canonical JSON manually with deterministic key order.
+        let canonical = serde_json::json!({
+            "agent_id": self.agent_id,
+            "capabilities": self.capabilities,
+            "name": self.name,
+            "ttl_secs": self.ttl_secs,
+            "waku_topic": self.waku_topic,
+        });
+        serde_json::to_vec(&canonical).expect("canonical JSON serialization cannot fail")
+    }
+
+    /// Sign this announcement with a secp256k1 signing key.
+    ///
+    /// Computes `canonical_bytes()` and signs with the provided key,
+    /// setting the `signature` field to the DER-encoded signature bytes.
+    pub fn sign(&mut self, signing_key: &SigningKey) -> Result<()> {
+        use k256::ecdsa::signature::Signer;
+        let message = self.canonical_bytes();
+        let sig: Signature = signing_key.sign(&message);
+        self.signature = Some(sig.to_der().as_bytes().to_vec());
+        Ok(())
+    }
+
+    /// Verify the signature against `agent_id` (compressed secp256k1 pubkey hex).
+    ///
+    /// Returns `Ok(())` if the signature is present and valid, or an error
+    /// describing why verification failed.
+    pub fn verify(&self) -> Result<()> {
+        let sig_bytes = self.signature.as_ref().context("missing signature")?;
+
+        let pubkey_bytes = hex::decode(&self.agent_id).context("agent_id is not valid hex")?;
+        let verifying_key = VerifyingKey::from_sec1_bytes(&pubkey_bytes)
+            .context("agent_id is not a valid secp256k1 public key")?;
+
+        let signature = Signature::from_der(sig_bytes).context("signature is not valid DER")?;
+
+        let message = self.canonical_bytes();
+        verifying_key
+            .verify(&message, &signature)
+            .context("signature verification failed")?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -57,5 +111,114 @@ mod tests {
         assert!(json.contains("signature"));
         let deserialized: PresenceAnnouncement = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.signature, Some(vec![1, 2, 3, 4]));
+    }
+
+    fn make_signing_key() -> SigningKey {
+        SigningKey::random(&mut k256::elliptic_curve::rand_core::OsRng)
+    }
+
+    fn pubkey_hex(key: &SigningKey) -> String {
+        hex::encode(key.verifying_key().to_encoded_point(true).as_bytes())
+    }
+
+    fn make_signed_announcement(key: &SigningKey) -> PresenceAnnouncement {
+        let mut ann = PresenceAnnouncement {
+            agent_id: pubkey_hex(key),
+            name: "test-agent".to_string(),
+            capabilities: vec!["echo".to_string(), "summarize".to_string()],
+            waku_topic: "/lmao/1/task/test/proto".to_string(),
+            ttl_secs: 300,
+            signature: None,
+        };
+        ann.sign(key).unwrap();
+        ann
+    }
+
+    #[test]
+    fn test_sign_verify_roundtrip() {
+        let key = make_signing_key();
+        let ann = make_signed_announcement(&key);
+        assert!(ann.signature.is_some());
+        ann.verify().unwrap();
+    }
+
+    #[test]
+    fn test_canonical_bytes_deterministic() {
+        let key = make_signing_key();
+        let ann = make_signed_announcement(&key);
+        let bytes1 = ann.canonical_bytes();
+        let bytes2 = ann.canonical_bytes();
+        assert_eq!(bytes1, bytes2);
+    }
+
+    #[test]
+    fn test_canonical_bytes_excludes_signature() {
+        let key = make_signing_key();
+        let ann = make_signed_announcement(&key);
+        let canonical = String::from_utf8(ann.canonical_bytes()).unwrap();
+        assert!(!canonical.contains("signature"));
+    }
+
+    #[test]
+    fn test_tampered_name_rejected() {
+        let key = make_signing_key();
+        let mut ann = make_signed_announcement(&key);
+        ann.name = "evil-agent".to_string();
+        assert!(ann.verify().is_err());
+    }
+
+    #[test]
+    fn test_tampered_capabilities_rejected() {
+        let key = make_signing_key();
+        let mut ann = make_signed_announcement(&key);
+        ann.capabilities.push("admin".to_string());
+        assert!(ann.verify().is_err());
+    }
+
+    #[test]
+    fn test_tampered_agent_id_rejected() {
+        let key = make_signing_key();
+        let other_key = make_signing_key();
+        let mut ann = make_signed_announcement(&key);
+        // Swap agent_id to a different key — signature should not verify
+        ann.agent_id = pubkey_hex(&other_key);
+        assert!(ann.verify().is_err());
+    }
+
+    #[test]
+    fn test_missing_signature_rejected() {
+        let key = make_signing_key();
+        let mut ann = make_signed_announcement(&key);
+        ann.signature = None;
+        let err = ann.verify().unwrap_err();
+        assert!(err.to_string().contains("missing signature"));
+    }
+
+    #[test]
+    fn test_wrong_key_signature_rejected() {
+        let key = make_signing_key();
+        let wrong_key = make_signing_key();
+        let mut ann = PresenceAnnouncement {
+            agent_id: pubkey_hex(&key),
+            name: "test".to_string(),
+            capabilities: vec![],
+            waku_topic: "/test/proto".to_string(),
+            ttl_secs: 60,
+            signature: None,
+        };
+        // Sign with wrong key
+        ann.sign(&wrong_key).unwrap();
+        assert!(ann.verify().is_err());
+    }
+
+    #[test]
+    fn test_corrupted_signature_rejected() {
+        let key = make_signing_key();
+        let mut ann = make_signed_announcement(&key);
+        // Corrupt the signature bytes
+        if let Some(ref mut sig) = ann.signature {
+            sig[0] ^= 0xff;
+        }
+        assert!(ann.verify().is_err());
     }
 }

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -345,14 +345,17 @@ impl<T: Transport> WakuA2ANode<T> {
 
     /// Broadcast a presence announcement with a custom TTL.
     pub async fn announce_presence_with_ttl(&self, ttl_secs: u64) -> Result<()> {
-        let announcement = PresenceAnnouncement {
+        let mut announcement = PresenceAnnouncement {
             agent_id: self.pubkey().to_string(),
             name: self.card.name.clone(),
             capabilities: self.card.capabilities.clone(),
             waku_topic: topics::task_topic(self.pubkey()),
             ttl_secs,
-            signature: None, // TODO: sign with secp256k1 key
+            signature: None,
         };
+        announcement
+            .sign(&self.signing_key)
+            .context("Failed to sign presence announcement")?;
         let envelope = A2AEnvelope::Presence(announcement);
         let payload =
             serde_json::to_vec(&envelope).context("Failed to serialize presence announcement")?;
@@ -383,6 +386,15 @@ impl<T: Transport> WakuA2ANode<T> {
         while let Ok(msg) = rx.try_recv() {
             if let Ok(A2AEnvelope::Presence(ann)) = serde_json::from_slice::<A2AEnvelope>(&msg) {
                 if ann.agent_id != self.pubkey() {
+                    if let Err(e) = ann.verify() {
+                        eprintln!(
+                            "[node] Presence rejected (invalid signature): {} ({}) — {}",
+                            ann.name,
+                            &ann.agent_id[..8.min(ann.agent_id.len())],
+                            e
+                        );
+                        continue;
+                    }
                     self.peer_map.update(&ann);
                     eprintln!(
                         "[node] Presence received: {} ({}) caps={:?}",
@@ -2152,5 +2164,123 @@ mod registry_tests {
         // No registry set — should still work, just return Waku results
         let all = node.discover_all().await.unwrap();
         assert!(all.is_empty()); // no Waku broadcasts either
+    }
+}
+
+#[cfg(test)]
+mod signed_presence_tests {
+    use super::*;
+    use logos_messaging_a2a_transport::memory::InMemoryTransport;
+
+    fn make_node_with_transport(
+        name: &str,
+        transport: InMemoryTransport,
+    ) -> WakuA2ANode<InMemoryTransport> {
+        WakuA2ANode::new(
+            name,
+            &format!("{name} agent"),
+            vec!["test".into()],
+            transport,
+        )
+    }
+
+    #[tokio::test]
+    async fn signed_announcement_accepted_by_peer() {
+        let transport = InMemoryTransport::new();
+        let alice = make_node_with_transport("alice", transport.clone());
+        let bob = make_node_with_transport("bob", transport.clone());
+
+        // Alice announces (signed automatically)
+        alice.announce_presence().await.unwrap();
+
+        // Bob polls — should accept the signed announcement
+        let count = bob.poll_presence().await.unwrap();
+        assert_eq!(count, 1);
+
+        let peers = bob.peers().all_live();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].1.name, "alice");
+    }
+
+    #[tokio::test]
+    async fn unsigned_announcement_rejected() {
+        let transport = InMemoryTransport::new();
+        let alice = make_node_with_transport("alice", transport.clone());
+        let bob = make_node_with_transport("bob", transport.clone());
+
+        // Inject an unsigned announcement directly (bypassing sign)
+        let unsigned = PresenceAnnouncement {
+            agent_id: alice.pubkey().to_string(),
+            name: "alice".to_string(),
+            capabilities: vec!["test".into()],
+            waku_topic: topics::task_topic(alice.pubkey()),
+            ttl_secs: 300,
+            signature: None,
+        };
+        let envelope = A2AEnvelope::Presence(unsigned);
+        let payload = serde_json::to_vec(&envelope).unwrap();
+        transport.publish(topics::PRESENCE, &payload).await.unwrap();
+
+        // Bob should reject the unsigned announcement
+        let count = bob.poll_presence().await.unwrap();
+        assert_eq!(count, 0);
+        assert!(bob.peers().all_live().is_empty());
+    }
+
+    #[tokio::test]
+    async fn tampered_announcement_rejected() {
+        let transport = InMemoryTransport::new();
+        let alice = make_node_with_transport("alice", transport.clone());
+        let bob = make_node_with_transport("bob", transport.clone());
+
+        // Create a properly signed announcement, then tamper with it
+        let mut ann = PresenceAnnouncement {
+            agent_id: alice.pubkey().to_string(),
+            name: "alice".to_string(),
+            capabilities: vec!["test".into()],
+            waku_topic: topics::task_topic(alice.pubkey()),
+            ttl_secs: 300,
+            signature: None,
+        };
+        ann.sign(alice.signing_key()).unwrap();
+
+        // Tamper with the name after signing
+        ann.name = "evil-alice".to_string();
+
+        let envelope = A2AEnvelope::Presence(ann);
+        let payload = serde_json::to_vec(&envelope).unwrap();
+        transport.publish(topics::PRESENCE, &payload).await.unwrap();
+
+        // Bob should reject the tampered announcement
+        let count = bob.poll_presence().await.unwrap();
+        assert_eq!(count, 0);
+        assert!(bob.peers().all_live().is_empty());
+    }
+
+    #[tokio::test]
+    async fn wrong_key_announcement_rejected() {
+        let transport = InMemoryTransport::new();
+        let alice = make_node_with_transport("alice", transport.clone());
+        let bob = make_node_with_transport("bob", transport.clone());
+
+        // Sign with bob's key but claim to be alice
+        let mut ann = PresenceAnnouncement {
+            agent_id: alice.pubkey().to_string(),
+            name: "alice".to_string(),
+            capabilities: vec!["test".into()],
+            waku_topic: topics::task_topic(alice.pubkey()),
+            ttl_secs: 300,
+            signature: None,
+        };
+        ann.sign(bob.signing_key()).unwrap();
+
+        let envelope = A2AEnvelope::Presence(ann);
+        let payload = serde_json::to_vec(&envelope).unwrap();
+        transport.publish(topics::PRESENCE, &payload).await.unwrap();
+
+        // Bob should reject — signature doesn't match agent_id
+        let count = bob.poll_presence().await.unwrap();
+        assert_eq!(count, 0);
+        assert!(bob.peers().all_live().is_empty());
     }
 }


### PR DESCRIPTION
## 🎯 Purpose
Implement cryptographic signing and verification for presence announcements, replacing the `// TODO: sign with secp256k1 key` placeholder. Prevents spoofed/tampered presence on the network.

## ⚙️ Approach
- Add `sign()`, `verify()`, `canonical_bytes()` to `PresenceAnnouncement` (core crate)
- Deterministic JSON (sorted keys, excludes signature) for consistent hashing
- secp256k1 ECDSA via k256, DER-encoded signatures
- Node signs in `announce_presence_with_ttl()`, verifies in `poll_presence()`
- Invalid announcements logged and skipped

## 🧪 How to Test
```bash
cargo test --workspace
```
8 unit tests + 4 integration tests covering sign/verify roundtrip, tampered fields, missing/corrupted/wrong-key signatures

## 🔗 Dependencies
k256, hex, anyhow (all existing workspace deps)

## 🔜 Future Work
- Sequence numbers for dedup
- Replay protection via timestamps
- Aggregate signatures

## 📋 Checklist
- [x] Tests pass
- [x] cargo fmt clean
- [x] cargo clippy clean
- [x] Signed presence verified in node
- [x] Unsigned/tampered rejected