### PR TITLE
ci: add code coverage reporting with tarpaulin + codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,25 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Generate coverage
+        run: cargo tarpaulin --workspace --out xml
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: cobertura.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   # Optional: end-to-end tests with nwaku Docker (manual trigger only)
   test-e2e:
     name: E2E Tests (nwaku)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LMAO — Logos Module for Agent Orchestration
 
+[![codecov](https://codecov.io/gh/jimmy-claw/lmao/branch/master/graph/badge.svg)](https://codecov.io/gh/jimmy-claw/lmao)
+
 > **LMAO** = **L**ogos **M**odule for **A**gent **O**rchestration
 >
 > Yes, the acronym is intentional. Building decentralized AI agent infrastructure is serious work — but it doesn't have to be humourless. LMAO implements Google's [A2A protocol](https://github.com/google/A2A) over [Logos Messaging](https://logos.co/messaging/) decentralized transport, bringing censorship-resistant, serverless agent-to-agent communication to the Logos stack.


### PR DESCRIPTION
## 🎯 Purpose
Add automated code coverage tracking via cargo-tarpaulin and Codecov integration.

## ⚙️ Approach
- New CI job runs cargo-tarpaulin on every push/PR
- Coverage results uploaded to Codecov
- README badge shows current coverage percentage

## 🧪 How to Test
- CI should show new coverage job
- After merge, codecov.io/gh/jimmy-claw/lmao will show coverage data

## 🔗 Dependencies
- Codecov token needs to be set as repo secret (CODECOV_TOKEN) for private repos, or works automatically for public repos

## 🔜 Future Work
- Set coverage thresholds
- Add per-crate coverage breakdown

## 📋 Checklist
- [x] CI passes
- [x] README updated with badge
- [x] No code changes, CI-only