### PR TITLE
fix: resolve broken rustdoc links and add doc CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace -- -D warnings
 
+  doc:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check rustdoc warnings
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/crates/logos-messaging-a2a-storage/src/lib.rs
+++ b/crates/logos-messaging-a2a-storage/src/lib.rs
@@ -6,7 +6,7 @@
 //! | Backend | Feature flag | When to use |
 //! |---------|-------------|-------------|
 //! | [`LogosStorageRest`] | `rest` (default) | Standalone processes talking to a Codex REST API |
-//! | [`LogosCoreStorageBackend`] | `logos-core` | Inside a Logos Core host process (desktop client) |
+//! | `LogosCoreStorageBackend` | `logos-core` | Inside a Logos Core host process (desktop client) |
 //!
 //! # Example (REST)
 //!

--- a/crates/logos-messaging-a2a-transport/src/sds/bloom.rs
+++ b/crates/logos-messaging-a2a-transport/src/sds/bloom.rs
@@ -72,7 +72,7 @@ impl SdsBloomFilter {
 
     /// Serialize the bloom filter to bytes for inclusion in SDS messages.
     ///
-    /// The format is: [8 bytes bitmap_bits LE][4 bytes k_num LE][32 bytes sip_keys][bitmap...]
+    /// The format is: \[8 bytes bitmap_bits LE\]\[4 bytes k_num LE\]\[32 bytes sip_keys\]\[bitmap...\]
     pub fn to_bytes(&self) -> Vec<u8> {
         let filter = self.inner.lock().unwrap();
         let bitmap = filter.bitmap();
@@ -91,7 +91,7 @@ impl SdsBloomFilter {
         out
     }
 
-    /// Deserialize a bloom filter from bytes produced by [`to_bytes`].
+    /// Deserialize a bloom filter from bytes produced by [`Self::to_bytes`].
     ///
     /// Returns `None` if the data is too short or malformed.
     pub fn from_bytes(data: &[u8]) -> Option<Self> {

--- a/crates/logos-messaging-a2a-transport/src/sds/channel.rs
+++ b/crates/logos-messaging-a2a-transport/src/sds/channel.rs
@@ -10,7 +10,7 @@
 //! - Incoming buffer with dependency resolution
 //! - Sync messages for consistency protocol
 //!
-//! Reference: https://forum.research.logos.co/t/introducing-the-reliable-channel-api/580
+//! Reference: <https://forum.research.logos.co/t/introducing-the-reliable-channel-api/580>
 
 use crate::Transport;
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Purpose

Fix all broken rustdoc links that cause `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` to fail, and add a CI job to prevent future regressions.

## Approach

- **bloom.rs**: Escape `[bitmap...]` bracket notation with `\[...\]` so rustdoc doesn't interpret it as an intra-doc link
- **bloom.rs**: Qualify `[`to_bytes`]` as `[`Self::to_bytes`]` so the link resolves within the impl block
- **channel.rs**: Wrap bare URL in angle brackets (`<https://...>`) to satisfy `rustdoc::bare_urls`
- **storage lib.rs**: Convert `[`LogosCoreStorageBackend`]` doc-link to inline code (`` `LogosCoreStorageBackend` ``) since the type is behind the `logos-core` feature gate and won't resolve in default builds
- **ci.yml**: Add a `doc` job that runs `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## How to Test

```bash
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
cargo test --workspace
cargo fmt --check
```

## Dependencies

None.

## Future Work

None.

## Checklist

- [x] All rustdoc warnings resolved
- [x] `cargo doc --workspace --no-deps` passes clean with `-D warnings`
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --check` passes
- [x] CI doc job added

🤖 Generated with [Claude Code](https://claude.com/claude-code)