### PR TITLE
build: enhance Makefile with comprehensive targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,82 @@
-.PHONY: demo-logos-core demo-logos-core-real test
+.PHONY: build test clippy fmt check doc clean examples bench demo-logos-core demo-logos-core-real
 
-# Run the Logos Core e2e demo (uses stub liblogos_core by default).
-# The demo build.rs auto-compiles the C stub if LOGOS_CORE_LIB_DIR is not set.
+# Build all crates
+build:
+	~/.cargo/bin/cargo build --workspace
+
+# Build in release mode
+release:
+	~/.cargo/bin/cargo build --workspace --release
+
+# Run all tests
+test:
+	~/.cargo/bin/cargo test --workspace
+
+# Run clippy lints
+clippy:
+	~/.cargo/bin/cargo clippy --workspace -- -D warnings
+
+# Format code
+fmt:
+	~/.cargo/bin/cargo fmt --all
+
+# Check formatting (CI mode)
+fmt-check:
+	~/.cargo/bin/cargo fmt --all -- --check
+
+# Full CI check (format + clippy + test)
+check: fmt-check clippy test
+
+# Generate documentation
+doc:
+	~/.cargo/bin/cargo doc --workspace --no-deps
+
+# Build examples
+examples:
+	~/.cargo/bin/cargo build --examples
+
+# Run benchmarks (requires criterion, see jimmy/add-benchmarks branch)
+bench:
+	~/.cargo/bin/cargo bench --workspace
+
+# Run the two-agent demo
+demo:
+	~/.cargo/bin/cargo run --example two_agents
+
+# Run the ping-pong demo (optionally encrypted)
+demo-ping:
+	~/.cargo/bin/cargo run --example ping_pong
+
+demo-ping-encrypted:
+	~/.cargo/bin/cargo run --example ping_pong -- --encrypt
+
+# Run the echo agent
+demo-echo:
+	~/.cargo/bin/cargo run --example echo_agent
+
+# Logos Core e2e demo (stub)
 demo-logos-core:
-	cargo run -p logos-core-e2e-demo
+	~/.cargo/bin/cargo run -p logos-core-e2e-demo
 
-# Run with the real Logos Core SDK (requires delivery_module + storage_module plugins).
-# Example: LOGOS_CORE_LIB_DIR=/home/jimmy/logoscore-test make demo-logos-core-real
+# Logos Core e2e demo (real SDK)
+# Usage: LOGOS_CORE_LIB_DIR=/path/to/logoscore make demo-logos-core-real
 demo-logos-core-real:
 	LD_LIBRARY_PATH="$(LOGOS_CORE_LIB_DIR):$$LD_LIBRARY_PATH" \
 		LOGOS_CORE_LIB_DIR=$(LOGOS_CORE_LIB_DIR) \
-		cargo run -p logos-core-e2e-demo
+		~/.cargo/bin/cargo run -p logos-core-e2e-demo
 
-test:
-	cargo test --workspace
+# Build MCP bridge
+mcp:
+	~/.cargo/bin/cargo build -p logos-messaging-a2a-mcp --release
+
+# Build CLI
+cli:
+	~/.cargo/bin/cargo build -p logos-messaging-a2a-cli --release
+
+# Build FFI shared library
+ffi:
+	~/.cargo/bin/cargo build -p logos-messaging-a2a-ffi --release
+
+# Clean build artifacts
+clean:
+	~/.cargo/bin/cargo clean


### PR DESCRIPTION
## 🎯 Purpose

The existing Makefile had only 3 targets. This adds comprehensive targets for all common development operations, making it easy to build, test, lint, and run demos without remembering individual cargo commands.

## ⚙️ Approach

- Added targets for: build, release, test, clippy, fmt, fmt-check, check (full CI), doc, examples, bench
- Added individual crate build targets: mcp, cli, ffi
- Added demo targets: two_agents, ping_pong (plain + encrypted), echo_agent
- All targets use ~/.cargo/bin/cargo for crib compatibility
- Kept existing logos-core demo targets

## 🧪 How to Test

```bash
make check    # runs fmt-check + clippy + test
make demo     # runs two_agents example
make build    # builds all crates
```

## 🔗 Dependencies

None — pure Makefile changes.

## 🔜 Future Work

- Add `make coverage` target (tarpaulin)
- Add `make install` for CLI/MCP binaries

## 📋 Checklist

- [x] cargo fmt — no changes
- [x] cargo clippy — clean
- [x] cargo test — all pass
- [x] PR template followed