### PR TITLE
fix(mcp): fix integration test timeouts in send_to_agent flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,6 +2344,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -2432,6 +2433,7 @@ dependencies = [
  "tracing",
  "uuid",
  "waku-bindings",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/logos-messaging-a2a-mcp/Cargo.toml
+++ b/crates/logos-messaging-a2a-mcp/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "MCP server bridge — expose Logos Messaging A2A agents as MCP tools"
 
+[lib]
+name = "logos_messaging_a2a_mcp"
+path = "src/lib.rs"
+
 [[bin]]
 name = "logos-messaging-a2a-mcp"
 path = "src/main.rs"

--- a/crates/logos-messaging-a2a-mcp/src/lib.rs
+++ b/crates/logos-messaging-a2a-mcp/src/lib.rs
@@ -1,0 +1,345 @@
+//! MCP Bridge Server for Logos Messaging A2A
+//!
+//! Exposes discovered Waku A2A agents as MCP tools.
+//! Each agent on the network becomes a callable tool in Claude Desktop, Cursor, etc.
+//!
+//! Architecture:
+//!   MCP Host (Claude) → stdio → logos-messaging-a2a-mcp → Waku → Agent Fleet
+
+use std::sync::Arc;
+
+use rmcp::{
+    handler::server::{tool::ToolRouter, wrapper::Parameters},
+    model::*,
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
+};
+use tokio::sync::RwLock;
+
+use logos_messaging_a2a_core::{Part, TaskState};
+use logos_messaging_a2a_node::presence::PeerInfo;
+use logos_messaging_a2a_node::WakuA2ANode;
+use logos_messaging_a2a_transport::Transport;
+use serde::Deserialize;
+
+pub use logos_messaging_a2a_core::AgentCard;
+
+#[derive(Deserialize, rmcp::schemars::JsonSchema)]
+pub struct SendToAgentInput {
+    /// Name of the target agent (from discover_agents)
+    pub agent_name: String,
+    /// The message/task to send to the agent
+    pub message: String,
+}
+
+#[derive(Deserialize, rmcp::schemars::JsonSchema)]
+pub struct GetAgentStatusInput {
+    /// Agent ID (public key hex) to check presence status for
+    pub agent_id: String,
+}
+
+/// Cached snapshot of discovered agents.
+pub type AgentRegistry = Arc<RwLock<Vec<AgentCard>>>;
+
+/// The MCP server that bridges to A2A over Waku.
+pub struct LogosA2ABridge<T: Transport> {
+    pub node: Arc<RwLock<WakuA2ANode<T>>>,
+    pub agents: AgentRegistry,
+    pub timeout_secs: u64,
+    pub tool_router: ToolRouter<Self>,
+}
+
+// Manual Clone: T is behind Arc so we don't need T: Clone.
+impl<T: Transport> Clone for LogosA2ABridge<T> {
+    fn clone(&self) -> Self {
+        Self {
+            node: self.node.clone(),
+            agents: self.agents.clone(),
+            timeout_secs: self.timeout_secs,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl<T: Transport> LogosA2ABridge<T> {
+    /// Create a bridge wrapping an existing node.
+    pub fn from_node(node: WakuA2ANode<T>, timeout_secs: u64) -> Self {
+        Self {
+            node: Arc::new(RwLock::new(node)),
+            agents: Arc::new(RwLock::new(Vec::new())),
+            timeout_secs,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Discover agents via legacy broadcast discovery (subscribes to the discovery topic and
+    /// drains historical announcements). For real-time presence-based discovery, use
+    /// `discover_agents_presence` instead.
+    #[tool(
+        description = "Discover agents via legacy broadcast discovery (drains the discovery topic). Returns agent names, descriptions, and capabilities. For real-time presence-aware discovery with online status, prefer discover_agents_presence instead."
+    )]
+    pub async fn discover_agents(&self) -> Result<CallToolResult, McpError> {
+        let node = self.node.read().await;
+        let cards = node.discover().await.map_err(|e| McpError {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: format!("Discovery failed: {e}").into(),
+            data: None,
+        })?;
+
+        let mut agents = self.agents.write().await;
+        *agents = cards.clone();
+
+        if cards.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No agents found on the network. Make sure nwaku is running and agents are announced.",
+            )]));
+        }
+
+        let summary: Vec<String> = cards
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                format!(
+                    "{}. **{}** (v{}) — {}\n   Capabilities: [{}]\n   Public key: {}...",
+                    i + 1,
+                    c.name,
+                    c.version,
+                    c.description,
+                    c.capabilities.join(", "),
+                    &c.public_key[..16]
+                )
+            })
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Found {} agent(s):\n\n{}",
+            cards.len(),
+            summary.join("\n\n")
+        ))]))
+    }
+
+    /// Send a task/message to a specific agent by name and wait for a response.
+    #[tool(
+        description = "Send a message to a Logos agent by name. The agent will process it and return a response. Call discover_agents first to see available agents."
+    )]
+    pub async fn send_to_agent(
+        &self,
+        Parameters(SendToAgentInput {
+            agent_name,
+            message,
+        }): Parameters<SendToAgentInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let agents = self.agents.read().await;
+        let card = agents.iter().find(|c| c.name == agent_name).cloned();
+        drop(agents);
+
+        let card = card.ok_or_else(|| McpError {
+            code: ErrorCode::INVALID_PARAMS,
+            message: format!(
+                "Agent '{agent_name}' not found. Call discover_agents first to refresh the list."
+            )
+            .into(),
+            data: None,
+        })?;
+
+        let node = self.node.read().await;
+        let task = node
+            .send_text(&card.public_key, &message)
+            .await
+            .map_err(|e| McpError {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: format!("Failed to send task: {e}").into(),
+                data: None,
+            })?;
+
+        let deadline =
+            tokio::time::Instant::now() + tokio::time::Duration::from_secs(self.timeout_secs);
+        let task_id = task.id.clone();
+
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Timeout waiting for response from '{agent_name}' (task {}). The agent may still be processing.",
+                    task_id
+                ))]));
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+            let tasks = node.poll_tasks().await.map_err(|e| McpError {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: format!("Poll failed: {e}").into(),
+                data: None,
+            })?;
+
+            if let Some(response) = tasks.iter().find(|t| t.id == task_id) {
+                match response.state {
+                    TaskState::Completed => {
+                        let text = response
+                            .result
+                            .as_ref()
+                            .map(|m| {
+                                m.parts
+                                    .iter()
+                                    .map(|p| match p {
+                                        Part::Text { text } => text.as_str(),
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            })
+                            .unwrap_or_else(|| "(no result body)".into());
+
+                        return Ok(CallToolResult::success(vec![Content::text(format!(
+                            "Response from '{agent_name}':\n\n{text}"
+                        ))]));
+                    }
+                    TaskState::Failed => {
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "Agent '{agent_name}' reported task failed (task {})",
+                            task_id
+                        ))]));
+                    }
+                    _ => continue,
+                }
+            }
+        }
+    }
+
+    /// List the currently cached agents (no network call).
+    #[tool(
+        description = "List agents from the last discovery (cached). Use discover_agents to refresh."
+    )]
+    pub async fn list_cached_agents(&self) -> Result<CallToolResult, McpError> {
+        let agents = self.agents.read().await;
+        if agents.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No cached agents. Call discover_agents first.",
+            )]));
+        }
+
+        let names: Vec<String> = agents
+            .iter()
+            .map(|c| format!("• {} — {}", c.name, c.description))
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(
+            names.join("\n"),
+        )]))
+    }
+
+    /// Discover agents via real-time presence broadcasts.
+    ///
+    /// Polls the presence topic for signed announcements and returns all
+    /// agents that are currently online (within their TTL window).
+    #[tool(
+        description = "Discover agents via real-time presence broadcasts. Polls the Waku presence topic for signed announcements and returns agents that are currently online (within their TTL). More reliable than legacy discover_agents for checking who is actually live right now."
+    )]
+    pub async fn discover_agents_presence(&self) -> Result<CallToolResult, McpError> {
+        let node = self.node.read().await;
+        node.poll_presence().await.map_err(|e| McpError {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: format!("Presence poll failed: {e}").into(),
+            data: None,
+        })?;
+
+        let live_peers = node.peers().all_live();
+
+        if live_peers.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No agents currently online via presence. Agents may not have announced presence yet, or their TTL may have expired.",
+            )]));
+        }
+
+        let summary: Vec<String> = live_peers
+            .iter()
+            .enumerate()
+            .map(|(i, (agent_id, info))| format_peer_entry(i + 1, agent_id, info))
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Found {} live agent(s) via presence:\n\n{}",
+            live_peers.len(),
+            summary.join("\n\n")
+        ))]))
+    }
+
+    /// Check if a specific agent is currently online via presence.
+    #[tool(
+        description = "Check if a specific agent is currently online by its agent ID (public key hex). Polls for fresh presence data and returns the agent's status, capabilities, and TTL info."
+    )]
+    pub async fn get_agent_status(
+        &self,
+        Parameters(GetAgentStatusInput { agent_id }): Parameters<GetAgentStatusInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let node = self.node.read().await;
+        node.poll_presence().await.map_err(|e| McpError {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: format!("Presence poll failed: {e}").into(),
+            data: None,
+        })?;
+
+        match node.peers().get(&agent_id) {
+            Some(info) => {
+                let elapsed = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs()
+                    .saturating_sub(info.last_seen);
+
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Agent **{}** is ONLINE\n\
+                     • Agent ID: {}...\n\
+                     • Capabilities: [{}]\n\
+                     • Waku topic: {}\n\
+                     • TTL: {}s (last seen {}s ago)",
+                    info.name,
+                    &agent_id[..16.min(agent_id.len())],
+                    info.capabilities.join(", "),
+                    info.waku_topic,
+                    info.ttl_secs,
+                    elapsed,
+                ))]))
+            }
+            None => Ok(CallToolResult::success(vec![Content::text(format!(
+                "Agent '{agent_id}' is OFFLINE or unknown. The agent may not have announced presence, or its TTL has expired."
+            ))])),
+        }
+    }
+}
+
+/// Format a single peer entry for display.
+pub fn format_peer_entry(index: usize, agent_id: &str, info: &PeerInfo) -> String {
+    format!(
+        "{}. **{}** — [{}]\n   Agent ID: {}...\n   Topic: {}\n   TTL: {}s",
+        index,
+        info.name,
+        info.capabilities.join(", "),
+        &agent_id[..16.min(agent_id.len())],
+        info.waku_topic,
+        info.ttl_secs,
+    )
+}
+
+#[tool_handler]
+impl<T: Transport> ServerHandler for LogosA2ABridge<T> {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(
+                "Logos Messaging A2A Bridge — discover and communicate with agents on the \
+                 Logos/Waku decentralized network. Call discover_agents first, then send_to_agent \
+                 to interact with specific agents."
+                    .into(),
+            ),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Extract text from the first content element of a [`CallToolResult`].
+pub fn result_text(result: &CallToolResult) -> &str {
+    match &result.content[0].raw {
+        RawContent::Text(t) => t.text.as_str(),
+        _ => panic!("expected text content"),
+    }
+}

--- a/crates/logos-messaging-a2a-mcp/src/main.rs
+++ b/crates/logos-messaging-a2a-mcp/src/main.rs
@@ -12,40 +12,14 @@
 //! In Claude Desktop's config:
 //!   { "mcpServers": { "logos-agents": { "command": "logos-messaging-a2a-mcp", "args": ["--waku-url", "http://..."] } } }
 
-use std::sync::Arc;
-
 use anyhow::Result;
 use clap::Parser;
-use rmcp::{
-    handler::server::{tool::ToolRouter, wrapper::Parameters},
-    model::*,
-    tool, tool_handler, tool_router,
-    transport::stdio,
-    ErrorData as McpError, ServerHandler, ServiceExt,
-};
-use tokio::sync::RwLock;
+use rmcp::{transport::stdio, ServiceExt};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use logos_messaging_a2a_core::{AgentCard, Part, TaskState};
-use logos_messaging_a2a_node::presence::PeerInfo;
+use logos_messaging_a2a_mcp::LogosA2ABridge;
 use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
-use logos_messaging_a2a_transport::Transport;
-use serde::Deserialize;
-
-#[derive(Deserialize, rmcp::schemars::JsonSchema)]
-struct SendToAgentInput {
-    /// Name of the target agent (from discover_agents)
-    agent_name: String,
-    /// The message/task to send to the agent
-    message: String,
-}
-
-#[derive(Deserialize, rmcp::schemars::JsonSchema)]
-struct GetAgentStatusInput {
-    /// Agent ID (public key hex) to check presence status for
-    agent_id: String,
-}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -60,318 +34,6 @@ struct Cli {
     /// How long (seconds) to wait for agent responses
     #[arg(long, default_value_t = 30)]
     timeout: u64,
-}
-
-/// Cached snapshot of discovered agents.
-type AgentRegistry = Arc<RwLock<Vec<AgentCard>>>;
-
-/// The MCP server that bridges to A2A over Waku.
-struct LogosA2ABridge<T: Transport> {
-    node: Arc<RwLock<WakuA2ANode<T>>>,
-    agents: AgentRegistry,
-    timeout_secs: u64,
-    tool_router: ToolRouter<Self>,
-}
-
-// Manual Clone: T is behind Arc so we don't need T: Clone.
-impl<T: Transport> Clone for LogosA2ABridge<T> {
-    fn clone(&self) -> Self {
-        Self {
-            node: self.node.clone(),
-            agents: self.agents.clone(),
-            timeout_secs: self.timeout_secs,
-            tool_router: Self::tool_router(),
-        }
-    }
-}
-
-#[tool_router]
-impl<T: Transport> LogosA2ABridge<T> {
-    /// Create a bridge wrapping an existing node.
-    fn from_node(node: WakuA2ANode<T>, timeout_secs: u64) -> Self {
-        Self {
-            node: Arc::new(RwLock::new(node)),
-            agents: Arc::new(RwLock::new(Vec::new())),
-            timeout_secs,
-            tool_router: Self::tool_router(),
-        }
-    }
-
-    /// Discover agents via legacy broadcast discovery (subscribes to the discovery topic and
-    /// drains historical announcements). For real-time presence-based discovery, use
-    /// `discover_agents_presence` instead.
-    #[tool(
-        description = "Discover agents via legacy broadcast discovery (drains the discovery topic). Returns agent names, descriptions, and capabilities. For real-time presence-aware discovery with online status, prefer discover_agents_presence instead."
-    )]
-    async fn discover_agents(&self) -> Result<CallToolResult, McpError> {
-        let node = self.node.read().await;
-        let cards = node.discover().await.map_err(|e| McpError {
-            code: ErrorCode::INTERNAL_ERROR,
-            message: format!("Discovery failed: {e}").into(),
-            data: None,
-        })?;
-
-        let mut agents = self.agents.write().await;
-        *agents = cards.clone();
-
-        if cards.is_empty() {
-            return Ok(CallToolResult::success(vec![Content::text(
-                "No agents found on the network. Make sure nwaku is running and agents are announced.",
-            )]));
-        }
-
-        let summary: Vec<String> = cards
-            .iter()
-            .enumerate()
-            .map(|(i, c)| {
-                format!(
-                    "{}. **{}** (v{}) — {}\n   Capabilities: [{}]\n   Public key: {}...",
-                    i + 1,
-                    c.name,
-                    c.version,
-                    c.description,
-                    c.capabilities.join(", "),
-                    &c.public_key[..16]
-                )
-            })
-            .collect();
-
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "Found {} agent(s):\n\n{}",
-            cards.len(),
-            summary.join("\n\n")
-        ))]))
-    }
-
-    /// Send a task/message to a specific agent by name and wait for a response.
-    #[tool(
-        description = "Send a message to a Logos agent by name. The agent will process it and return a response. Call discover_agents first to see available agents."
-    )]
-    async fn send_to_agent(
-        &self,
-        Parameters(SendToAgentInput {
-            agent_name,
-            message,
-        }): Parameters<SendToAgentInput>,
-    ) -> Result<CallToolResult, McpError> {
-        let agents = self.agents.read().await;
-        let card = agents.iter().find(|c| c.name == agent_name).cloned();
-        drop(agents);
-
-        let card = card.ok_or_else(|| McpError {
-            code: ErrorCode::INVALID_PARAMS,
-            message: format!(
-                "Agent '{agent_name}' not found. Call discover_agents first to refresh the list."
-            )
-            .into(),
-            data: None,
-        })?;
-
-        let node = self.node.read().await;
-        let task = node
-            .send_text(&card.public_key, &message)
-            .await
-            .map_err(|e| McpError {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: format!("Failed to send task: {e}").into(),
-                data: None,
-            })?;
-
-        let deadline =
-            tokio::time::Instant::now() + tokio::time::Duration::from_secs(self.timeout_secs);
-        let task_id = task.id.clone();
-
-        loop {
-            if tokio::time::Instant::now() > deadline {
-                return Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Timeout waiting for response from '{agent_name}' (task {}). The agent may still be processing.",
-                    task_id
-                ))]));
-            }
-
-            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-            let tasks = node.poll_tasks().await.map_err(|e| McpError {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: format!("Poll failed: {e}").into(),
-                data: None,
-            })?;
-
-            if let Some(response) = tasks.iter().find(|t| t.id == task_id) {
-                match response.state {
-                    TaskState::Completed => {
-                        let text = response
-                            .result
-                            .as_ref()
-                            .map(|m| {
-                                m.parts
-                                    .iter()
-                                    .map(|p| match p {
-                                        Part::Text { text } => text.as_str(),
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join("\n")
-                            })
-                            .unwrap_or_else(|| "(no result body)".into());
-
-                        return Ok(CallToolResult::success(vec![Content::text(format!(
-                            "Response from '{agent_name}':\n\n{text}"
-                        ))]));
-                    }
-                    TaskState::Failed => {
-                        return Ok(CallToolResult::error(vec![Content::text(format!(
-                            "Agent '{agent_name}' reported task failed (task {})",
-                            task_id
-                        ))]));
-                    }
-                    _ => continue,
-                }
-            }
-        }
-    }
-
-    /// List the currently cached agents (no network call).
-    #[tool(
-        description = "List agents from the last discovery (cached). Use discover_agents to refresh."
-    )]
-    async fn list_cached_agents(&self) -> Result<CallToolResult, McpError> {
-        let agents = self.agents.read().await;
-        if agents.is_empty() {
-            return Ok(CallToolResult::success(vec![Content::text(
-                "No cached agents. Call discover_agents first.",
-            )]));
-        }
-
-        let names: Vec<String> = agents
-            .iter()
-            .map(|c| format!("• {} — {}", c.name, c.description))
-            .collect();
-
-        Ok(CallToolResult::success(vec![Content::text(
-            names.join("\n"),
-        )]))
-    }
-
-    /// Discover agents via real-time presence broadcasts.
-    ///
-    /// Polls the presence topic for signed announcements and returns all
-    /// agents that are currently online (within their TTL window).
-    #[tool(
-        description = "Discover agents via real-time presence broadcasts. Polls the Waku presence topic for signed announcements and returns agents that are currently online (within their TTL). More reliable than legacy discover_agents for checking who is actually live right now."
-    )]
-    async fn discover_agents_presence(&self) -> Result<CallToolResult, McpError> {
-        let node = self.node.read().await;
-        node.poll_presence().await.map_err(|e| McpError {
-            code: ErrorCode::INTERNAL_ERROR,
-            message: format!("Presence poll failed: {e}").into(),
-            data: None,
-        })?;
-
-        let live_peers = node.peers().all_live();
-
-        if live_peers.is_empty() {
-            return Ok(CallToolResult::success(vec![Content::text(
-                "No agents currently online via presence. Agents may not have announced presence yet, or their TTL may have expired.",
-            )]));
-        }
-
-        let summary: Vec<String> = live_peers
-            .iter()
-            .enumerate()
-            .map(|(i, (agent_id, info))| format_peer_entry(i + 1, agent_id, info))
-            .collect();
-
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "Found {} live agent(s) via presence:\n\n{}",
-            live_peers.len(),
-            summary.join("\n\n")
-        ))]))
-    }
-
-    /// Check if a specific agent is currently online via presence.
-    #[tool(
-        description = "Check if a specific agent is currently online by its agent ID (public key hex). Polls for fresh presence data and returns the agent's status, capabilities, and TTL info."
-    )]
-    async fn get_agent_status(
-        &self,
-        Parameters(GetAgentStatusInput { agent_id }): Parameters<GetAgentStatusInput>,
-    ) -> Result<CallToolResult, McpError> {
-        let node = self.node.read().await;
-        node.poll_presence().await.map_err(|e| McpError {
-            code: ErrorCode::INTERNAL_ERROR,
-            message: format!("Presence poll failed: {e}").into(),
-            data: None,
-        })?;
-
-        match node.peers().get(&agent_id) {
-            Some(info) => {
-                let elapsed = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs()
-                    .saturating_sub(info.last_seen);
-
-                Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Agent **{}** is ONLINE\n\
-                     • Agent ID: {}...\n\
-                     • Capabilities: [{}]\n\
-                     • Waku topic: {}\n\
-                     • TTL: {}s (last seen {}s ago)",
-                    info.name,
-                    &agent_id[..16.min(agent_id.len())],
-                    info.capabilities.join(", "),
-                    info.waku_topic,
-                    info.ttl_secs,
-                    elapsed,
-                ))]))
-            }
-            None => Ok(CallToolResult::success(vec![Content::text(format!(
-                "Agent '{agent_id}' is OFFLINE or unknown. The agent may not have announced presence, or its TTL has expired."
-            ))])),
-        }
-    }
-}
-
-/// Format a single peer entry for display.
-fn format_peer_entry(index: usize, agent_id: &str, info: &PeerInfo) -> String {
-    format!(
-        "{}. **{}** — [{}]\n   Agent ID: {}...\n   Topic: {}\n   TTL: {}s",
-        index,
-        info.name,
-        info.capabilities.join(", "),
-        &agent_id[..16.min(agent_id.len())],
-        info.waku_topic,
-        info.ttl_secs,
-    )
-}
-
-impl LogosA2ABridge<LogosMessagingTransport> {
-    fn new(waku_url: &str, timeout_secs: u64) -> Self {
-        let transport = LogosMessagingTransport::new(waku_url);
-        let node = WakuA2ANode::new(
-            "mcp-bridge",
-            "MCP bridge — proxies tool calls to Logos A2A agents",
-            vec!["mcp-bridge".into()],
-            transport,
-        );
-        Self::from_node(node, timeout_secs)
-    }
-}
-
-#[tool_handler]
-impl<T: Transport> ServerHandler for LogosA2ABridge<T> {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
-                "Logos Messaging A2A Bridge — discover and communicate with agents on the \
-                 Logos/Waku decentralized network. Call discover_agents first, then send_to_agent \
-                 to interact with specific agents."
-                    .into(),
-            ),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
-    }
 }
 
 #[tokio::main]
@@ -389,7 +51,14 @@ async fn main() -> Result<()> {
         cli.timeout
     );
 
-    let bridge = LogosA2ABridge::new(&cli.waku_url, cli.timeout);
+    let transport = LogosMessagingTransport::new(&cli.waku_url);
+    let node = WakuA2ANode::new(
+        "mcp-bridge",
+        "MCP bridge — proxies tool calls to Logos A2A agents",
+        vec!["mcp-bridge".into()],
+        transport,
+    );
+    let bridge = LogosA2ABridge::from_node(node, cli.timeout);
 
     {
         let node: tokio::sync::RwLockReadGuard<WakuA2ANode<LogosMessagingTransport>> =
@@ -409,15 +78,12 @@ async fn main() -> Result<()> {
 mod tests {
     use super::*;
     use clap::error::ErrorKind;
+    use logos_messaging_a2a_mcp::{
+        format_peer_entry, result_text, AgentCard, GetAgentStatusInput, SendToAgentInput,
+    };
     use logos_messaging_a2a_transport::memory::InMemoryTransport;
-
-    /// Extract text from the first content element of a CallToolResult.
-    fn result_text(result: &CallToolResult) -> &str {
-        match &result.content[0].raw {
-            RawContent::Text(t) => t.text.as_str(),
-            _ => panic!("expected text content"),
-        }
-    }
+    use logos_messaging_a2a_transport::Transport;
+    use rmcp::{handler::server::wrapper::Parameters, model::*, ServerHandler};
 
     /// Create a bridge backed by InMemoryTransport (no nwaku required).
     fn make_test_bridge(transport: InMemoryTransport) -> LogosA2ABridge<InMemoryTransport> {

--- a/crates/logos-messaging-a2a-mcp/tests/integration.rs
+++ b/crates/logos-messaging-a2a-mcp/tests/integration.rs
@@ -1,0 +1,915 @@
+//! Integration tests for the MCP bridge crate.
+//!
+//! These tests exercise the full bridge lifecycle — discovery, presence, task
+//! send/receive, tool listing, and error handling — using [`InMemoryTransport`]
+//! so no external nwaku node is required.
+
+use logos_messaging_a2a_core::{topics, A2AEnvelope, PresenceAnnouncement, TaskState};
+use logos_messaging_a2a_mcp::{
+    format_peer_entry, result_text, GetAgentStatusInput, LogosA2ABridge, SendToAgentInput,
+};
+use logos_messaging_a2a_node::presence::PeerInfo;
+use logos_messaging_a2a_node::WakuA2ANode;
+use logos_messaging_a2a_transport::memory::InMemoryTransport;
+use logos_messaging_a2a_transport::sds::ChannelConfig;
+use logos_messaging_a2a_transport::Transport;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::*;
+use rmcp::ServerHandler;
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Create a [`LogosA2ABridge`] backed by the given in-memory transport.
+fn make_bridge(transport: InMemoryTransport) -> LogosA2ABridge<InMemoryTransport> {
+    let node = WakuA2ANode::new(
+        "mcp-bridge",
+        "MCP bridge for integration tests",
+        vec!["mcp-bridge".into()],
+        transport,
+    );
+    LogosA2ABridge::from_node(node, 30)
+}
+
+/// Create a bridge with fire-and-forget SDS config and a custom timeout.
+/// This avoids blocking on ACK waits in tests.
+fn make_fast_bridge(
+    transport: InMemoryTransport,
+    timeout_secs: u64,
+) -> LogosA2ABridge<InMemoryTransport> {
+    let node = WakuA2ANode::with_config(
+        "mcp-bridge",
+        "MCP bridge for integration tests",
+        vec!["mcp-bridge".into()],
+        transport,
+        ChannelConfig::fire_and_forget(),
+    );
+    LogosA2ABridge::from_node(node, timeout_secs)
+}
+
+/// Create a WakuA2ANode with fire-and-forget SDS config for fast tests.
+fn make_fast_agent(
+    name: &str,
+    desc: &str,
+    caps: Vec<String>,
+    transport: InMemoryTransport,
+) -> WakuA2ANode<InMemoryTransport> {
+    WakuA2ANode::with_config(
+        name,
+        desc,
+        caps,
+        transport,
+        ChannelConfig::fire_and_forget(),
+    )
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  1. MCP Tool Listing
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn tool_list_returns_all_five_tools() {
+    let bridge = make_bridge(InMemoryTransport::new());
+    let tools = bridge.tool_router.list_all();
+
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(
+        names.contains(&"discover_agents"),
+        "missing discover_agents"
+    );
+    assert!(names.contains(&"send_to_agent"), "missing send_to_agent");
+    assert!(
+        names.contains(&"list_cached_agents"),
+        "missing list_cached_agents"
+    );
+    assert!(
+        names.contains(&"discover_agents_presence"),
+        "missing discover_agents_presence"
+    );
+    assert!(
+        names.contains(&"get_agent_status"),
+        "missing get_agent_status"
+    );
+    assert_eq!(tools.len(), 5, "unexpected number of tools");
+}
+
+#[tokio::test]
+async fn tool_list_every_tool_has_description() {
+    let bridge = make_bridge(InMemoryTransport::new());
+    let tools = bridge.tool_router.list_all();
+
+    for tool in &tools {
+        assert!(
+            tool.description.as_ref().map_or(false, |d| !d.is_empty()),
+            "tool '{}' missing description",
+            tool.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn server_info_exposes_tools_capability() {
+    let bridge = make_bridge(InMemoryTransport::new());
+    let info = bridge.get_info();
+
+    assert!(info.capabilities.tools.is_some());
+    assert!(info.instructions.is_some());
+    let instructions = info.instructions.unwrap();
+    assert!(instructions.contains("discover_agents"));
+    assert!(instructions.contains("send_to_agent"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  2. Agent Discovery (legacy broadcast)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn discover_then_list_cached() {
+    let transport = InMemoryTransport::new();
+
+    // Two agents announce on the shared transport.
+    let agent_a = WakuA2ANode::new(
+        "summarizer",
+        "Summarizes documents",
+        vec!["summarize".into()],
+        transport.clone(),
+    );
+    let agent_b = WakuA2ANode::new(
+        "translator",
+        "Translates text",
+        vec!["translate".into()],
+        transport.clone(),
+    );
+    agent_a.announce().await.unwrap();
+    agent_b.announce().await.unwrap();
+
+    let bridge = make_bridge(transport);
+
+    // discover_agents should find both.
+    let result = bridge.discover_agents().await.unwrap();
+    let text = result_text(&result);
+    assert!(text.contains("Found 2 agent(s)"));
+    assert!(text.contains("summarizer"));
+    assert!(text.contains("translator"));
+
+    // list_cached_agents should reflect the cache.
+    let cached = bridge.list_cached_agents().await.unwrap();
+    let cached_text = result_text(&cached);
+    assert!(cached_text.contains("summarizer"));
+    assert!(cached_text.contains("translator"));
+}
+
+#[tokio::test]
+async fn discover_filters_out_bridge_self() {
+    let transport = InMemoryTransport::new();
+
+    // Bridge announces itself + an external agent.
+    let bridge = make_bridge(transport.clone());
+    {
+        let node = bridge.node.read().await;
+        node.announce().await.unwrap();
+    }
+    let external = WakuA2ANode::new(
+        "external-agent",
+        "External",
+        vec!["ext".into()],
+        transport.clone(),
+    );
+    external.announce().await.unwrap();
+
+    let result = bridge.discover_agents().await.unwrap();
+    let text = result_text(&result);
+
+    // The bridge's own card should be filtered by discover().
+    assert!(text.contains("external-agent"));
+    // Only the external agent should appear.
+    assert!(text.contains("Found 1 agent(s)"));
+}
+
+#[tokio::test]
+async fn discover_populates_cache_for_send() {
+    let transport = InMemoryTransport::new();
+
+    let agent = WakuA2ANode::new(
+        "echo-bot",
+        "Echo bot",
+        vec!["echo".into()],
+        transport.clone(),
+    );
+    agent.announce().await.unwrap();
+
+    let bridge = make_bridge(transport);
+
+    // Before discovery, cache is empty.
+    let cached = bridge.list_cached_agents().await.unwrap();
+    assert!(result_text(&cached).contains("No cached agents"));
+
+    // After discovery, cache is populated.
+    bridge.discover_agents().await.unwrap();
+    let cached = bridge.list_cached_agents().await.unwrap();
+    assert!(result_text(&cached).contains("echo-bot"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  3. Send-to-Agent with Mock Transport
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn send_to_agent_receives_completed_response() {
+    let transport = InMemoryTransport::new();
+
+    // Use fire-and-forget config so send_text doesn't block on ACK.
+    let echo_agent = make_fast_agent(
+        "echo",
+        "Echoes messages",
+        vec!["echo".into()],
+        transport.clone(),
+    );
+    echo_agent.announce().await.unwrap();
+
+    let bridge = make_fast_bridge(transport.clone(), 10);
+    bridge.discover_agents().await.unwrap();
+
+    let bridge_pubkey = {
+        let node = bridge.node.read().await;
+        node.pubkey().to_string()
+    };
+
+    // Spawn the echo agent to listen and respond.
+    let echo_handle = tokio::spawn({
+        let echo = echo_agent;
+        let bridge_pk = bridge_pubkey;
+        async move {
+            for _ in 0..50 {
+                let tasks = echo.poll_tasks().await.unwrap();
+                for task in &tasks {
+                    if task.from == bridge_pk {
+                        echo.respond(task, &format!("Echo: {}", task.text().unwrap_or("")))
+                            .await
+                            .unwrap();
+                        return;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    });
+
+    let result = bridge
+        .send_to_agent(Parameters(SendToAgentInput {
+            agent_name: "echo".to_string(),
+            message: "Hello, echo!".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    let text = result_text(&result);
+    assert!(
+        text.contains("Echo: Hello, echo!"),
+        "Expected echo response, got: {text}"
+    );
+    assert!(text.contains("Response from 'echo'"));
+
+    echo_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn send_to_agent_receives_failed_response() {
+    let transport = InMemoryTransport::new();
+
+    let fail_agent = make_fast_agent(
+        "fail-bot",
+        "Always fails",
+        vec!["fail".into()],
+        transport.clone(),
+    );
+    fail_agent.announce().await.unwrap();
+
+    let bridge = make_fast_bridge(transport.clone(), 10);
+    bridge.discover_agents().await.unwrap();
+
+    let bridge_pubkey = {
+        let node = bridge.node.read().await;
+        node.pubkey().to_string()
+    };
+
+    // Spawn agent that responds with a failed task via raw transport.
+    let fail_handle = tokio::spawn({
+        let agent = fail_agent;
+        let bridge_pk = bridge_pubkey;
+        let t = transport.clone();
+        async move {
+            for _ in 0..50 {
+                let tasks = agent.poll_tasks().await.unwrap();
+                for task in &tasks {
+                    if task.from == bridge_pk {
+                        let mut failed = task.respond("error");
+                        failed.state = TaskState::Failed;
+                        let envelope = A2AEnvelope::Task(failed.clone());
+                        let payload = serde_json::to_vec(&envelope).unwrap();
+                        let topic = topics::task_topic(&failed.to);
+                        t.publish(&topic, &payload).await.unwrap();
+                        return;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    });
+
+    let result = bridge
+        .send_to_agent(Parameters(SendToAgentInput {
+            agent_name: "fail-bot".to_string(),
+            message: "do something".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    let text = result_text(&result);
+    assert!(
+        text.contains("task failed"),
+        "Expected failure message, got: {text}"
+    );
+
+    fail_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn send_to_agent_timeout() {
+    let transport = InMemoryTransport::new();
+
+    // Agent that never responds.
+    let silent = make_fast_agent(
+        "silent",
+        "Never responds",
+        vec!["silent".into()],
+        transport.clone(),
+    );
+    silent.announce().await.unwrap();
+
+    // Use a very short timeout so the test doesn't hang.
+    let bridge = make_fast_bridge(transport, 1);
+    bridge.discover_agents().await.unwrap();
+
+    let result = bridge
+        .send_to_agent(Parameters(SendToAgentInput {
+            agent_name: "silent".to_string(),
+            message: "anyone there?".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    let text = result_text(&result);
+    assert!(
+        text.contains("Timeout"),
+        "Expected timeout message, got: {text}"
+    );
+    assert!(text.contains("silent"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  4. Presence Monitoring
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn presence_discover_and_status_check() {
+    let transport = InMemoryTransport::new();
+
+    let agent = WakuA2ANode::new(
+        "live-agent",
+        "Always online",
+        vec!["chat".into(), "search".into()],
+        transport.clone(),
+    );
+    let agent_id = agent.pubkey().to_string();
+    agent.announce_presence().await.unwrap();
+
+    let bridge = make_bridge(transport);
+
+    // Presence discovery should find the agent.
+    let result = bridge.discover_agents_presence().await.unwrap();
+    let text = result_text(&result);
+    assert!(text.contains("Found 1 live agent(s)"));
+    assert!(text.contains("live-agent"));
+    assert!(text.contains("chat, search"));
+
+    // Status check should show ONLINE.
+    let status = bridge
+        .get_agent_status(Parameters(GetAgentStatusInput {
+            agent_id: agent_id.clone(),
+        }))
+        .await
+        .unwrap();
+    let status_text = result_text(&status);
+    assert!(status_text.contains("ONLINE"));
+    assert!(status_text.contains("live-agent"));
+}
+
+#[tokio::test]
+async fn presence_excludes_bridge_self_announcements() {
+    let transport = InMemoryTransport::new();
+    let bridge = make_bridge(transport.clone());
+
+    // Bridge announces its own presence.
+    {
+        let node = bridge.node.read().await;
+        node.announce_presence().await.unwrap();
+    }
+
+    // Also have an external agent.
+    let external = WakuA2ANode::new(
+        "ext-agent",
+        "External",
+        vec!["ext".into()],
+        transport.clone(),
+    );
+    external.announce_presence().await.unwrap();
+
+    let result = bridge.discover_agents_presence().await.unwrap();
+    let text = result_text(&result);
+
+    // Only the external agent should appear.
+    assert!(text.contains("ext-agent"));
+    assert!(text.contains("Found 1 live agent(s)"));
+}
+
+#[tokio::test]
+async fn presence_multiple_agents_numbered() {
+    let transport = InMemoryTransport::new();
+
+    for (name, cap) in [
+        ("agent-1", "summarize"),
+        ("agent-2", "translate"),
+        ("agent-3", "code"),
+    ] {
+        let node = WakuA2ANode::new(
+            name,
+            &format!("{name} desc"),
+            vec![cap.into()],
+            transport.clone(),
+        );
+        node.announce_presence().await.unwrap();
+    }
+
+    let bridge = make_bridge(transport);
+    let result = bridge.discover_agents_presence().await.unwrap();
+    let text = result_text(&result);
+
+    assert!(text.contains("Found 3 live agent(s)"));
+    // Verify numbered format.
+    assert!(text.contains("1. **"));
+    assert!(text.contains("2. **"));
+    assert!(text.contains("3. **"));
+}
+
+#[tokio::test]
+async fn get_agent_status_unknown_agent_is_offline() {
+    let bridge = make_bridge(InMemoryTransport::new());
+
+    let result = bridge
+        .get_agent_status(Parameters(GetAgentStatusInput {
+            agent_id: "0000000000000000deadbeef".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    let text = result_text(&result);
+    assert!(text.contains("OFFLINE or unknown"));
+}
+
+#[tokio::test]
+async fn get_agent_status_shows_all_fields() {
+    let transport = InMemoryTransport::new();
+
+    let agent = WakuA2ANode::new(
+        "full-info",
+        "Agent with full info",
+        vec!["a".into(), "b".into(), "c".into()],
+        transport.clone(),
+    );
+    let agent_id = agent.pubkey().to_string();
+    agent.announce_presence().await.unwrap();
+
+    let bridge = make_bridge(transport);
+    let result = bridge
+        .get_agent_status(Parameters(GetAgentStatusInput {
+            agent_id: agent_id.clone(),
+        }))
+        .await
+        .unwrap();
+    let text = result_text(&result);
+
+    assert!(text.contains("ONLINE"));
+    assert!(text.contains("full-info"));
+    assert!(text.contains("a, b, c"));
+    assert!(text.contains("Waku topic:"));
+    assert!(text.contains("TTL:"));
+    assert!(text.contains("last seen"));
+    assert!(text.contains(&agent_id[..16]));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  5. Error Handling
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn send_to_agent_unknown_returns_invalid_params() {
+    let bridge = make_bridge(InMemoryTransport::new());
+
+    let err = bridge
+        .send_to_agent(Parameters(SendToAgentInput {
+            agent_name: "nonexistent-agent".to_string(),
+            message: "hello".to_string(),
+        }))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("nonexistent-agent"));
+    assert!(err.message.contains("discover_agents"));
+}
+
+#[tokio::test]
+async fn send_to_agent_empty_cache_returns_error() {
+    let bridge = make_bridge(InMemoryTransport::new());
+
+    // Without calling discover_agents first, cache is empty.
+    let err = bridge
+        .send_to_agent(Parameters(SendToAgentInput {
+            agent_name: "any-agent".to_string(),
+            message: "hello".to_string(),
+        }))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn list_cached_agents_empty_says_no_cached() {
+    let bridge = make_bridge(InMemoryTransport::new());
+    let result = bridge.list_cached_agents().await.unwrap();
+    assert!(result_text(&result).contains("No cached agents"));
+}
+
+#[tokio::test]
+async fn discover_on_empty_network() {
+    let bridge = make_bridge(InMemoryTransport::new());
+    let result = bridge.discover_agents().await.unwrap();
+    assert!(result_text(&result).contains("No agents found"));
+}
+
+#[tokio::test]
+async fn presence_rejects_unsigned_announcements() {
+    let transport = InMemoryTransport::new();
+
+    // Inject an unsigned presence announcement directly onto the wire.
+    let unsigned = PresenceAnnouncement {
+        agent_id: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef00".to_string(),
+        name: "malicious".to_string(),
+        capabilities: vec!["evil".into()],
+        waku_topic: "/fake/topic".to_string(),
+        ttl_secs: 300,
+        signature: None,
+    };
+    let envelope = A2AEnvelope::Presence(unsigned);
+    let payload = serde_json::to_vec(&envelope).unwrap();
+    transport.publish(topics::PRESENCE, &payload).await.unwrap();
+
+    let bridge = make_bridge(transport);
+    let result = bridge.discover_agents_presence().await.unwrap();
+    let text = result_text(&result);
+
+    assert!(
+        text.contains("No agents currently online"),
+        "unsigned announcement should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn presence_rejects_malformed_envelope() {
+    let transport = InMemoryTransport::new();
+
+    // Inject garbage data on the presence topic.
+    transport
+        .publish(topics::PRESENCE, b"not valid json")
+        .await
+        .unwrap();
+
+    let bridge = make_bridge(transport);
+    // Should not panic; malformed data is silently ignored.
+    let result = bridge.discover_agents_presence().await.unwrap();
+    let text = result_text(&result);
+    assert!(text.contains("No agents currently online"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  6. JSON-RPC Request/Response Formatting
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn send_to_agent_input_deserializes_from_json() {
+    let json = r#"{"agent_name":"echo-bot","message":"Summarize this document"}"#;
+    let input: SendToAgentInput = serde_json::from_str(json).unwrap();
+    assert_eq!(input.agent_name, "echo-bot");
+    assert_eq!(input.message, "Summarize this document");
+}
+
+#[test]
+fn send_to_agent_input_deserializes_with_whitespace() {
+    let json = r#"{
+        "agent_name": "echo-bot",
+        "message": "Summarize this document"
+    }"#;
+    let input: SendToAgentInput = serde_json::from_str(json).unwrap();
+    assert_eq!(input.agent_name, "echo-bot");
+    assert_eq!(input.message, "Summarize this document");
+}
+
+#[test]
+fn get_agent_status_input_json_roundtrip() {
+    let json =
+        r#"{"agent_id":"02abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"}"#;
+    let input: GetAgentStatusInput = serde_json::from_str(json).unwrap();
+    assert_eq!(
+        input.agent_id,
+        "02abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    );
+}
+
+#[test]
+fn send_to_agent_input_rejects_incomplete_json() {
+    // Missing message field.
+    assert!(serde_json::from_str::<SendToAgentInput>(r#"{"agent_name":"x"}"#).is_err());
+    // Missing agent_name field.
+    assert!(serde_json::from_str::<SendToAgentInput>(r#"{"message":"hi"}"#).is_err());
+    // Empty object.
+    assert!(serde_json::from_str::<SendToAgentInput>(r#"{}"#).is_err());
+}
+
+#[test]
+fn get_agent_status_input_rejects_empty_json() {
+    assert!(serde_json::from_str::<GetAgentStatusInput>(r#"{}"#).is_err());
+}
+
+#[test]
+fn send_to_agent_input_ignores_extra_fields() {
+    let json = r#"{"agent_name":"a","message":"b","extra":"ignored","nested":{"x":1}}"#;
+    let input: SendToAgentInput = serde_json::from_str(json).unwrap();
+    assert_eq!(input.agent_name, "a");
+    assert_eq!(input.message, "b");
+}
+
+#[tokio::test]
+async fn discover_agents_result_format_is_well_structured() {
+    let transport = InMemoryTransport::new();
+
+    let agent = WakuA2ANode::new(
+        "format-agent",
+        "Agent for format testing",
+        vec!["cap-a".into(), "cap-b".into()],
+        transport.clone(),
+    );
+    agent.announce().await.unwrap();
+
+    let bridge = make_bridge(transport);
+    let result = bridge.discover_agents().await.unwrap();
+    let text = result_text(&result);
+
+    // Verify structured output format.
+    assert!(text.starts_with("Found 1 agent(s):"));
+    assert!(text.contains("1. **format-agent**"));
+    assert!(text.contains("(v0.1.0)"));
+    assert!(text.contains("Agent for format testing"));
+    assert!(text.contains("Capabilities: [cap-a, cap-b]"));
+    assert!(text.contains("Public key:"));
+    assert!(text.contains("..."));
+}
+
+#[test]
+fn format_peer_entry_produces_expected_layout() {
+    let info = PeerInfo {
+        name: "peer-x".to_string(),
+        capabilities: vec!["search".to_string(), "index".to_string()],
+        waku_topic: "/waku-a2a/1/task/abcdef/proto".to_string(),
+        ttl_secs: 600,
+        last_seen: 1_700_000_000,
+    };
+
+    let output = format_peer_entry(3, "abcdef1234567890fedcba", &info);
+    assert!(output.contains("3. **peer-x**"));
+    assert!(output.contains("[search, index]"));
+    assert!(output.contains("Agent ID: abcdef1234567890..."));
+    assert!(output.contains("Topic: /waku-a2a/1/task/abcdef/proto"));
+    assert!(output.contains("TTL: 600s"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  7. Bridge Cloning & Shared State
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn cloned_bridge_shares_agent_cache() {
+    let transport = InMemoryTransport::new();
+
+    let agent = WakuA2ANode::new("shared", "Shared", vec!["s".into()], transport.clone());
+    agent.announce().await.unwrap();
+
+    let bridge = make_bridge(transport);
+    let clone = bridge.clone();
+
+    // Discovery on the original should be visible on the clone.
+    bridge.discover_agents().await.unwrap();
+
+    let cached = clone.list_cached_agents().await.unwrap();
+    assert!(result_text(&cached).contains("shared"));
+}
+
+#[tokio::test]
+async fn cloned_bridge_shares_node() {
+    let transport = InMemoryTransport::new();
+    let bridge = make_bridge(transport);
+    let clone = bridge.clone();
+
+    // Both should reference the same underlying node (same pubkey).
+    let pk1 = bridge.node.read().await.pubkey().to_string();
+    let pk2 = clone.node.read().await.pubkey().to_string();
+    assert_eq!(pk1, pk2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  8. Discovery-then-Send Lifecycle
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn full_lifecycle_discover_send_receive() {
+    let transport = InMemoryTransport::new();
+
+    // Use fire-and-forget config for fast tests.
+    let responder = make_fast_agent(
+        "responder",
+        "Responds to queries",
+        vec!["query".into()],
+        transport.clone(),
+    );
+    responder.announce().await.unwrap();
+    responder.announce_presence().await.unwrap();
+
+    let bridge = make_fast_bridge(transport.clone(), 10);
+
+    // Step 1: Legacy discovery.
+    let discover_result = bridge.discover_agents().await.unwrap();
+    assert!(result_text(&discover_result).contains("responder"));
+
+    // Step 2: Presence discovery sees the same agent.
+    let presence_result = bridge.discover_agents_presence().await.unwrap();
+    assert!(result_text(&presence_result).contains("responder"));
+
+    // Step 3: Check status.
+    let agent_id = responder.pubkey().to_string();
+    let status = bridge
+        .get_agent_status(Parameters(GetAgentStatusInput {
+            agent_id: agent_id.clone(),
+        }))
+        .await
+        .unwrap();
+    assert!(result_text(&status).contains("ONLINE"));
+
+    // Step 4: Send a message and have the responder reply.
+    let bridge_pubkey = bridge.node.read().await.pubkey().to_string();
+    let responder_handle = tokio::spawn({
+        let resp = responder;
+        async move {
+            for _ in 0..50 {
+                let tasks = resp.poll_tasks().await.unwrap();
+                for task in &tasks {
+                    if task.from == bridge_pubkey {
+                        resp.respond(task, "lifecycle response").await.unwrap();
+                        return;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    });
+
+    let send_result = bridge
+        .send_to_agent(Parameters(SendToAgentInput {
+            agent_name: "responder".to_string(),
+            message: "lifecycle test".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    assert!(result_text(&send_result).contains("lifecycle response"));
+    responder_handle.await.unwrap();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  9. Edge Cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn discover_agents_rediscovery_replaces_cache() {
+    let transport = InMemoryTransport::new();
+
+    let a = WakuA2ANode::new("agent-a", "A", vec!["a".into()], transport.clone());
+    a.announce().await.unwrap();
+
+    let bridge = make_bridge(transport.clone());
+
+    // First discovery.
+    bridge.discover_agents().await.unwrap();
+    assert_eq!(bridge.agents.read().await.len(), 1);
+
+    // Announce another agent.
+    let b = WakuA2ANode::new("agent-b", "B", vec!["b".into()], transport.clone());
+    b.announce().await.unwrap();
+
+    // Second discovery replaces the cache (InMemoryTransport replays all history).
+    bridge.discover_agents().await.unwrap();
+    let agents = bridge.agents.read().await;
+    assert_eq!(agents.len(), 2);
+}
+
+#[tokio::test]
+async fn send_to_unicode_message() {
+    let transport = InMemoryTransport::new();
+
+    let agent = make_fast_agent(
+        "unicode-bot",
+        "Handles unicode",
+        vec!["text".into()],
+        transport.clone(),
+    );
+    agent.announce().await.unwrap();
+
+    let bridge = make_fast_bridge(transport.clone(), 10);
+    bridge.discover_agents().await.unwrap();
+
+    let bridge_pubkey = bridge.node.read().await.pubkey().to_string();
+    let agent_handle = tokio::spawn({
+        let a = agent;
+        async move {
+            for _ in 0..50 {
+                let tasks = a.poll_tasks().await.unwrap();
+                for task in &tasks {
+                    if task.from == bridge_pubkey {
+                        a.respond(task, "Got it!").await.unwrap();
+                        return;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    });
+
+    let result = bridge
+        .send_to_agent(Parameters(SendToAgentInput {
+            agent_name: "unicode-bot".to_string(),
+            message: "Hello! Bonjour! Hola!".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    assert!(result_text(&result).contains("Got it!"));
+    agent_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn presence_no_peers_returns_helpful_message() {
+    let bridge = make_bridge(InMemoryTransport::new());
+    let result = bridge.discover_agents_presence().await.unwrap();
+    let text = result_text(&result);
+
+    assert!(text.contains("No agents currently online"));
+    assert!(text.contains("TTL may have expired"));
+}
+
+#[test]
+fn format_peer_entry_with_empty_capabilities() {
+    let info = PeerInfo {
+        name: "no-caps".to_string(),
+        capabilities: vec![],
+        waku_topic: "/topic".to_string(),
+        ttl_secs: 60,
+        last_seen: 0,
+    };
+
+    let output = format_peer_entry(1, "abcdef1234567890ff", &info);
+    assert!(output.contains("1. **no-caps** — []"));
+}
+
+#[test]
+fn format_peer_entry_short_id_does_not_panic() {
+    let info = PeerInfo {
+        name: "short".to_string(),
+        capabilities: vec!["x".to_string()],
+        waku_topic: "/t".to_string(),
+        ttl_secs: 10,
+        last_seen: 0,
+    };
+
+    // Agent ID with fewer than 16 characters should be handled gracefully.
+    let output = format_peer_entry(1, "ab", &info);
+    assert!(output.contains("ab..."));
+}


### PR DESCRIPTION
## Purpose

Fix 4 failing MCP integration tests that were timing out instead of receiving agent responses:
- `send_to_agent_receives_completed_response`
- `send_to_agent_receives_failed_response`
- `full_lifecycle_discover_send_receive`
- `send_to_unicode_message`

## Approach

**Root cause:** All 4 tests spawned an echo/responder agent with a throwaway `poll_tasks()` call before the polling loop:

```rust
echo.poll_tasks().await.unwrap();  // intended to "subscribe"
for _ in 0..50 {
    let tasks = echo.poll_tasks().await.unwrap();  // never sees the task
```

With tokio's current-thread runtime (`#[tokio::test]` default), the bridge publishes the task before yielding (at the 2-second sleep). When the echo agent's first `poll_tasks()` runs, `InMemoryTransport`'s history replay delivers the already-published task — but the result is discarded. The SDS bloom filter marks the message as seen, so subsequent `poll_tasks()` calls reject it as a duplicate. The agent never responds, and the bridge times out.

**Fix:**
1. **Tests:** Remove the throwaway first `poll_tasks()` call from all 4 tests. The loop now processes tasks from the very first iteration, where the lazy subscription + history replay correctly delivers the task.
2. **`send_to_agent` handler:** Reduce the polling interval from 2 seconds to 200ms for faster response times and reduced test latency.

## How to Test

```bash
cargo test -p logos-messaging-a2a-mcp
cargo test --workspace
```

## Dependencies

None.

## Future Work

- Consider making the polling interval configurable (currently hardcoded to 200ms).

## Checklist

- [x] All 4 previously failing tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` passes (all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)