### PR TITLE
bench(core,crypto): add criterion benchmarks for serialization and crypto ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbindgen"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +778,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -950,6 +989,67 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1704,6 +1804,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2194,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2428,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "criterion",
  "hex",
  "k256 0.13.4",
  "logos-messaging-a2a-crypto",
@@ -2322,6 +2445,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chacha20poly1305",
+ "criterion",
  "hex",
  "rand 0.8.5",
  "serde",
@@ -2344,6 +2468,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -2654,6 +2779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2977,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "poly1305"
@@ -3157,6 +3316,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3523,6 +3702,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -4217,6 +4405,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,6 +4857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,6 +5031,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/logos-messaging-a2a-core/Cargo.toml
+++ b/crates/logos-messaging-a2a-core/Cargo.toml
@@ -15,3 +15,8 @@ async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "serialization"
+harness = false

--- a/crates/logos-messaging-a2a-core/benches/serialization.rs
+++ b/crates/logos-messaging-a2a-core/benches/serialization.rs
@@ -1,0 +1,135 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use logos_messaging_a2a_core::{AgentCard, Message, Part, TaskState};
+use logos_messaging_a2a_crypto::IntroBundle;
+
+fn sample_agent_card() -> AgentCard {
+    AgentCard {
+        name: "echo-agent".to_string(),
+        description: "Echoes messages back to the sender".to_string(),
+        version: "0.1.0".to_string(),
+        capabilities: vec![
+            "text".to_string(),
+            "echo".to_string(),
+            "translate".to_string(),
+        ],
+        public_key: "02abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"
+            .to_string(),
+        intro_bundle: Some(IntroBundle::new(
+            "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
+        )),
+    }
+}
+
+fn sample_message() -> Message {
+    Message {
+        role: "user".to_string(),
+        parts: vec![
+            Part::Text {
+                text: "Hello, can you help me with a task?".to_string(),
+            },
+            Part::Text {
+                text: "I need to translate this document from English to Spanish.".to_string(),
+            },
+        ],
+    }
+}
+
+fn bench_agent_card_serialize(c: &mut Criterion) {
+    let card = sample_agent_card();
+    c.bench_function("agent_card_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&card)).unwrap())
+    });
+}
+
+fn bench_agent_card_deserialize(c: &mut Criterion) {
+    let card = sample_agent_card();
+    let json = serde_json::to_string(&card).unwrap();
+    c.bench_function("agent_card_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<AgentCard>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_task_state_serialize(c: &mut Criterion) {
+    let states = [
+        TaskState::Submitted,
+        TaskState::Working,
+        TaskState::InputRequired,
+        TaskState::Completed,
+        TaskState::Failed,
+        TaskState::Cancelled,
+    ];
+    c.bench_function("task_state_serialize_all", |b| {
+        b.iter(|| {
+            for state in &states {
+                serde_json::to_string(black_box(state)).unwrap();
+            }
+        })
+    });
+}
+
+fn bench_task_state_deserialize(c: &mut Criterion) {
+    let jsons = [
+        "\"submitted\"",
+        "\"working\"",
+        "\"input_required\"",
+        "\"completed\"",
+        "\"failed\"",
+        "\"cancelled\"",
+    ];
+    c.bench_function("task_state_deserialize_all", |b| {
+        b.iter(|| {
+            for json in &jsons {
+                serde_json::from_str::<TaskState>(black_box(json)).unwrap();
+            }
+        })
+    });
+}
+
+fn bench_part_serialize(c: &mut Criterion) {
+    let part = Part::Text {
+        text: "Hello, this is a sample text part for benchmarking serialization performance."
+            .to_string(),
+    };
+    c.bench_function("part_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&part)).unwrap())
+    });
+}
+
+fn bench_part_deserialize(c: &mut Criterion) {
+    let part = Part::Text {
+        text: "Hello, this is a sample text part for benchmarking serialization performance."
+            .to_string(),
+    };
+    let json = serde_json::to_string(&part).unwrap();
+    c.bench_function("part_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<Part>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_message_serialize(c: &mut Criterion) {
+    let msg = sample_message();
+    c.bench_function("message_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&msg)).unwrap())
+    });
+}
+
+fn bench_message_deserialize(c: &mut Criterion) {
+    let msg = sample_message();
+    let json = serde_json::to_string(&msg).unwrap();
+    c.bench_function("message_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<Message>(black_box(&json)).unwrap())
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_agent_card_serialize,
+    bench_agent_card_deserialize,
+    bench_task_state_serialize,
+    bench_task_state_deserialize,
+    bench_part_serialize,
+    bench_part_deserialize,
+    bench_message_serialize,
+    bench_message_deserialize,
+);
+criterion_main!(benches);

--- a/crates/logos-messaging-a2a-crypto/Cargo.toml
+++ b/crates/logos-messaging-a2a-crypto/Cargo.toml
@@ -12,3 +12,10 @@ serde_json = { workspace = true }
 hex = { workspace = true }
 anyhow = { workspace = true }
 base64 = "0.22"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "crypto"
+harness = false

--- a/crates/logos-messaging-a2a-crypto/benches/crypto.rs
+++ b/crates/logos-messaging-a2a-crypto/benches/crypto.rs
@@ -1,0 +1,102 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use logos_messaging_a2a_crypto::AgentIdentity;
+
+fn bench_key_generation(c: &mut Criterion) {
+    c.bench_function("key_generation", |b| b.iter(|| AgentIdentity::generate()));
+}
+
+fn bench_shared_key_derivation(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    c.bench_function("shared_key_derivation", |b| {
+        b.iter(|| alice.shared_key(black_box(&bob.public)))
+    });
+}
+
+fn bench_encrypt_small(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    let key = alice.shared_key(&bob.public);
+    let plaintext = b"Hello, encrypted world!";
+    c.bench_function("encrypt_small_23B", |b| {
+        b.iter(|| key.encrypt(black_box(plaintext)).unwrap())
+    });
+}
+
+fn bench_decrypt_small(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    let key = alice.shared_key(&bob.public);
+    let encrypted = key.encrypt(b"Hello, encrypted world!").unwrap();
+    c.bench_function("decrypt_small_23B", |b| {
+        b.iter(|| key.decrypt(black_box(&encrypted)).unwrap())
+    });
+}
+
+fn bench_encrypt_1kb(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    let key = alice.shared_key(&bob.public);
+    let plaintext = vec![0xab_u8; 1024];
+    c.bench_function("encrypt_1KB", |b| {
+        b.iter(|| key.encrypt(black_box(&plaintext)).unwrap())
+    });
+}
+
+fn bench_decrypt_1kb(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    let key = alice.shared_key(&bob.public);
+    let encrypted = key.encrypt(&vec![0xab_u8; 1024]).unwrap();
+    c.bench_function("decrypt_1KB", |b| {
+        b.iter(|| key.decrypt(black_box(&encrypted)).unwrap())
+    });
+}
+
+fn bench_encrypt_64kb(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    let key = alice.shared_key(&bob.public);
+    let plaintext = vec![0xab_u8; 64 * 1024];
+    c.bench_function("encrypt_64KB", |b| {
+        b.iter(|| key.encrypt(black_box(&plaintext)).unwrap())
+    });
+}
+
+fn bench_decrypt_64kb(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    let key = alice.shared_key(&bob.public);
+    let encrypted = key.encrypt(&vec![0xab_u8; 64 * 1024]).unwrap();
+    c.bench_function("decrypt_64KB", |b| {
+        b.iter(|| key.decrypt(black_box(&encrypted)).unwrap())
+    });
+}
+
+fn bench_roundtrip_encrypt_decrypt(c: &mut Criterion) {
+    let alice = AgentIdentity::generate();
+    let bob = AgentIdentity::generate();
+    let key_ab = alice.shared_key(&bob.public);
+    let key_ba = bob.shared_key(&alice.public);
+    let plaintext = b"Roundtrip benchmark message";
+    c.bench_function("roundtrip_encrypt_decrypt", |b| {
+        b.iter(|| {
+            let encrypted = key_ab.encrypt(black_box(plaintext)).unwrap();
+            key_ba.decrypt(black_box(&encrypted)).unwrap()
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_key_generation,
+    bench_shared_key_derivation,
+    bench_encrypt_small,
+    bench_decrypt_small,
+    bench_encrypt_1kb,
+    bench_decrypt_1kb,
+    bench_encrypt_64kb,
+    bench_decrypt_64kb,
+    bench_roundtrip_encrypt_decrypt,
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Purpose
Establishes baseline performance numbers for core protocol types and crypto primitives so we can catch regressions and measure optimization impact going forward.

## Approach
- Added [criterion](https://docs.rs/criterion) benchmarks to two crates:
  - **logos-messaging-a2a-core** — serde_json serialize/deserialize for `AgentCard`, `TaskState` (all 6 variants), `Part`, and `Message`
  - **logos-messaging-a2a-crypto** — key generation, ECDH shared key derivation, ChaCha20-Poly1305 encrypt/decrypt at 23B, 1KB, and 64KB, and a full encrypt→decrypt roundtrip

## How to Test
```bash
cargo bench --workspace
# or individually:
cargo bench -p logos-messaging-a2a-core
cargo bench -p logos-messaging-a2a-crypto
```
HTML reports are generated in `target/criterion/`.

## Dependencies
- `criterion = "0.5"` added as a dev-dependency to both crates (with `html_reports` feature)

## Future Work
- Add benchmarks for envelope serialization and Task type
- Add benchmarks for larger payload sizes and streaming chunks
- Integrate with CI for automated regression detection

## Checklist
- [x] `cargo bench --workspace` passes
- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo test --workspace` — all tests pass
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)