### PR TITLE
feat: task streaming — partial results over Waku topics

### DIFF
--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -75,6 +75,15 @@ enum TaskAction {
         #[arg(long)]
         id: String,
     },
+    /// Follow a task's streaming output
+    Stream {
+        /// Task ID (UUID) to follow
+        #[arg(long)]
+        id: String,
+        /// How long to wait for the stream to complete (seconds)
+        #[arg(long, default_value = "30")]
+        timeout: u64,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -268,6 +277,45 @@ async fn main() -> Result<()> {
                     Err(e) => {
                         eprintln!("Failed to poll: {}", e);
                     }
+                }
+            }
+            TaskAction::Stream { id, timeout } => {
+                let node = WakuA2ANode::new("cli-stream", "CLI client", vec![], transport);
+                println!(
+                    "Following stream for task {} (timeout {}s)...\n",
+                    id, timeout
+                );
+
+                let deadline =
+                    tokio::time::Instant::now() + std::time::Duration::from_secs(timeout);
+                let mut last_index: Option<u32> = None;
+
+                while tokio::time::Instant::now() < deadline {
+                    match node.poll_stream_chunks(&id).await {
+                        Ok(chunks) => {
+                            for chunk in &chunks {
+                                // Only print chunks we haven't printed yet
+                                if last_index.is_none() || chunk.chunk_index > last_index.unwrap() {
+                                    print!("{}", chunk.text);
+                                    last_index = Some(chunk.chunk_index);
+                                }
+                            }
+                            // Check if stream is complete
+                            if chunks.iter().any(|c| c.is_final) {
+                                println!();
+                                println!("\n--- Stream complete ({} chunks) ---", chunks.len());
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Stream poll error: {}", e);
+                        }
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+
+                if last_index.is_none() {
+                    println!("No stream chunks received for task {}", id);
                 }
             }
         },
@@ -798,5 +846,50 @@ mod tests {
     fn unknown_flag_rejected() {
         let err = try_parse(&["cli", "--bogus"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::UnknownArgument);
+    }
+
+    // ── Task Stream ──
+
+    #[test]
+    fn task_stream_with_id() {
+        let cli = try_parse(&["cli", "task", "stream", "--id", "task-42"]).unwrap();
+        match cli.command {
+            Commands::Task {
+                action: TaskAction::Stream { id, timeout },
+            } => {
+                assert_eq!(id, "task-42");
+                assert_eq!(timeout, 30); // default
+            }
+            _ => panic!("expected Task Stream"),
+        }
+    }
+
+    #[test]
+    fn task_stream_with_timeout() {
+        let cli = try_parse(&[
+            "cli",
+            "task",
+            "stream",
+            "--id",
+            "task-42",
+            "--timeout",
+            "60",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Task {
+                action: TaskAction::Stream { id, timeout },
+            } => {
+                assert_eq!(id, "task-42");
+                assert_eq!(timeout, 60);
+            }
+            _ => panic!("expected Task Stream"),
+        }
+    }
+
+    #[test]
+    fn task_stream_missing_id() {
+        let err = try_parse(&["cli", "task", "stream"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     }
 }

--- a/crates/logos-messaging-a2a-core/src/envelope.rs
+++ b/crates/logos-messaging-a2a-core/src/envelope.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent::AgentCard;
 use crate::presence::PresenceAnnouncement;
-use crate::task::Task;
+use crate::task::{Task, TaskStreamChunk};
 
 /// Wire envelope for all messages on Waku topics.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -19,6 +19,7 @@ pub enum A2AEnvelope {
         sender_pubkey: String,
     },
     Presence(PresenceAnnouncement),
+    StreamChunk(TaskStreamChunk),
 }
 
 #[cfg(test)]
@@ -56,6 +57,21 @@ mod tests {
         let deserialized: A2AEnvelope = serde_json::from_str(&json).unwrap();
         assert_eq!(envelope, deserialized);
         assert!(json.contains("encrypted_task"));
+    }
+
+    #[test]
+    fn test_stream_chunk_envelope_serialization() {
+        let chunk = TaskStreamChunk {
+            task_id: "task-42".to_string(),
+            chunk_index: 3,
+            text: "partial ".to_string(),
+            is_final: false,
+        };
+        let envelope = A2AEnvelope::StreamChunk(chunk.clone());
+        let json = serde_json::to_string(&envelope).unwrap();
+        assert!(json.contains("stream_chunk"));
+        let deserialized: A2AEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(envelope, deserialized);
     }
 
     #[test]

--- a/crates/logos-messaging-a2a-core/src/task.rs
+++ b/crates/logos-messaging-a2a-core/src/task.rs
@@ -27,6 +27,18 @@ pub struct Message {
     pub parts: Vec<Part>,
 }
 
+/// A streaming chunk for incremental task results (e.g., LLM token output).
+///
+/// Agents send a sequence of chunks with incrementing `chunk_index`.
+/// The final chunk has `is_final = true`, signalling the stream is complete.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TaskStreamChunk {
+    pub task_id: String,
+    pub chunk_index: u32,
+    pub text: String,
+    pub is_final: bool,
+}
+
 /// An A2A task: the unit of work exchanged between agents.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Task {
@@ -288,5 +300,33 @@ mod tests {
         task.payload_cid = Some("zQmBig".to_string());
         let response = task.respond("got it");
         assert!(response.payload_cid.is_none());
+    }
+
+    #[test]
+    fn test_stream_chunk_serialization() {
+        let chunk = TaskStreamChunk {
+            task_id: "task-1".to_string(),
+            chunk_index: 0,
+            text: "Hello ".to_string(),
+            is_final: false,
+        };
+        let json = serde_json::to_string(&chunk).unwrap();
+        assert!(json.contains("\"task_id\":\"task-1\""));
+        assert!(json.contains("\"chunk_index\":0"));
+        assert!(json.contains("\"is_final\":false"));
+        let deserialized: TaskStreamChunk = serde_json::from_str(&json).unwrap();
+        assert_eq!(chunk, deserialized);
+    }
+
+    #[test]
+    fn test_stream_chunk_final() {
+        let chunk = TaskStreamChunk {
+            task_id: "task-1".to_string(),
+            chunk_index: 5,
+            text: "done".to_string(),
+            is_final: true,
+        };
+        assert!(chunk.is_final);
+        assert_eq!(chunk.chunk_index, 5);
     }
 }

--- a/crates/logos-messaging-a2a-core/src/topics.rs
+++ b/crates/logos-messaging-a2a-core/src/topics.rs
@@ -14,6 +14,10 @@ pub fn ack_topic(message_id: &str) -> String {
     format!("/waku-a2a/1/ack/{}/proto", message_id)
 }
 
+pub fn stream_topic(task_id: &str) -> String {
+    format!("/waku-a2a/1/stream/{}/proto", task_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -28,5 +32,10 @@ mod tests {
     #[test]
     fn test_presence_topic() {
         assert_eq!(PRESENCE, "/lmao/1/presence/proto");
+    }
+
+    #[test]
+    fn test_stream_topic() {
+        assert_eq!(stream_topic("abc-123"), "/waku-a2a/1/stream/abc-123/proto");
     }
 }

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -5,7 +5,7 @@ use k256::ecdsa::SigningKey;
 use logos_messaging_a2a_core::registry::AgentRegistry;
 pub use logos_messaging_a2a_core::Task as TaskType;
 use logos_messaging_a2a_core::{
-    topics, A2AEnvelope, AgentCard, Message, PresenceAnnouncement, Task,
+    topics, A2AEnvelope, AgentCard, Message, PresenceAnnouncement, Task, TaskStreamChunk,
 };
 use logos_messaging_a2a_crypto::{AgentIdentity, IntroBundle};
 use logos_messaging_a2a_execution::{AgentId, ExecutionBackend};
@@ -123,6 +123,8 @@ pub struct WakuA2ANode<T: Transport> {
     presence_rx: tokio::sync::Mutex<Option<mpsc::Receiver<Vec<u8>>>>,
     /// Optional persistent agent registry (e.g. LEZ on-chain).
     registry: Option<Arc<dyn AgentRegistry>>,
+    /// Buffered stream chunks keyed by task_id, sorted by chunk_index.
+    stream_chunks: std::sync::Mutex<HashMap<String, Vec<TaskStreamChunk>>>,
 }
 
 impl<T: Transport> WakuA2ANode<T> {
@@ -162,6 +164,7 @@ impl<T: Transport> WakuA2ANode<T> {
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
+            stream_chunks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -209,6 +212,7 @@ impl<T: Transport> WakuA2ANode<T> {
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
+            stream_chunks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -253,6 +257,7 @@ impl<T: Transport> WakuA2ANode<T> {
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
+            stream_chunks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -299,6 +304,7 @@ impl<T: Transport> WakuA2ANode<T> {
             peer_map: presence::PeerMap::new(),
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
+            stream_chunks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -785,6 +791,85 @@ impl<T: Transport> WakuA2ANode<T> {
         let task = Task::new(self.pubkey(), to, text);
         self.send_task(&task).await?;
         Ok(task)
+    }
+
+    /// Publish a sequence of stream chunks for a task.
+    ///
+    /// Each string in `chunks` becomes a `TaskStreamChunk` with incrementing
+    /// `chunk_index`. The last chunk is automatically marked `is_final = true`.
+    /// Chunks are published to a dedicated stream topic derived from the task ID.
+    pub async fn respond_stream(&self, task: &Task, chunks: Vec<String>) -> Result<()> {
+        let topic = topics::stream_topic(&task.id);
+        let total = chunks.len();
+        for (i, text) in chunks.into_iter().enumerate() {
+            let chunk = TaskStreamChunk {
+                task_id: task.id.clone(),
+                chunk_index: i as u32,
+                text,
+                is_final: i == total - 1,
+            };
+            let envelope = A2AEnvelope::StreamChunk(chunk);
+            let payload =
+                serde_json::to_vec(&envelope).context("Failed to serialize stream chunk")?;
+            self.channel
+                .transport()
+                .publish(&topic, &payload)
+                .await
+                .context("Failed to publish stream chunk")?;
+        }
+        eprintln!("[node] Streamed {} chunk(s) for task {}", total, task.id);
+        Ok(())
+    }
+
+    /// Poll for stream chunks for a given task ID.
+    ///
+    /// Subscribes to the task's stream topic, drains available chunks,
+    /// buffers them internally, and returns all chunks received so far
+    /// sorted by `chunk_index`.
+    pub async fn poll_stream_chunks(&self, task_id: &str) -> Result<Vec<TaskStreamChunk>> {
+        let topic = topics::stream_topic(task_id);
+        let mut rx = self.channel.transport().subscribe(&topic).await?;
+
+        // Drain all available messages from the subscription
+        let mut new_chunks = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let Ok(A2AEnvelope::StreamChunk(chunk)) = serde_json::from_slice::<A2AEnvelope>(&msg)
+            {
+                if chunk.task_id == task_id {
+                    new_chunks.push(chunk);
+                }
+            }
+        }
+
+        let _ = self.channel.transport().unsubscribe(&topic).await;
+
+        // Merge into the internal buffer
+        let mut buffer = self.stream_chunks.lock().unwrap();
+        let entry = buffer.entry(task_id.to_string()).or_default();
+        for chunk in new_chunks {
+            // Avoid duplicates by chunk_index
+            if !entry.iter().any(|c| c.chunk_index == chunk.chunk_index) {
+                entry.push(chunk);
+            }
+        }
+        entry.sort_by_key(|c| c.chunk_index);
+        Ok(entry.clone())
+    }
+
+    /// Reassemble all buffered stream chunks for a task into a single string.
+    ///
+    /// Returns `None` if no chunks are buffered or the stream is incomplete
+    /// (no final chunk received yet).
+    pub fn reassemble_stream(&self, task_id: &str) -> Option<String> {
+        let buffer = self.stream_chunks.lock().unwrap();
+        let chunks = buffer.get(task_id)?;
+        if chunks.is_empty() {
+            return None;
+        }
+        if !chunks.iter().any(|c| c.is_final) {
+            return None;
+        }
+        Some(chunks.iter().map(|c| c.text.as_str()).collect())
     }
 
     /// If auto-pay is enabled, call `backend.pay()` and attach proof to the task.
@@ -2692,5 +2777,203 @@ mod signed_presence_tests {
         let count = bob.poll_presence().await.unwrap();
         assert_eq!(count, 0);
         assert!(bob.peers().all_live().is_empty());
+    }
+}
+
+#[cfg(test)]
+mod stream_tests {
+    use super::*;
+    use logos_messaging_a2a_transport::memory::InMemoryTransport;
+
+    fn make_node_with_transport(
+        name: &str,
+        transport: InMemoryTransport,
+    ) -> WakuA2ANode<InMemoryTransport> {
+        WakuA2ANode::new(
+            name,
+            &format!("{} agent", name),
+            vec!["text".into()],
+            transport,
+        )
+    }
+
+    #[tokio::test]
+    async fn respond_stream_publishes_chunks() {
+        let transport = InMemoryTransport::new();
+        let node = make_node_with_transport("streamer", transport.clone());
+        let task = Task::new(node.pubkey(), "02recipient", "do something");
+
+        let chunks = vec!["Hello ".to_string(), "world".to_string(), "!".to_string()];
+        node.respond_stream(&task, chunks).await.unwrap();
+
+        // Subscribe to stream topic — history replay gives us published chunks
+        let stream_topic = topics::stream_topic(&task.id);
+        let mut rx = transport.subscribe(&stream_topic).await.unwrap();
+
+        for i in 0..3 {
+            let msg = rx.try_recv().unwrap();
+            let envelope: A2AEnvelope = serde_json::from_slice(&msg).unwrap();
+            match envelope {
+                A2AEnvelope::StreamChunk(chunk) => {
+                    assert_eq!(chunk.task_id, task.id);
+                    assert_eq!(chunk.chunk_index, i as u32);
+                    assert_eq!(chunk.is_final, i == 2);
+                }
+                _ => panic!("Expected StreamChunk envelope"),
+            }
+        }
+        // No more messages
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn poll_stream_chunks_receives_ordered() {
+        let transport = InMemoryTransport::new();
+        let task_id = "test-task-123";
+        let stream_topic = topics::stream_topic(task_id);
+
+        // Inject chunks out of order
+        for (idx, text, is_final) in [(1, "world", false), (0, "Hello ", false), (2, "!", true)] {
+            let chunk = TaskStreamChunk {
+                task_id: task_id.to_string(),
+                chunk_index: idx,
+                text: text.to_string(),
+                is_final,
+            };
+            let envelope = A2AEnvelope::StreamChunk(chunk);
+            let payload = serde_json::to_vec(&envelope).unwrap();
+            transport.publish(&stream_topic, &payload).await.unwrap();
+        }
+
+        let node = make_node_with_transport("receiver", transport);
+        let chunks = node.poll_stream_chunks(task_id).await.unwrap();
+
+        assert_eq!(chunks.len(), 3);
+        // Should be sorted by chunk_index
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert_eq!(chunks[0].text, "Hello ");
+        assert_eq!(chunks[1].chunk_index, 1);
+        assert_eq!(chunks[1].text, "world");
+        assert_eq!(chunks[2].chunk_index, 2);
+        assert_eq!(chunks[2].text, "!");
+        assert!(chunks[2].is_final);
+    }
+
+    #[tokio::test]
+    async fn poll_stream_deduplicates_chunks() {
+        let transport = InMemoryTransport::new();
+        let task_id = "dedup-task";
+        let stream_topic = topics::stream_topic(task_id);
+
+        // Inject the same chunk twice
+        let chunk = TaskStreamChunk {
+            task_id: task_id.to_string(),
+            chunk_index: 0,
+            text: "Hello".to_string(),
+            is_final: false,
+        };
+        let envelope = A2AEnvelope::StreamChunk(chunk);
+        let payload = serde_json::to_vec(&envelope).unwrap();
+        transport.publish(&stream_topic, &payload).await.unwrap();
+        transport.publish(&stream_topic, &payload).await.unwrap();
+
+        let node = make_node_with_transport("receiver", transport);
+        let chunks = node.poll_stream_chunks(task_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reassemble_stream_concatenates_text() {
+        let transport = InMemoryTransport::new();
+        let task_id = "reassemble-task";
+        let stream_topic = topics::stream_topic(task_id);
+
+        let texts = ["Hello ", "beautiful ", "world!"];
+        for (i, text) in texts.iter().enumerate() {
+            let chunk = TaskStreamChunk {
+                task_id: task_id.to_string(),
+                chunk_index: i as u32,
+                text: text.to_string(),
+                is_final: i == texts.len() - 1,
+            };
+            let envelope = A2AEnvelope::StreamChunk(chunk);
+            let payload = serde_json::to_vec(&envelope).unwrap();
+            transport.publish(&stream_topic, &payload).await.unwrap();
+        }
+
+        let node = make_node_with_transport("receiver", transport);
+        node.poll_stream_chunks(task_id).await.unwrap();
+        let result = node.reassemble_stream(task_id);
+        assert_eq!(result, Some("Hello beautiful world!".to_string()));
+    }
+
+    #[tokio::test]
+    async fn reassemble_returns_none_without_final() {
+        let transport = InMemoryTransport::new();
+        let task_id = "incomplete-task";
+        let stream_topic = topics::stream_topic(task_id);
+
+        let chunk = TaskStreamChunk {
+            task_id: task_id.to_string(),
+            chunk_index: 0,
+            text: "partial".to_string(),
+            is_final: false,
+        };
+        let envelope = A2AEnvelope::StreamChunk(chunk);
+        let payload = serde_json::to_vec(&envelope).unwrap();
+        transport.publish(&stream_topic, &payload).await.unwrap();
+
+        let node = make_node_with_transport("receiver", transport);
+        node.poll_stream_chunks(task_id).await.unwrap();
+        assert!(node.reassemble_stream(task_id).is_none());
+    }
+
+    #[test]
+    fn reassemble_returns_none_for_unknown_task() {
+        let transport = InMemoryTransport::new();
+        let node = make_node_with_transport("receiver", transport);
+        assert!(node.reassemble_stream("nonexistent").is_none());
+    }
+
+    #[tokio::test]
+    async fn respond_stream_single_chunk() {
+        let transport = InMemoryTransport::new();
+        let node = make_node_with_transport("streamer", transport.clone());
+        let task = Task::new(node.pubkey(), "02recipient", "do something");
+
+        // Single chunk should be both first and final
+        node.respond_stream(&task, vec!["all at once".to_string()])
+            .await
+            .unwrap();
+
+        let receiver = make_node_with_transport("receiver", transport);
+        let chunks = receiver.poll_stream_chunks(&task.id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert_eq!(chunks[0].text, "all at once");
+        assert!(chunks[0].is_final);
+    }
+
+    #[tokio::test]
+    async fn poll_stream_ignores_wrong_task_id() {
+        let transport = InMemoryTransport::new();
+        let target_task = "target-task";
+        let other_task = "other-task";
+        let stream_topic = topics::stream_topic(target_task);
+
+        // Inject a chunk with a different task_id on the same topic
+        let chunk = TaskStreamChunk {
+            task_id: other_task.to_string(),
+            chunk_index: 0,
+            text: "wrong task".to_string(),
+            is_final: true,
+        };
+        let envelope = A2AEnvelope::StreamChunk(chunk);
+        let payload = serde_json::to_vec(&envelope).unwrap();
+        transport.publish(&stream_topic, &payload).await.unwrap();
+
+        let node = make_node_with_transport("receiver", transport);
+        let chunks = node.poll_stream_chunks(target_task).await.unwrap();
+        assert!(chunks.is_empty());
     }
 }


### PR DESCRIPTION
## 🎯 Purpose
Implement A2A task streaming over Waku, allowing agents to send partial/incremental results as they work (e.g., LLM token-by-token output). Without streaming, agents must buffer entire responses before sending — bad UX for long-running tasks.

## ⚙️ Approach
- **Core types**: `TaskStreamChunk` struct with `task_id`, `chunk_index`, `text`, `is_final` fields. New `A2AEnvelope::StreamChunk` variant for wire serialization. Dedicated `stream_topic(task_id)` for per-task stream isolation.
- **Node API**: `respond_stream(task, chunks)` publishes a sequence of chunks with auto-incrementing index and final flag. `poll_stream_chunks(task_id)` subscribes to the stream topic, deduplicates by chunk_index, sorts, and buffers internally. `reassemble_stream(task_id)` concatenates all buffered chunks into a single string (returns None if stream incomplete).
- **CLI**: `task stream --id <task-id> [--timeout 30]` live-follows a task's streaming output, printing new chunks as they arrive and exiting on final chunk or timeout.
- **No breaking changes** — the new envelope variant is additive, existing `extract_task_from_envelope` handles it via the catch-all arm.

## 🧪 How to Test
- `cargo test --workspace` — 8 new streaming tests covering:
  - Chunk publishing and ordering verification
  - Out-of-order chunk reception + sorting
  - Duplicate chunk deduplication
  - Stream reassembly with final flag
  - Incomplete stream returns None
  - Unknown task returns None
  - Single-chunk streams (is_final on first chunk)
  - Wrong task_id filtering
- CLI: `cargo run --bin logos-messaging-a2a -- task stream --id <uuid>` (requires nwaku)

## 🔗 Dependencies
None — uses existing Transport trait and InMemoryTransport for testing.

## 🔜 Future Work
- `subscribe_task_stream(task_id, callback)` — real-time push-based chunk handler
- Encrypted stream chunks (integrate with existing X25519+ChaCha20 path)
- Missed chunk detection and repair requests
- Storage offloading for large streams

## 📋 Checklist
- [x] `TaskStreamChunk` type in core
- [x] `A2AEnvelope::StreamChunk` variant
- [x] Stream publishing (`respond_stream`)
- [x] Stream receiving/reassembly (`poll_stream_chunks`, `reassemble_stream`)
- [x] CLI `task stream` subcommand
- [x] Tests: chunk ordering, final flag, dedup, reassembly
- [x] `cargo fmt --all` ✅
- [x] `cargo clippy --workspace -- -D warnings` ✅
- [x] `cargo test --workspace` ✅ (372 tests pass)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)