### PR TITLE
refactor: migrate library crate logging from eprintln! to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2354,6 +2355,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -2384,6 +2386,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tracing",
  "uuid",
  "waku-bindings",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ anyhow = "1"
 async-trait = "0.1"
 sha2 = "0.10"
 bloomfilter = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies]
 logos-messaging-a2a-crypto = { path = "crates/logos-messaging-a2a-crypto" }

--- a/crates/logos-messaging-a2a-cli/Cargo.toml
+++ b/crates/logos-messaging-a2a-cli/Cargo.toml
@@ -19,3 +19,4 @@ clap = { workspace = true }
 k256 = { workspace = true }
 hex = { workspace = true }
 anyhow = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -4,6 +4,7 @@ use logos_messaging_a2a_core::Task;
 use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 use std::collections::HashSet;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -145,6 +146,11 @@ fn print_peer(agent_id: &str, info: &logos_messaging_a2a_node::presence::PeerInf
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
     let cli = Cli::parse();
     let transport = LogosMessagingTransport::new(&cli.waku);
 

--- a/crates/logos-messaging-a2a-node/Cargo.toml
+++ b/crates/logos-messaging-a2a-node/Cargo.toml
@@ -18,3 +18,4 @@ hex = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 fastrand = "2"
+tracing = { workspace = true }

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -388,10 +388,7 @@ impl<T: Transport> WakuA2ANode<T> {
             .publish(topics::PRESENCE, &payload)
             .await
             .context("Failed to publish presence announcement")?;
-        eprintln!(
-            "[node] Presence announced: {} (TTL={}s)",
-            self.card.name, ttl_secs
-        );
+        tracing::info!(name = %self.card.name, ttl_secs, "Presence announced");
         Ok(())
     }
 
@@ -411,20 +408,20 @@ impl<T: Transport> WakuA2ANode<T> {
             if let Ok(A2AEnvelope::Presence(ann)) = serde_json::from_slice::<A2AEnvelope>(&msg) {
                 if ann.agent_id != self.pubkey() {
                     if let Err(e) = ann.verify() {
-                        eprintln!(
-                            "[node] Presence rejected (invalid signature): {} ({}) — {}",
-                            ann.name,
-                            &ann.agent_id[..8.min(ann.agent_id.len())],
-                            e
+                        tracing::warn!(
+                            name = %ann.name,
+                            agent_id = %&ann.agent_id[..8.min(ann.agent_id.len())],
+                            error = %e,
+                            "Presence rejected (invalid signature)"
                         );
                         continue;
                     }
                     self.peer_map.update(&ann);
-                    eprintln!(
-                        "[node] Presence received: {} ({}) caps={:?}",
-                        ann.name,
-                        &ann.agent_id[..8.min(ann.agent_id.len())],
-                        ann.capabilities
+                    tracing::info!(
+                        name = %ann.name,
+                        agent_id = %&ann.agent_id[..8.min(ann.agent_id.len())],
+                        capabilities = ?ann.capabilities,
+                        "Presence received"
                     );
                     count += 1;
                 }
@@ -480,7 +477,7 @@ impl<T: Transport> WakuA2ANode<T> {
             .publish(topics::DISCOVERY, &payload)
             .await
             .context("Failed to announce AgentCard")?;
-        eprintln!("[node] Announced: {} ({})", self.card.name, self.pubkey());
+        tracing::info!(name = %self.card.name, pubkey = %self.pubkey(), "Announced");
         Ok(())
     }
 
@@ -605,9 +602,9 @@ impl<T: Transport> WakuA2ANode<T> {
         };
 
         if acked {
-            eprintln!("[node] Task {} sent and ACKed", task.id);
+            tracing::info!(task_id = %task.id, "Task sent and ACKed");
         } else {
-            eprintln!("[node] Task {} sent but no ACK received", task.id);
+            tracing::warn!(task_id = %task.id, "Task sent but no ACK received");
         }
         Ok(acked)
     }
@@ -758,12 +755,12 @@ impl<T: Transport> WakuA2ANode<T> {
                     match self.decrypt_task(identity, &sender_pubkey, &encrypted) {
                         Ok(task) => self.maybe_fetch_offloaded(task).await,
                         Err(e) => {
-                            eprintln!("[node] Failed to decrypt task: {}", e);
+                            tracing::error!(error = %e, "Failed to decrypt task");
                             Ok(None)
                         }
                     }
                 } else {
-                    eprintln!("[node] Received encrypted task but no identity configured");
+                    tracing::warn!("Received encrypted task but no identity configured");
                     Ok(None)
                 }
             }
@@ -784,7 +781,7 @@ impl<T: Transport> WakuA2ANode<T> {
                     .context("Failed to deserialize offloaded task")?;
                 return Ok(Some(original));
             }
-            eprintln!("[node] Task has payload_cid but no storage backend configured");
+            tracing::warn!(payload_cid = %cid, "Task has payload_cid but no storage backend configured");
         }
         Ok(Some(task))
     }
@@ -814,7 +811,7 @@ impl<T: Transport> WakuA2ANode<T> {
             .await
             .context("Failed to send response")?;
 
-        eprintln!("[node] Responded to task {}", task.id);
+        tracing::info!(task_id = %task.id, "Responded to task");
         Ok(())
     }
 
@@ -849,7 +846,7 @@ impl<T: Transport> WakuA2ANode<T> {
                 .await
                 .context("Failed to publish stream chunk")?;
         }
-        eprintln!("[node] Streamed {} chunk(s) for task {}", total, task.id);
+        tracing::info!(task_id = %task.id, chunks = total, "Streamed chunks for task");
         Ok(())
     }
 
@@ -946,9 +943,10 @@ impl<T: Transport> WakuA2ANode<T> {
         let tx_hash = match &task.payment_tx {
             Some(tx) if !tx.is_empty() => tx.clone(),
             _ => {
-                eprintln!(
-                    "[node] Rejecting task {} — no payment tx hash provided (need {} tokens)",
-                    task.id, pay_cfg.required_amount
+                tracing::warn!(
+                    task_id = %task.id,
+                    required_amount = pay_cfg.required_amount,
+                    "Rejecting task — no payment tx hash provided"
                 );
                 return false;
             }
@@ -958,9 +956,10 @@ impl<T: Transport> WakuA2ANode<T> {
         {
             let seen = self.seen_tx_hashes.lock().unwrap();
             if seen.contains(&tx_hash) {
-                eprintln!(
-                    "[node] Rejecting task {} — replayed payment tx {}",
-                    task.id, tx_hash
+                tracing::warn!(
+                    task_id = %task.id,
+                    tx_hash = %tx_hash,
+                    "Rejecting task — replayed payment tx"
                 );
                 return false;
             }
@@ -974,9 +973,11 @@ impl<T: Transport> WakuA2ANode<T> {
                     true
                 }
                 _ => {
-                    eprintln!(
-                        "[node] Rejecting task {} — insufficient payment (need {}, got {:?})",
-                        task.id, pay_cfg.required_amount, task.payment_amount
+                    tracing::warn!(
+                        task_id = %task.id,
+                        required = pay_cfg.required_amount,
+                        got = ?task.payment_amount,
+                        "Rejecting task — insufficient payment"
                     );
                     false
                 }
@@ -986,18 +987,22 @@ impl<T: Transport> WakuA2ANode<T> {
             match pay_cfg.backend.verify_transfer(&tx_hash).await {
                 Ok(details) => {
                     if details.amount < pay_cfg.required_amount {
-                        eprintln!(
-                            "[node] Rejecting task {} — on-chain amount {} < required {}",
-                            task.id, details.amount, pay_cfg.required_amount
+                        tracing::warn!(
+                            task_id = %task.id,
+                            on_chain_amount = details.amount,
+                            required = pay_cfg.required_amount,
+                            "Rejecting task — on-chain amount below required"
                         );
                         return false;
                     }
                     if !pay_cfg.receiving_account.is_empty()
                         && details.to.to_lowercase() != pay_cfg.receiving_account.to_lowercase()
                     {
-                        eprintln!(
-                            "[node] Rejecting task {} — payment sent to {} but expected {}",
-                            task.id, details.to, pay_cfg.receiving_account
+                        tracing::warn!(
+                            task_id = %task.id,
+                            actual_recipient = %details.to,
+                            expected_recipient = %pay_cfg.receiving_account,
+                            "Rejecting task — payment sent to wrong address"
                         );
                         return false;
                     }
@@ -1006,9 +1011,10 @@ impl<T: Transport> WakuA2ANode<T> {
                     true
                 }
                 Err(e) => {
-                    eprintln!(
-                        "[node] Rejecting task {} — on-chain verification failed: {}",
-                        task.id, e
+                    tracing::error!(
+                        task_id = %task.id,
+                        error = %e,
+                        "Rejecting task — on-chain verification failed"
                     );
                     false
                 }

--- a/crates/logos-messaging-a2a-node/src/retry.rs
+++ b/crates/logos-messaging-a2a-node/src/retry.rs
@@ -46,11 +46,11 @@ impl<'a, T: Transport> RetryLayer<'a, T> {
                     // Don't sleep after the final attempt
                     if attempt + 1 < self.config.max_attempts {
                         let delay = self.compute_delay(attempt);
-                        eprintln!(
-                            "[retry] Attempt {}/{} failed, retrying in {}ms",
-                            attempt + 1,
-                            self.config.max_attempts,
-                            delay.as_millis(),
+                        tracing::debug!(
+                            attempt = attempt + 1,
+                            max_attempts = self.config.max_attempts,
+                            delay_ms = delay.as_millis() as u64,
+                            "Send attempt failed, retrying"
                         );
                         tokio::time::sleep(delay).await;
                     }

--- a/crates/logos-messaging-a2a-transport/Cargo.toml
+++ b/crates/logos-messaging-a2a-transport/Cargo.toml
@@ -21,6 +21,7 @@ hex = { workspace = true }
 sha2 = { workspace = true }
 bloomfilter = { workspace = true }
 base64 = { version = "0.22", optional = true }
+tracing = { workspace = true }
 waku-bindings = { git = "https://github.com/jimmy-claw/logos-delivery-rust-bindings", branch = "jimmy/rln-optional", default-features = false, optional = true }
 
 [build-dependencies]

--- a/crates/logos-messaging-a2a-transport/src/sds/bloom.rs
+++ b/crates/logos-messaging-a2a-transport/src/sds/bloom.rs
@@ -51,9 +51,9 @@ impl SdsBloomFilter {
             *count = 0;
             // Note: this means we lose dedup state for old messages.
             // In practice, old messages should already be in local history.
-            eprintln!(
-                "[sds::bloom] filter reset after reaching capacity {}",
-                self.capacity
+            tracing::debug!(
+                capacity = self.capacity,
+                "Bloom filter reset after reaching capacity"
             );
         }
     }

--- a/crates/logos-messaging-a2a-transport/src/sds/channel.rs
+++ b/crates/logos-messaging-a2a-transport/src/sds/channel.rs
@@ -262,9 +262,11 @@ impl<T: Transport> MessageChannel<T> {
 
         for attempt in 0..=self.config.max_retries {
             if attempt > 0 {
-                eprintln!(
-                    "[sds] retransmit attempt {}/{} for {}",
-                    attempt, self.config.max_retries, message_id
+                tracing::debug!(
+                    attempt,
+                    max_retries = self.config.max_retries,
+                    message_id = %message_id,
+                    "SDS retransmit attempt"
                 );
             }
 
@@ -291,9 +293,10 @@ impl<T: Transport> MessageChannel<T> {
         let _ = self.transport.unsubscribe(&ack_topic).await;
         self.bloom.set(&message_id);
         self.record_in_history(&message_id, ts);
-        eprintln!(
-            "[sds] no ACK after {} retries for {}",
-            self.config.max_retries, message_id
+        tracing::warn!(
+            retries = self.config.max_retries,
+            message_id = %message_id,
+            "No ACK after retries"
         );
         Ok((msg, false))
     }


### PR DESCRIPTION
## Description
Migrate all `eprintln!` logging in library crates (`logos-messaging-a2a-node`, `logos-messaging-a2a-transport`) to the `tracing` crate with structured fields and appropriate log levels. CLI user-facing `println!` output is left untouched.

## Changes
- **Root Cargo.toml**: Add `tracing` and `tracing-subscriber` as workspace dependencies
- **logos-messaging-a2a-node**: Replace 17 `eprintln!` calls with `tracing::{info,warn,error,debug}!` using structured fields (e.g. `task_id`, `name`, `pubkey`)
- **logos-messaging-a2a-transport**: Replace 3 `eprintln!` calls in SDS channel and bloom filter with `tracing::{warn,debug}!`
- **logos-messaging-a2a-cli**: Initialize `tracing-subscriber` with `EnvFilter` (respects `RUST_LOG` env var), writes to stderr

### Log level mapping
| Level | Usage |
|-------|-------|
| `error!` | Decryption failures, on-chain verification failures |
| `warn!` | No ACK, no storage backend, payment rejections, invalid signatures |
| `info!` | Task sent/responded, presence announced/received, agent announced |
| `debug!` | Retry attempts, SDS retransmits, bloom filter resets |

## Checklist
- [x] Builds cleanly (`cargo clippy --workspace -- -D warnings`)
- [x] Tests pass (`cargo test --workspace`)
- [ ] README updated if new features, CLI commands, or behaviour changed
- [x] New public methods have doc comments
- [x] Branch is off `main` (not another feature branch)

> Users can now control log verbosity with `RUST_LOG=info logos-messaging-a2a agent run --name echo`