### PR TITLE
fix: resolve all clippy warnings across workspace

### DIFF
--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -1076,8 +1076,10 @@ mod tests {
     use async_trait::async_trait;
     use std::sync::{Arc, Mutex};
 
+    type PublishedMessages = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
+
     struct MockTransport {
-        published: Arc<Mutex<Vec<(String, Vec<u8>)>>>,
+        published: PublishedMessages,
         state: Arc<Mutex<MockState>>,
     }
 

--- a/crates/logos-messaging-a2a-node/tests/integration.rs
+++ b/crates/logos-messaging-a2a-node/tests/integration.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// Helper: create a node pair sharing one transport.
-
 fn make_arc_pair() -> (
     Arc<WakuA2ANode<InMemoryTransport>>,
     Arc<WakuA2ANode<InMemoryTransport>>,

--- a/crates/logos-messaging-a2a-transport/src/sds/channel.rs
+++ b/crates/logos-messaging-a2a-transport/src/sds/channel.rs
@@ -698,7 +698,7 @@ mod tests {
         let delivered = bob.receive(&raw1);
         // msg1 has no deps (or deps are satisfied), delivers immediately
         // Then resolving buffered msg2 should also deliver
-        assert!(delivered.len() >= 1);
+        assert!(!delivered.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 🎯 Purpose
Fix all clippy warnings across the workspace for cleaner CI output.

## ⚙️ Approach
- Fixed empty line after doc comment in node crate
- Simplified complex type with type alias in node crate  
- Used is_empty() instead of len comparison in transport crate

## 🧪 How to Test
cargo clippy --workspace --all-targets (zero warnings)
cargo test --workspace (all pass)

## 🔗 Dependencies
None

## 🔜 Future Work
Consider adding deny(clippy::all) to CI

## 📋 Checklist
- [x] cargo fmt
- [x] cargo clippy (zero warnings)
- [x] cargo test (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)