### PR TITLE
feat: message retry with exponential backoff for unreliable P2P transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,6 +2343,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "fastrand",
  "hex",
  "k256 0.13.4",
  "logos-messaging-a2a-core",

--- a/crates/logos-messaging-a2a-core/src/lib.rs
+++ b/crates/logos-messaging-a2a-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod envelope;
 pub mod presence;
 pub mod registry;
+pub mod retry;
 pub mod task;
 pub mod topics;
 
@@ -9,4 +10,5 @@ pub mod topics;
 pub use agent::*;
 pub use envelope::*;
 pub use presence::*;
+pub use retry::*;
 pub use task::*;

--- a/crates/logos-messaging-a2a-core/src/retry.rs
+++ b/crates/logos-messaging-a2a-core/src/retry.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for exponential-backoff retry of message sends over
+/// unreliable P2P transports.
+///
+/// Delay for attempt `n` (0-indexed) is:
+///
+/// ```text
+/// min(base_delay_ms * 2^n, max_delay_ms)  [+ random jitter]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    /// Maximum number of send attempts (including the first try).
+    pub max_attempts: u32,
+    /// Base delay in milliseconds before the first retry.
+    pub base_delay_ms: u64,
+    /// Upper bound on the delay between retries, in milliseconds.
+    pub max_delay_ms: u64,
+    /// When `true`, add random jitter (0 .. delay) to each backoff interval
+    /// to avoid thundering-herd problems.
+    pub jitter: bool,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            base_delay_ms: 1_000,
+            max_delay_ms: 60_000,
+            jitter: true,
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Compute the delay (in milliseconds) for the given 0-indexed retry
+    /// attempt.  Jitter, if enabled, is applied by the caller.
+    pub fn delay_ms(&self, attempt: u32) -> u64 {
+        let exp = self.base_delay_ms.saturating_mul(1u64 << attempt.min(31));
+        exp.min(self.max_delay_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_values() {
+        let cfg = RetryConfig::default();
+        assert_eq!(cfg.max_attempts, 5);
+        assert_eq!(cfg.base_delay_ms, 1_000);
+        assert_eq!(cfg.max_delay_ms, 60_000);
+        assert!(cfg.jitter);
+    }
+
+    #[test]
+    fn test_delay_exponential() {
+        let cfg = RetryConfig {
+            max_attempts: 5,
+            base_delay_ms: 1_000,
+            max_delay_ms: 60_000,
+            jitter: false,
+        };
+        assert_eq!(cfg.delay_ms(0), 1_000);
+        assert_eq!(cfg.delay_ms(1), 2_000);
+        assert_eq!(cfg.delay_ms(2), 4_000);
+        assert_eq!(cfg.delay_ms(3), 8_000);
+        assert_eq!(cfg.delay_ms(4), 16_000);
+    }
+
+    #[test]
+    fn test_delay_capped() {
+        let cfg = RetryConfig {
+            max_attempts: 10,
+            base_delay_ms: 1_000,
+            max_delay_ms: 10_000,
+            jitter: false,
+        };
+        assert_eq!(cfg.delay_ms(5), 10_000); // 32_000 capped to 10_000
+        assert_eq!(cfg.delay_ms(9), 10_000);
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let cfg = RetryConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let deser: RetryConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.max_attempts, cfg.max_attempts);
+        assert_eq!(deser.base_delay_ms, cfg.base_delay_ms);
+        assert_eq!(deser.max_delay_ms, cfg.max_delay_ms);
+        assert_eq!(deser.jitter, cfg.jitter);
+    }
+}

--- a/crates/logos-messaging-a2a-node/Cargo.toml
+++ b/crates/logos-messaging-a2a-node/Cargo.toml
@@ -17,3 +17,4 @@ k256 = { workspace = true }
 hex = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+fastrand = "2"

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod presence;
+pub mod retry;
 
 use anyhow::{Context, Result};
 use k256::ecdsa::SigningKey;
 use logos_messaging_a2a_core::registry::AgentRegistry;
+use logos_messaging_a2a_core::RetryConfig;
 pub use logos_messaging_a2a_core::Task as TaskType;
 use logos_messaging_a2a_core::{
     topics, A2AEnvelope, AgentCard, Message, PresenceAnnouncement, Task, TaskStreamChunk,
@@ -125,6 +127,9 @@ pub struct WakuA2ANode<T: Transport> {
     registry: Option<Arc<dyn AgentRegistry>>,
     /// Buffered stream chunks keyed by task_id, sorted by chunk_index.
     stream_chunks: std::sync::Mutex<HashMap<String, Vec<TaskStreamChunk>>>,
+    /// Optional retry configuration for exponential-backoff retries of
+    /// transport send failures.
+    retry_config: Option<RetryConfig>,
 }
 
 impl<T: Transport> WakuA2ANode<T> {
@@ -165,6 +170,7 @@ impl<T: Transport> WakuA2ANode<T> {
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
+            retry_config: None,
         }
     }
 
@@ -213,6 +219,7 @@ impl<T: Transport> WakuA2ANode<T> {
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
+            retry_config: None,
         }
     }
 
@@ -258,6 +265,7 @@ impl<T: Transport> WakuA2ANode<T> {
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
+            retry_config: None,
         }
     }
 
@@ -305,6 +313,7 @@ impl<T: Transport> WakuA2ANode<T> {
             presence_rx: tokio::sync::Mutex::new(None),
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
+            retry_config: None,
         }
     }
 
@@ -324,6 +333,15 @@ impl<T: Transport> WakuA2ANode<T> {
     /// require payment proof before processing.
     pub fn with_payment(mut self, config: PaymentConfig) -> Self {
         self.payment = Some(config);
+        self
+    }
+
+    /// Enable exponential-backoff retry for transport send failures.
+    ///
+    /// When configured, `send_task` / `send_task_to` will retry on transport
+    /// errors up to `config.max_attempts` times with exponential backoff.
+    pub fn with_retry(mut self, config: RetryConfig) -> Self {
+        self.retry_config = Some(config);
         self
     }
 
@@ -445,6 +463,11 @@ impl<T: Transport> WakuA2ANode<T> {
         &self.channel
     }
 
+    /// Get the current retry configuration, if any.
+    pub fn retry_config(&self) -> Option<&RetryConfig> {
+        self.retry_config.as_ref()
+    }
+
     /// Broadcast this agent's card on the discovery topic.
     ///
     /// Discovery uses raw A2AEnvelope (not SDS-wrapped) since it's a
@@ -555,6 +578,9 @@ impl<T: Transport> WakuA2ANode<T> {
     /// When a [`PaymentConfig`] with `auto_pay = true` is set, the node
     /// calls `backend.pay()` before sending and attaches the TX hash to
     /// the task envelope.
+    ///
+    /// When a [`RetryConfig`] is set (via [`with_retry`](Self::with_retry)),
+    /// transport-level failures are retried with exponential backoff.
     pub async fn send_task_to(
         &self,
         task: &Task,
@@ -566,11 +592,17 @@ impl<T: Transport> WakuA2ANode<T> {
 
         // Use SDS reliable delivery — the SDS message_id (SHA256 of payload)
         // is used for ACK routing, not the task UUID.
-        let (_msg, acked) = self
-            .channel
-            .send_reliable(&topic, &payload)
-            .await
-            .context("SDS publish failed")?;
+        let (_msg, acked) = if let Some(ref retry_cfg) = self.retry_config {
+            retry::RetryLayer::new(&self.channel, retry_cfg)
+                .send_reliable(&topic, &payload)
+                .await
+                .context("SDS publish failed (after retries)")?
+        } else {
+            self.channel
+                .send_reliable(&topic, &payload)
+                .await
+                .context("SDS publish failed")?
+        };
 
         if acked {
             eprintln!("[node] Task {} sent and ACKed", task.id);

--- a/crates/logos-messaging-a2a-node/src/retry.rs
+++ b/crates/logos-messaging-a2a-node/src/retry.rs
@@ -1,0 +1,78 @@
+//! Retry layer for unreliable P2P transport sends.
+//!
+//! [`RetryLayer`] wraps the SDS [`MessageChannel`] send path and replays a
+//! failed `send_reliable` call with exponential backoff according to a
+//! [`RetryConfig`].
+
+use anyhow::Result;
+use logos_messaging_a2a_core::RetryConfig;
+use logos_messaging_a2a_transport::sds::MessageChannel;
+use logos_messaging_a2a_transport::Transport;
+use std::time::Duration;
+
+/// Retry wrapper around [`MessageChannel::send_reliable`].
+///
+/// When a send fails (returns `Err`), the layer retries up to
+/// `config.max_attempts - 1` additional times with exponential backoff.
+/// A successful send that is **not** ACKed (`Ok((_, false))`) is *not*
+/// retried — the SDS layer already handles its own retransmission loop for
+/// that case.
+pub struct RetryLayer<'a, T: Transport> {
+    channel: &'a MessageChannel<T>,
+    config: &'a RetryConfig,
+}
+
+impl<'a, T: Transport> RetryLayer<'a, T> {
+    pub fn new(channel: &'a MessageChannel<T>, config: &'a RetryConfig) -> Self {
+        Self { channel, config }
+    }
+
+    /// Send with exponential-backoff retry on failure.
+    ///
+    /// Returns the same `(ContentMessage, was_acked)` tuple as
+    /// `MessageChannel::send_reliable`.
+    pub async fn send_reliable(
+        &self,
+        topic: &str,
+        payload: &[u8],
+    ) -> Result<(logos_messaging_a2a_transport::sds::ContentMessage, bool)> {
+        let mut last_err = None;
+
+        for attempt in 0..self.config.max_attempts {
+            match self.channel.send_reliable(topic, payload).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    last_err = Some(e);
+                    // Don't sleep after the final attempt
+                    if attempt + 1 < self.config.max_attempts {
+                        let delay = self.compute_delay(attempt);
+                        eprintln!(
+                            "[retry] Attempt {}/{} failed, retrying in {}ms",
+                            attempt + 1,
+                            self.config.max_attempts,
+                            delay.as_millis(),
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_err
+            .unwrap()
+            .context(format!("all {} attempts failed", self.config.max_attempts)))
+    }
+
+    /// Compute the delay for a given 0-indexed attempt, with optional jitter.
+    fn compute_delay(&self, attempt: u32) -> Duration {
+        let base = self.config.delay_ms(attempt);
+        let delay = if self.config.jitter {
+            // Simple jitter: uniform random in [0, base]
+            let jitter = fastrand::u64(0..=base);
+            base.saturating_add(jitter) / 2
+        } else {
+            base
+        };
+        Duration::from_millis(delay)
+    }
+}

--- a/crates/logos-messaging-a2a-node/tests/retry.rs
+++ b/crates/logos-messaging-a2a-node/tests/retry.rs
@@ -1,0 +1,272 @@
+//! Integration tests for message retry with exponential backoff.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use logos_messaging_a2a_core::RetryConfig;
+use logos_messaging_a2a_node::WakuA2ANode;
+use logos_messaging_a2a_transport::Transport;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// FailNTransport: fails the first N publishes, then succeeds
+// ---------------------------------------------------------------------------
+
+struct FailNState {
+    fail_count: usize,
+    subscribers: HashMap<String, Vec<mpsc::Sender<Vec<u8>>>>,
+    history: HashMap<String, Vec<Vec<u8>>>,
+}
+
+#[derive(Clone)]
+struct FailNTransport {
+    state: Arc<Mutex<FailNState>>,
+    attempts: Arc<AtomicUsize>,
+}
+
+impl FailNTransport {
+    fn new(fail_count: usize) -> Self {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        Self {
+            state: Arc::new(Mutex::new(FailNState {
+                fail_count,
+                subscribers: HashMap::new(),
+                history: HashMap::new(),
+            })),
+            attempts,
+        }
+    }
+
+    fn attempt_count(&self) -> usize {
+        self.attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Transport for FailNTransport {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst);
+        let fail_count = self.state.lock().unwrap().fail_count;
+
+        if attempt < fail_count {
+            return Err(anyhow::anyhow!(
+                "simulated transport failure (attempt {})",
+                attempt + 1
+            ));
+        }
+
+        let data = payload.to_vec();
+        let mut state = self.state.lock().unwrap();
+        state
+            .history
+            .entry(topic.to_string())
+            .or_default()
+            .push(data.clone());
+        if let Some(subs) = state.subscribers.get_mut(topic) {
+            subs.retain(|tx| tx.try_send(data.clone()).is_ok());
+        }
+        Ok(())
+    }
+
+    async fn subscribe(&self, topic: &str) -> Result<mpsc::Receiver<Vec<u8>>> {
+        let mut state = self.state.lock().unwrap();
+        let (tx, rx) = mpsc::channel(1024);
+        if let Some(history) = state.history.get(topic) {
+            for msg in history {
+                let _ = tx.try_send(msg.clone());
+            }
+        }
+        state
+            .subscribers
+            .entry(topic.to_string())
+            .or_default()
+            .push(tx);
+        Ok(rx)
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<()> {
+        let mut state = self.state.lock().unwrap();
+        state.subscribers.remove(topic);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_retry_succeeds_after_failures() {
+    let transport = FailNTransport::new(3); // fail 3 times, then succeed
+    let attempts = transport.attempts.clone();
+
+    let retry_cfg = RetryConfig {
+        max_attempts: 5,
+        base_delay_ms: 10, // fast for testing
+        max_delay_ms: 100,
+        jitter: false,
+    };
+
+    let node = WakuA2ANode::with_config(
+        "retry-test",
+        "retry test agent",
+        vec![],
+        transport,
+        logos_messaging_a2a_transport::sds::ChannelConfig {
+            ack_timeout: std::time::Duration::from_millis(1),
+            max_retries: 0,
+            ..Default::default()
+        },
+    )
+    .with_retry(retry_cfg);
+
+    let task = logos_messaging_a2a_core::Task::new(node.pubkey(), "02deadbeef", "hello retry");
+    let result = node.send_task(&task).await;
+    assert!(result.is_ok(), "send should succeed after retries");
+
+    // 3 failures + 1 success = 4 transport publish calls (at least)
+    assert!(
+        attempts.load(Ordering::SeqCst) >= 4,
+        "expected at least 4 attempts, got {}",
+        attempts.load(Ordering::SeqCst)
+    );
+}
+
+#[tokio::test]
+async fn test_retry_exhausted() {
+    let transport = FailNTransport::new(100); // always fail
+
+    let retry_cfg = RetryConfig {
+        max_attempts: 3,
+        base_delay_ms: 10,
+        max_delay_ms: 50,
+        jitter: false,
+    };
+
+    let node = WakuA2ANode::with_config(
+        "retry-exhaust",
+        "retry exhaust agent",
+        vec![],
+        transport.clone(),
+        logos_messaging_a2a_transport::sds::ChannelConfig {
+            ack_timeout: std::time::Duration::from_millis(1),
+            max_retries: 0,
+            ..Default::default()
+        },
+    )
+    .with_retry(retry_cfg);
+
+    let task = logos_messaging_a2a_core::Task::new(node.pubkey(), "02deadbeef", "doomed");
+    let result = node.send_task(&task).await;
+    assert!(result.is_err(), "send should fail when retries exhausted");
+
+    // Should have attempted exactly 3 times
+    assert_eq!(transport.attempt_count(), 3);
+}
+
+#[tokio::test]
+async fn test_no_retry_without_config() {
+    let transport = FailNTransport::new(1); // fail once
+
+    // No retry config — should fail immediately
+    let node = WakuA2ANode::with_config(
+        "no-retry",
+        "no retry agent",
+        vec![],
+        transport.clone(),
+        logos_messaging_a2a_transport::sds::ChannelConfig {
+            ack_timeout: std::time::Duration::from_millis(1),
+            max_retries: 0,
+            ..Default::default()
+        },
+    );
+
+    let task = logos_messaging_a2a_core::Task::new(node.pubkey(), "02deadbeef", "no retry");
+    let result = node.send_task(&task).await;
+    assert!(result.is_err(), "should fail without retry config");
+    assert_eq!(transport.attempt_count(), 1, "should only attempt once");
+}
+
+#[tokio::test]
+async fn test_retry_first_attempt_succeeds() {
+    let transport = FailNTransport::new(0); // never fail
+
+    let retry_cfg = RetryConfig {
+        max_attempts: 5,
+        base_delay_ms: 10,
+        max_delay_ms: 100,
+        jitter: false,
+    };
+
+    let node = WakuA2ANode::with_config(
+        "instant-ok",
+        "instant success agent",
+        vec![],
+        transport.clone(),
+        logos_messaging_a2a_transport::sds::ChannelConfig {
+            ack_timeout: std::time::Duration::from_millis(1),
+            max_retries: 0,
+            ..Default::default()
+        },
+    )
+    .with_retry(retry_cfg);
+
+    let task = logos_messaging_a2a_core::Task::new(node.pubkey(), "02deadbeef", "easy");
+    let result = node.send_task(&task).await;
+    assert!(result.is_ok(), "should succeed on first attempt");
+    // Only 1 publish attempt needed (the SDS layer may add ACK publishes)
+    assert!(
+        transport.attempt_count() >= 1,
+        "should have at least 1 attempt"
+    );
+}
+
+#[tokio::test]
+async fn test_retry_with_jitter() {
+    let transport = FailNTransport::new(2);
+    let attempts = transport.attempts.clone();
+
+    let retry_cfg = RetryConfig {
+        max_attempts: 5,
+        base_delay_ms: 10,
+        max_delay_ms: 100,
+        jitter: true, // enable jitter
+    };
+
+    let node = WakuA2ANode::with_config(
+        "jitter-test",
+        "jitter test agent",
+        vec![],
+        transport,
+        logos_messaging_a2a_transport::sds::ChannelConfig {
+            ack_timeout: std::time::Duration::from_millis(1),
+            max_retries: 0,
+            ..Default::default()
+        },
+    )
+    .with_retry(retry_cfg);
+
+    let task = logos_messaging_a2a_core::Task::new(node.pubkey(), "02deadbeef", "jitter");
+    let result = node.send_task(&task).await;
+    assert!(result.is_ok(), "should succeed with jitter enabled");
+    assert!(
+        attempts.load(Ordering::SeqCst) >= 3,
+        "expected at least 3 attempts"
+    );
+}
+
+#[tokio::test]
+async fn test_with_retry_builder() {
+    let transport = FailNTransport::new(0);
+
+    let node = WakuA2ANode::new("builder-test", "test", vec![], transport);
+    assert!(node.retry_config().is_none());
+
+    let transport2 = FailNTransport::new(0);
+    let node2 = WakuA2ANode::new("builder-test2", "test", vec![], transport2)
+        .with_retry(RetryConfig::default());
+    assert!(node2.retry_config().is_some());
+    assert_eq!(node2.retry_config().unwrap().max_attempts, 5);
+}


### PR DESCRIPTION
## 🎯 Purpose

Closes #86. Adds application-level retry with exponential backoff for message sends over unreliable P2P (Waku) transport. Currently, failed sends are silently lost — this ensures transient failures are automatically retried.

## ⚙️ Approach

- **RetryConfig** (core crate): configurable max_attempts (5), base_delay_ms (1s), max_delay_ms (60s), jitter (true). Serializable for agent card config.
- **RetryLayer** (node crate): wraps MessageChannel send_reliable with exponential backoff. Only retries on transport errors, not on missing ACKs (SDS handles those).
- **Node integration**: Node gains optional retry_config field. When set, task sends go through RetryLayer.
- **Jitter**: uniform random jitter via fastrand to avoid thundering herd.

## 🧪 How to Test

```
cargo test --workspace
cargo test -p logos-messaging-a2a-node --test retry
```

Integration tests use a mock transport that fails N times then succeeds.

## 🔗 Dependencies

- fastrand (new, lightweight) for jitter randomization

## 🔜 Future Work

- Persistent retry queue (survive restarts)
- Per-message retry config overrides
- Metrics/callbacks for retry events

## 📋 Checklist

- [x] cargo fmt
- [x] cargo clippy -- -D warnings
- [x] cargo test --workspace
- [x] New tests for retry config, retry layer, and node integration
- [x] Documentation (doc comments on all public items)
