### PR TITLE
test(ffi): add comprehensive tests for C FFI bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "logos-messaging-a2a-transport",
  "once_cell",
  "serde_json",
+ "serial_test",
  "tokio",
 ]
 
@@ -3467,6 +3468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,6 +3516,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -3715,6 +3731,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/logos-messaging-a2a-ffi/Cargo.toml
+++ b/crates/logos-messaging-a2a-ffi/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "C FFI bridge for logos-messaging-a2a — enables Logos Core Qt module integration"
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "lib"]
 name = "logos_messaging_a2a_ffi"
 
 [dependencies]
@@ -16,3 +16,6 @@ logos-messaging-a2a-crypto = { path = "../logos-messaging-a2a-crypto" }
 tokio = { workspace = true }
 serde_json = { workspace = true }
 once_cell = "1"
+
+[dev-dependencies]
+serial_test = "3"

--- a/crates/logos-messaging-a2a-ffi/src/lib.rs
+++ b/crates/logos-messaging-a2a-ffi/src/lib.rs
@@ -202,3 +202,315 @@ pub unsafe extern "C" fn waku_a2a_shutdown() {
         *guard = None;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::ffi::CString;
+
+    /// Helper: create a C string literal for test arguments.
+    fn c(s: &str) -> CString {
+        CString::new(s).unwrap()
+    }
+
+    /// Ensure the global node is cleared before each test.
+    fn reset_node() {
+        unsafe {
+            waku_a2a_shutdown();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_free_string
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn free_string_null_does_not_crash() {
+        unsafe {
+            waku_a2a_free_string(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn free_string_valid_does_not_crash() {
+        let s = to_c_string("hello from test");
+        unsafe {
+            waku_a2a_free_string(s);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_pubkey — before init should be null
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn pubkey_returns_null_before_init() {
+        reset_node();
+        let pk = unsafe { waku_a2a_pubkey() };
+        assert!(
+            pk.is_null(),
+            "pubkey should be null when no node is initialized"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_agent_card_json — before init should be null
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn agent_card_json_returns_null_before_init() {
+        reset_node();
+        let json = unsafe { waku_a2a_agent_card_json() };
+        assert!(
+            json.is_null(),
+            "agent_card_json should be null when no node is initialized"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_init — plaintext mode
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn init_success_plaintext() {
+        reset_node();
+        let name = c("test-agent");
+        let desc = c("A test agent");
+        let url = c("http://127.0.0.1:8645");
+
+        let ret = unsafe { waku_a2a_init(name.as_ptr(), desc.as_ptr(), url.as_ptr(), false) };
+        assert_eq!(ret, 0, "init should return 0 on success");
+
+        // pubkey should now be non-null and a valid hex string
+        let pk = unsafe { waku_a2a_pubkey() };
+        assert!(!pk.is_null(), "pubkey should be non-null after init");
+        let pk_str = unsafe { CStr::from_ptr(pk) }.to_string_lossy().to_string();
+        assert!(!pk_str.is_empty(), "pubkey string should not be empty");
+        assert!(
+            pk_str.chars().all(|c| c.is_ascii_hexdigit()),
+            "pubkey should be hex: {pk_str}"
+        );
+        unsafe { waku_a2a_free_string(pk) };
+
+        reset_node();
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_init — encrypted mode
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn init_success_encrypted() {
+        reset_node();
+        let name = c("enc-agent");
+        let desc = c("An encrypted test agent");
+        let url = c("http://127.0.0.1:8645");
+
+        let ret = unsafe { waku_a2a_init(name.as_ptr(), desc.as_ptr(), url.as_ptr(), true) };
+        assert_eq!(ret, 0, "encrypted init should return 0");
+
+        // pubkey should be valid hex
+        let pk = unsafe { waku_a2a_pubkey() };
+        assert!(!pk.is_null());
+        let pk_str = unsafe { CStr::from_ptr(pk) }.to_string_lossy().to_string();
+        assert!(pk_str.chars().all(|c| c.is_ascii_hexdigit()));
+        unsafe { waku_a2a_free_string(pk) };
+
+        // agent card should contain intro_bundle for encrypted mode
+        let card_ptr = unsafe { waku_a2a_agent_card_json() };
+        assert!(!card_ptr.is_null());
+        let card_json = unsafe { CStr::from_ptr(card_ptr) }
+            .to_string_lossy()
+            .to_string();
+        let v: serde_json::Value =
+            serde_json::from_str(&card_json).expect("agent card should be valid JSON");
+        assert!(
+            v.get("intro_bundle").is_some(),
+            "encrypted card should have intro_bundle"
+        );
+        unsafe { waku_a2a_free_string(card_ptr) };
+
+        reset_node();
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_agent_card_json — valid JSON with expected fields
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn agent_card_json_valid_after_init() {
+        reset_node();
+        let name = c("card-agent");
+        let desc = c("Card test");
+        let url = c("http://127.0.0.1:8645");
+
+        let ret = unsafe { waku_a2a_init(name.as_ptr(), desc.as_ptr(), url.as_ptr(), false) };
+        assert_eq!(ret, 0);
+
+        let card_ptr = unsafe { waku_a2a_agent_card_json() };
+        assert!(!card_ptr.is_null());
+        let card_json = unsafe { CStr::from_ptr(card_ptr) }
+            .to_string_lossy()
+            .to_string();
+        let v: serde_json::Value =
+            serde_json::from_str(&card_json).expect("agent card should be valid JSON");
+
+        assert_eq!(v["name"], "card-agent");
+        assert_eq!(v["description"], "Card test");
+        assert!(v["public_key"].is_string());
+        assert!(v["capabilities"].is_array());
+        unsafe { waku_a2a_free_string(card_ptr) };
+
+        reset_node();
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_shutdown — pubkey returns null afterwards
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn shutdown_clears_node() {
+        reset_node();
+        let name = c("shutdown-agent");
+        let desc = c("Shutdown test");
+        let url = c("http://127.0.0.1:8645");
+
+        let ret = unsafe { waku_a2a_init(name.as_ptr(), desc.as_ptr(), url.as_ptr(), false) };
+        assert_eq!(ret, 0);
+
+        // pubkey is valid before shutdown
+        let pk = unsafe { waku_a2a_pubkey() };
+        assert!(!pk.is_null());
+        unsafe { waku_a2a_free_string(pk) };
+
+        // shutdown
+        unsafe { waku_a2a_shutdown() };
+
+        // pubkey should now be null
+        let pk_after = unsafe { waku_a2a_pubkey() };
+        assert!(pk_after.is_null(), "pubkey should be null after shutdown");
+    }
+
+    // ------------------------------------------------------------------
+    // waku_a2a_respond — invalid JSON returns -1
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn respond_invalid_json_returns_error() {
+        reset_node();
+        let name = c("respond-agent");
+        let desc = c("Respond test");
+        let url = c("http://127.0.0.1:8645");
+
+        let ret = unsafe { waku_a2a_init(name.as_ptr(), desc.as_ptr(), url.as_ptr(), false) };
+        assert_eq!(ret, 0);
+
+        let bad_json = c("this is not valid json");
+        let result_text = c("some response");
+
+        let ret = unsafe { waku_a2a_respond(bad_json.as_ptr(), result_text.as_ptr()) };
+        assert_eq!(ret, -1, "respond with invalid JSON should return -1");
+
+        reset_node();
+    }
+
+    // ------------------------------------------------------------------
+    // Error paths: operations without a running nwaku node return -1/null
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn announce_without_node_returns_error() {
+        reset_node();
+        let ret = unsafe { waku_a2a_announce() };
+        assert_eq!(ret, -1, "announce without node should return -1");
+    }
+
+    #[test]
+    #[serial]
+    fn discover_without_node_returns_null() {
+        reset_node();
+        let ret = unsafe { waku_a2a_discover() };
+        assert!(ret.is_null(), "discover without node should return null");
+    }
+
+    #[test]
+    #[serial]
+    fn send_text_without_node_returns_error() {
+        reset_node();
+        let to = c("deadbeef");
+        let text = c("hello");
+        let ret = unsafe { waku_a2a_send_text(to.as_ptr(), text.as_ptr()) };
+        assert_eq!(ret, -1, "send_text without node should return -1");
+    }
+
+    #[test]
+    #[serial]
+    fn poll_tasks_without_node_returns_null() {
+        reset_node();
+        let ret = unsafe { waku_a2a_poll_tasks() };
+        assert!(ret.is_null(), "poll_tasks without node should return null");
+    }
+
+    #[test]
+    #[serial]
+    fn respond_without_node_returns_error() {
+        reset_node();
+        let task_json = c("{}");
+        let result_text = c("reply");
+        let ret = unsafe { waku_a2a_respond(task_json.as_ptr(), result_text.as_ptr()) };
+        assert_eq!(ret, -1, "respond without node should return -1");
+    }
+
+    // ------------------------------------------------------------------
+    // Re-initialization: init can be called again after shutdown
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn reinit_after_shutdown() {
+        reset_node();
+        let name = c("agent-v1");
+        let desc = c("First init");
+        let url = c("http://127.0.0.1:8645");
+
+        let ret = unsafe { waku_a2a_init(name.as_ptr(), desc.as_ptr(), url.as_ptr(), false) };
+        assert_eq!(ret, 0);
+
+        let pk1 = unsafe { waku_a2a_pubkey() };
+        assert!(!pk1.is_null());
+        let pk1_str = unsafe { CStr::from_ptr(pk1) }.to_string_lossy().to_string();
+        unsafe { waku_a2a_free_string(pk1) };
+
+        unsafe { waku_a2a_shutdown() };
+
+        // Re-init with new identity
+        let name2 = c("agent-v2");
+        let desc2 = c("Second init");
+        let ret = unsafe { waku_a2a_init(name2.as_ptr(), desc2.as_ptr(), url.as_ptr(), false) };
+        assert_eq!(ret, 0);
+
+        let pk2 = unsafe { waku_a2a_pubkey() };
+        assert!(!pk2.is_null());
+        let pk2_str = unsafe { CStr::from_ptr(pk2) }.to_string_lossy().to_string();
+        unsafe { waku_a2a_free_string(pk2) };
+
+        // New node should have a different key
+        assert_ne!(
+            pk1_str, pk2_str,
+            "re-initialized node should have a new keypair"
+        );
+
+        reset_node();
+    }
+}


### PR DESCRIPTION
## Purpose

The FFI crate (`logos-messaging-a2a-ffi`) had 0 tests. This PR adds 15 tests covering all exported C FFI functions.

## Approach

- Added `serial_test` dev-dependency to serialize tests that share the global `NODE` / `RT` statics
- Added `"lib"` to crate-type so `cargo test` can build the test harness alongside `cdylib`/`staticlib`
- Tests cover:
  - **`waku_a2a_free_string`** — null pointer and valid pointer don't crash
  - **`waku_a2a_pubkey`** — returns null before init, valid hex after init
  - **`waku_a2a_agent_card_json`** — returns null before init, valid JSON with expected fields after init
  - **`waku_a2a_init`** — success in plaintext mode and encrypted mode (verifies `intro_bundle` present)
  - **`waku_a2a_shutdown`** — pubkey returns null afterwards
  - **`waku_a2a_respond`** — invalid JSON returns -1
  - **Error paths** — `announce`, `discover`, `send_text`, `poll_tasks`, `respond` all return -1/null when no node is initialized
  - **Re-initialization** — init → shutdown → init produces a new keypair

## How to Test

```bash
cargo test -p logos-messaging-a2a-ffi
# or
cargo test --workspace
```

## Dependencies

- `serial_test = "3"` (dev-dependency only)

## Future Work

- Integration tests with a running nwaku node for `announce`, `discover`, `send_text`, `poll_tasks`
- Test `waku_a2a_respond` with valid Task JSON + running transport

## Checklist

- [x] Tests pass locally (`cargo test --workspace`)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] No new dependencies in production (serial_test is dev-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)