### PR TITLE
test(mcp): comprehensive bridge tests + architecture docs update

### DIFF
--- a/crates/logos-messaging-a2a-mcp/src/main.rs
+++ b/crates/logos-messaging-a2a-mcp/src/main.rs
@@ -29,6 +29,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use logos_messaging_a2a_core::{AgentCard, Part, TaskState};
 use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
+use logos_messaging_a2a_transport::Transport;
 use serde::Deserialize;
 
 #[derive(Deserialize, rmcp::schemars::JsonSchema)]
@@ -58,25 +59,29 @@ struct Cli {
 type AgentRegistry = Arc<RwLock<Vec<AgentCard>>>;
 
 /// The MCP server that bridges to A2A over Waku.
-#[derive(Clone)]
-struct LogosA2ABridge {
-    node: Arc<RwLock<WakuA2ANode<LogosMessagingTransport>>>,
+struct LogosA2ABridge<T: Transport> {
+    node: Arc<RwLock<WakuA2ANode<T>>>,
     agents: AgentRegistry,
     timeout_secs: u64,
     tool_router: ToolRouter<Self>,
 }
 
-#[tool_router]
-impl LogosA2ABridge {
-    fn new(waku_url: &str, timeout_secs: u64) -> Self {
-        let transport = LogosMessagingTransport::new(waku_url);
-        let node = WakuA2ANode::new(
-            "mcp-bridge",
-            "MCP bridge — proxies tool calls to Logos A2A agents",
-            vec!["mcp-bridge".into()],
-            transport,
-        );
+// Manual Clone: T is behind Arc so we don't need T: Clone.
+impl<T: Transport> Clone for LogosA2ABridge<T> {
+    fn clone(&self) -> Self {
+        Self {
+            node: self.node.clone(),
+            agents: self.agents.clone(),
+            timeout_secs: self.timeout_secs,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
 
+#[tool_router]
+impl<T: Transport> LogosA2ABridge<T> {
+    /// Create a bridge wrapping an existing node.
+    fn from_node(node: WakuA2ANode<T>, timeout_secs: u64) -> Self {
         Self {
             node: Arc::new(RwLock::new(node)),
             agents: Arc::new(RwLock::new(Vec::new())),
@@ -239,8 +244,21 @@ impl LogosA2ABridge {
     }
 }
 
+impl LogosA2ABridge<LogosMessagingTransport> {
+    fn new(waku_url: &str, timeout_secs: u64) -> Self {
+        let transport = LogosMessagingTransport::new(waku_url);
+        let node = WakuA2ANode::new(
+            "mcp-bridge",
+            "MCP bridge — proxies tool calls to Logos A2A agents",
+            vec!["mcp-bridge".into()],
+            transport,
+        );
+        Self::from_node(node, timeout_secs)
+    }
+}
+
 #[tool_handler]
-impl ServerHandler for LogosA2ABridge {
+impl<T: Transport> ServerHandler for LogosA2ABridge<T> {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             instructions: Some(
@@ -290,6 +308,38 @@ async fn main() -> Result<()> {
 mod tests {
     use super::*;
     use clap::error::ErrorKind;
+    use logos_messaging_a2a_transport::memory::InMemoryTransport;
+
+    /// Extract text from the first content element of a CallToolResult.
+    fn result_text(result: &CallToolResult) -> &str {
+        match &result.content[0].raw {
+            RawContent::Text(t) => t.text.as_str(),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    /// Create a bridge backed by InMemoryTransport (no nwaku required).
+    fn make_test_bridge(transport: InMemoryTransport) -> LogosA2ABridge<InMemoryTransport> {
+        let node = WakuA2ANode::new(
+            "mcp-bridge",
+            "MCP bridge for tests",
+            vec!["mcp-bridge".into()],
+            transport,
+        );
+        LogosA2ABridge::from_node(node, 30)
+    }
+
+    /// Create an AgentCard fixture.
+    fn make_card(name: &str, desc: &str, caps: &[&str], pubkey: &str) -> AgentCard {
+        AgentCard {
+            name: name.to_string(),
+            version: "1.0".to_string(),
+            description: desc.to_string(),
+            capabilities: caps.iter().map(|s| s.to_string()).collect(),
+            public_key: pubkey.to_string(),
+            intro_bundle: None,
+        }
+    }
 
     // ── CLI arg parsing ──
 
@@ -332,45 +382,290 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::ValueValidation);
     }
 
-    // ── list_cached_agents with empty cache ──
+    // ── list_cached_agents ──
 
     #[tokio::test]
     async fn list_cached_agents_empty_cache() {
-        let bridge = LogosA2ABridge::new("http://localhost:8645", 30);
+        let bridge = make_test_bridge(InMemoryTransport::new());
         let result = bridge.list_cached_agents().await.unwrap();
-        // Should indicate no cached agents
-        let text = match &result.content[0].raw {
-            RawContent::Text(t) => t.text.as_str(),
-            _ => panic!("expected text content"),
-        };
-        assert!(text.contains("No cached agents"));
+        assert!(result_text(&result).contains("No cached agents"));
     }
-
-    // ── list_cached_agents with populated cache ──
 
     #[tokio::test]
     async fn list_cached_agents_with_agents() {
-        let bridge = LogosA2ABridge::new("http://localhost:8645", 30);
+        let bridge = make_test_bridge(InMemoryTransport::new());
 
-        // Populate cache
         {
             let mut agents = bridge.agents.write().await;
-            agents.push(AgentCard {
-                name: "test-agent".to_string(),
-                version: "1.0".to_string(),
-                description: "A test agent".to_string(),
-                capabilities: vec!["text".to_string()],
-                public_key: "deadbeef".to_string(),
-                intro_bundle: None,
-            });
+            agents.push(make_card(
+                "test-agent",
+                "A test agent",
+                &["text"],
+                "deadbeef",
+            ));
         }
 
         let result = bridge.list_cached_agents().await.unwrap();
-        let text = match &result.content[0].raw {
-            RawContent::Text(t) => t.text.as_str(),
-            _ => panic!("expected text content"),
-        };
+        let text = result_text(&result);
         assert!(text.contains("test-agent"));
         assert!(text.contains("A test agent"));
+    }
+
+    // ── discover_agents with mocked transport ──
+
+    #[tokio::test]
+    async fn discover_agents_finds_announced_agents() {
+        let transport = InMemoryTransport::new();
+
+        // Create an agent that announces on the same transport.
+        let echo = WakuA2ANode::new(
+            "echo-agent",
+            "Echoes messages back",
+            vec!["echo".into(), "text".into()],
+            transport.clone(),
+        );
+        echo.announce().await.unwrap();
+
+        let bridge = make_test_bridge(transport);
+        let result = bridge.discover_agents().await.unwrap();
+        let text = result_text(&result);
+
+        // Response should list the discovered agent.
+        assert!(text.contains("Found 1 agent(s)"));
+        assert!(text.contains("echo-agent"));
+        assert!(text.contains("Echoes messages back"));
+        assert!(text.contains("echo, text"));
+
+        // Cache should be populated.
+        let cached = bridge.agents.read().await;
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].name, "echo-agent");
+    }
+
+    #[tokio::test]
+    async fn discover_agents_no_agents_found() {
+        let bridge = make_test_bridge(InMemoryTransport::new());
+        let result = bridge.discover_agents().await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("No agents found"));
+    }
+
+    #[tokio::test]
+    async fn discover_agents_multiple_agents() {
+        let transport = InMemoryTransport::new();
+
+        // Announce three agents on the shared transport.
+        for (name, desc, caps) in [
+            ("summarizer", "Summarizes text", vec!["summarize"]),
+            ("translator", "Translates text", vec!["translate"]),
+            ("coder", "Writes code", vec!["code", "text"]),
+        ] {
+            let node = WakuA2ANode::new(
+                name,
+                desc,
+                caps.into_iter().map(String::from).collect(),
+                transport.clone(),
+            );
+            node.announce().await.unwrap();
+        }
+
+        let bridge = make_test_bridge(transport);
+        let result = bridge.discover_agents().await.unwrap();
+        let text = result_text(&result);
+
+        assert!(text.contains("Found 3 agent(s)"));
+        assert!(text.contains("summarizer"));
+        assert!(text.contains("translator"));
+        assert!(text.contains("coder"));
+
+        // All three should be cached.
+        let cached = bridge.agents.read().await;
+        assert_eq!(cached.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn discover_agents_cache_is_replaced_on_rediscovery() {
+        let transport = InMemoryTransport::new();
+
+        // First discovery: one agent.
+        let agent1 = WakuA2ANode::new("agent-1", "First", vec!["a".into()], transport.clone());
+        agent1.announce().await.unwrap();
+
+        let bridge = make_test_bridge(transport.clone());
+        bridge.discover_agents().await.unwrap();
+        assert_eq!(bridge.agents.read().await.len(), 1);
+
+        // Second discovery: the bridge re-discovers and gets agent-1 again
+        // (InMemoryTransport replays history). Cache should reflect the new snapshot.
+        let result = bridge.discover_agents().await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("agent-1"));
+    }
+
+    // ── discover_agents response formatting ──
+
+    #[tokio::test]
+    async fn discover_agents_format_includes_version_and_pubkey() {
+        let transport = InMemoryTransport::new();
+
+        let agent = WakuA2ANode::new(
+            "format-check",
+            "Checks formatting",
+            vec!["test".into()],
+            transport.clone(),
+        );
+        agent.announce().await.unwrap();
+
+        let bridge = make_test_bridge(transport);
+        let result = bridge.discover_agents().await.unwrap();
+        let text = result_text(&result);
+
+        // Should contain version and truncated public key.
+        assert!(text.contains("(v0.1.0)"));
+        assert!(text.contains("Public key:"));
+        assert!(text.contains("..."));
+    }
+
+    // ── send_to_agent ──
+
+    #[tokio::test]
+    async fn send_to_agent_unknown_agent_returns_error() {
+        let bridge = make_test_bridge(InMemoryTransport::new());
+        let err = bridge
+            .send_to_agent(Parameters(SendToAgentInput {
+                agent_name: "nonexistent".to_string(),
+                message: "hello".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("nonexistent"));
+        assert!(err.message.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn send_to_agent_suggests_discover_on_miss() {
+        let bridge = make_test_bridge(InMemoryTransport::new());
+        let err = bridge
+            .send_to_agent(Parameters(SendToAgentInput {
+                agent_name: "missing".to_string(),
+                message: "hi".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert!(err.message.contains("discover_agents"));
+    }
+
+    // ── SendToAgentInput deserialization ──
+
+    #[test]
+    fn send_to_agent_input_deserializes() {
+        let json = r#"{"agent_name": "echo", "message": "hello world"}"#;
+        let input: SendToAgentInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.agent_name, "echo");
+        assert_eq!(input.message, "hello world");
+    }
+
+    #[test]
+    fn send_to_agent_input_rejects_missing_fields() {
+        let json = r#"{"agent_name": "echo"}"#;
+        assert!(serde_json::from_str::<SendToAgentInput>(json).is_err());
+
+        let json = r#"{"message": "hello"}"#;
+        assert!(serde_json::from_str::<SendToAgentInput>(json).is_err());
+    }
+
+    #[test]
+    fn send_to_agent_input_accepts_extra_fields() {
+        let json = r#"{"agent_name": "echo", "message": "hi", "extra": "ignored"}"#;
+        let input: SendToAgentInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.agent_name, "echo");
+    }
+
+    // ── ServerInfo / capabilities ──
+
+    #[test]
+    fn server_info_has_instructions() {
+        let bridge = make_test_bridge(InMemoryTransport::new());
+        let info = bridge.get_info();
+
+        let instructions = info.instructions.expect("should have instructions");
+        assert!(instructions.contains("Logos"));
+        assert!(instructions.contains("discover_agents"));
+    }
+
+    #[test]
+    fn server_info_enables_tools() {
+        let bridge = make_test_bridge(InMemoryTransport::new());
+        let info = bridge.get_info();
+
+        assert!(
+            info.capabilities.tools.is_some(),
+            "tools capability should be enabled"
+        );
+    }
+
+    // ── Multiple agents in cache formatting ──
+
+    #[tokio::test]
+    async fn list_cached_agents_multiple_formatting() {
+        let bridge = make_test_bridge(InMemoryTransport::new());
+
+        {
+            let mut agents = bridge.agents.write().await;
+            agents.push(make_card(
+                "summarizer",
+                "Summarizes documents",
+                &["summarize"],
+                "aabbccdd",
+            ));
+            agents.push(make_card(
+                "translator",
+                "Translates text between languages",
+                &["translate"],
+                "11223344",
+            ));
+            agents.push(make_card(
+                "coder",
+                "Writes and reviews code",
+                &["code", "review"],
+                "deadbeef",
+            ));
+        }
+
+        let result = bridge.list_cached_agents().await.unwrap();
+        let text = result_text(&result);
+
+        // Each agent should appear as a bullet point.
+        assert!(text.contains("• summarizer — Summarizes documents"));
+        assert!(text.contains("• translator — Translates text between languages"));
+        assert!(text.contains("• coder — Writes and reviews code"));
+
+        // Should be 3 lines (one per agent).
+        assert_eq!(text.lines().count(), 3);
+    }
+
+    // ── discover_agents formatting with multiple agents ──
+
+    #[tokio::test]
+    async fn discover_agents_numbered_list_format() {
+        let transport = InMemoryTransport::new();
+
+        let a = WakuA2ANode::new("alpha", "Agent A", vec!["a".into()], transport.clone());
+        let b = WakuA2ANode::new("beta", "Agent B", vec!["b".into()], transport.clone());
+        a.announce().await.unwrap();
+        b.announce().await.unwrap();
+
+        let bridge = make_test_bridge(transport);
+        let result = bridge.discover_agents().await.unwrap();
+        let text = result_text(&result);
+
+        assert!(text.contains("Found 2 agent(s)"));
+        // Should contain numbered entries.
+        assert!(text.contains("1. **"));
+        assert!(text.contains("2. **"));
+        assert!(text.contains("Capabilities: ["));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,3 +258,183 @@ Agent A                    Codex Node               Agent B
   │                            │◀── download(CID) ────│
   │                            │── data ──────────────▶│
 ```
+
+## Message Retry with Exponential Backoff
+
+P2P transports are inherently unreliable. The retry layer wraps the SDS
+`send_reliable` path and replays failed sends with exponential backoff.
+
+```
+RetryConfig
+├── max_attempts: u32          default 5
+├── base_delay_ms: u64         default 1 000 ms
+├── max_delay_ms: u64          default 60 000 ms
+└── jitter: bool               default true
+```
+
+Delay for attempt `n` (0-indexed):
+
+```
+min(base_delay_ms × 2^n, max_delay_ms)  [+ random jitter]
+```
+
+```
+                        RetryLayer<T: Transport>
+                               │
+           attempt 0           │
+   send_reliable() ───────────▶│──── Ok ──▶ return
+                               │
+                          Err? │
+                               ▼
+                   sleep(base_delay_ms)
+                               │
+           attempt 1           │
+   send_reliable() ───────────▶│──── Ok ──▶ return
+                               │
+                          Err? │
+                               ▼
+                  sleep(base_delay_ms × 2)
+                               │
+              ...              │
+                               │
+       attempt max_attempts-1  │
+   send_reliable() ───────────▶│──── Ok ──▶ return
+                               │
+                          Err? │
+                               ▼
+                    return final error
+```
+
+Key design points:
+- Only **transport errors** (`Err`) are retried. A successful send that is
+  not ACKed (`Ok((_, false))`) is left to the SDS retransmission loop.
+- Jitter adds a uniform random offset in `[0, base_delay] / 2` to avoid
+  thundering-herd problems when many agents retry simultaneously.
+- Enable via `WakuA2ANode::with_retry(RetryConfig { ... })`.
+
+Implementation:
+- `logos-messaging-a2a-core::RetryConfig` — configuration type.
+- `logos-messaging-a2a-node::retry::RetryLayer` — the retry wrapper.
+
+## Waku Presence Broadcasts
+
+Agents periodically broadcast `PresenceAnnouncement` messages on the
+well-known topic `/lmao/1/presence/proto`. Peers listen, build a live
+`PeerMap`, and query it by capability.
+
+```
+PresenceAnnouncement
+├── agent_id: String           secp256k1 compressed pubkey hex
+├── name: String               human-readable agent name
+├── capabilities: Vec<String>  e.g. ["summarize", "translate"]
+├── waku_topic: String         where this agent receives tasks
+├── ttl_secs: u64              validity window
+└── signature: Option<Vec<u8>> secp256k1 over canonical JSON
+```
+
+### Signature Verification
+
+Announcements are signed over a **canonical JSON** serialization (fixed
+key order, `signature` field excluded) using the agent's secp256k1 key.
+Verifiers decode `agent_id` to a public key and check the DER-encoded
+signature, rejecting tampered or spoofed announcements.
+
+### PeerMap
+
+```
+PeerMap (Mutex<HashMap<agent_id, PeerInfo>>)
+│
+├── update(announcement)       insert / refresh an entry
+├── get(agent_id)              lookup, returns None if expired
+├── find_by_capability(cap)    filter live peers by capability
+├── all_live()                 all non-expired peers
+└── evict_expired()            garbage-collect stale entries
+```
+
+Entries expire when `now - last_seen > ttl_secs`. A TTL of 0 means the
+entry is always considered expired (useful for one-shot announcements).
+Expired entries are lazily filtered on read and batch-removed via
+`evict_expired()`.
+
+### Combined Discovery
+
+`WakuA2ANode::discover_all()` merges two discovery sources and
+deduplicates by public key:
+
+```
+                  ┌───────────────────────┐
+                  │   discover_all()       │
+                  └───────┬───────────────┘
+                          │
+              ┌───────────┼───────────────┐
+              ▼                           ▼
+   poll_presence()              registry.list_agents()
+   (Waku topic scan)           (persistent on-chain)
+              │                           │
+              └───────────┬───────────────┘
+                          ▼
+                 deduplicate by pubkey
+                          │
+                          ▼
+                  Vec<AgentCard>
+```
+
+Implementation:
+- `logos-messaging-a2a-core::PresenceAnnouncement` — wire type + signing.
+- `logos-messaging-a2a-node::presence::{PeerInfo, PeerMap}` — live peer tracking.
+
+## MCP Bridge Architecture
+
+The MCP bridge (`logos-messaging-a2a-mcp`) exposes discovered Waku A2A
+agents as MCP tools, letting MCP hosts like Claude Desktop or Cursor
+interact with the decentralized agent fleet.
+
+```
+┌─────────────────┐   stdio    ┌──────────────────────────┐   Waku    ┌──────────────┐
+│   MCP Host      │◀─────────▶│   LogosA2ABridge          │◀────────▶│  Agent Fleet  │
+│  (Claude, etc.) │            │                          │           │  (Waku P2P)   │
+│                 │            │  ┌────────────────────┐  │           │               │
+│  discover_agents│───────────▶│  │ WakuA2ANode<T>     │  │           │  Agent A      │
+│  send_to_agent  │            │  │  .discover()       │──┼──────────▶│  Agent B      │
+│  list_cached    │            │  │  .send_text()      │  │           │  Agent C      │
+│                 │            │  │  .poll_tasks()     │  │           │               │
+│                 │◀───────────│  └────────────────────┘  │           │               │
+│   tool results  │            │                          │           │               │
+│                 │            │  AgentRegistry (cache)    │           │               │
+└─────────────────┘            └──────────────────────────┘           └──────────────┘
+```
+
+### MCP Tools
+
+| Tool                | Description                                             |
+|---------------------|---------------------------------------------------------|
+| `discover_agents`   | Poll the Waku discovery topic; cache and return agents  |
+| `send_to_agent`     | Send a message to a named agent and poll for a response |
+| `list_cached_agents`| Return cached agents without a network call             |
+
+### Request Flow
+
+```
+Claude Desktop            MCP Bridge                  Waku Network
+  │                          │                            │
+  │── discover_agents ──────▶│                            │
+  │                          │── node.discover() ────────▶│
+  │                          │◀── Vec<AgentCard> ────────│
+  │                          │   cache in AgentRegistry   │
+  │◀── agent list ──────────│                            │
+  │                          │                            │
+  │── send_to_agent ────────▶│                            │
+  │   { name, message }      │── lookup name in cache     │
+  │                          │── node.send_text() ───────▶│
+  │                          │                            │
+  │                          │── poll loop (2s interval)  │
+  │                          │── node.poll_tasks() ──────▶│
+  │                          │◀── Task(Completed) ───────│
+  │◀── agent response ─────│                            │
+```
+
+The bridge runs as a stdio server (`rmcp` transport-io) — no HTTP server
+is involved. It is configured via CLI flags:
+
+- `--waku-url` — nwaku REST API endpoint (default `http://localhost:8645`)
+- `--timeout` — seconds to wait for agent responses (default `30`)


### PR DESCRIPTION
## Purpose

Add comprehensive test coverage for the MCP bridge and document three previously undocumented subsystems in the architecture docs.

## Approach

### MCP Bridge Tests (14 new tests, 22 total)

- Make `LogosA2ABridge` generic over `T: Transport` so tests can use `InMemoryTransport` instead of requiring a live nwaku node
- Add `from_node()` constructor for test use; production `new()` unchanged
- Test coverage:
  - `discover_agents` with mocked transport returning agents — verifies cache population and response formatting
  - `discover_agents` with no agents found — verifies empty message
  - `discover_agents` with multiple agents — verifies numbered list format
  - `discover_agents` cache replacement on rediscovery
  - `discover_agents` format includes version and public key
  - `send_to_agent` when agent not in cache — verifies INVALID_PARAMS error
  - `send_to_agent` error message suggests calling discover_agents
  - `SendToAgentInput` deserialization (valid, missing fields, extra fields)
  - `ServerInfo` instructions and tools capability
  - Multiple agents in cache bullet-point formatting

### Architecture Docs

Added three new sections to `docs/architecture.md`:
- **Message Retry with Exponential Backoff** — RetryConfig, delay formula, RetryLayer flow diagram
- **Waku Presence Broadcasts** — PresenceAnnouncement wire type, signature verification, PeerMap API, combined discovery via `discover_all()`
- **MCP Bridge Architecture** — stdio bridge diagram, MCP tool table, request flow sequence

## How to Test

```bash
cargo test -p logos-messaging-a2a-mcp
cargo clippy --workspace -- -D warnings
cargo test --workspace
```

All 22 MCP tests pass. Full workspace clippy and tests are clean.

## Dependencies

None — uses existing `InMemoryTransport` from the transport crate.

## Future Work

- Integration test for full `send_to_agent` → response round-trip via InMemoryTransport
- Timeout behavior test for `send_to_agent` poll loop

## Checklist

- [x] Tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [x] Formatted (`cargo fmt --all`)
- [x] No new dependencies added
- [x] Architecture docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)