### PR TITLE
feat(cli): add global --keyfile and --encrypt for persistent identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,7 @@ dependencies = [
  "logos-messaging-a2a-transport",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing-subscriber",
 ]
@@ -2344,6 +2345,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -2432,6 +2434,7 @@ dependencies = [
  "tracing",
  "uuid",
  "waku-bindings",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/logos-messaging-a2a-cli/Cargo.toml
+++ b/crates/logos-messaging-a2a-cli/Cargo.toml
@@ -20,3 +20,6 @@ k256 = { workspace = true }
 hex = { workspace = true }
 anyhow = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/logos-messaging-a2a-cli/src/agent.rs
+++ b/crates/logos-messaging-a2a-cli/src/agent.rs
@@ -1,39 +1,29 @@
 use anyhow::Result;
-use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 
 use crate::cli::AgentAction;
-use crate::common::parse_capabilities;
+use crate::common::{build_node, parse_capabilities, IdentityConfig};
 
-pub async fn handle(action: AgentAction, transport: LogosMessagingTransport) -> Result<()> {
+pub async fn handle(
+    action: AgentAction,
+    transport: LogosMessagingTransport,
+    identity: &IdentityConfig,
+) -> Result<()> {
     match action {
-        AgentAction::Run {
-            name,
-            capabilities,
-            encrypt,
-            keyfile,
-        } => {
+        AgentAction::Run { name, capabilities } => {
             let caps = parse_capabilities(&capabilities);
-            let node = if let Some(path) = keyfile {
-                println!("Using keyfile: {}", path.display());
-                WakuA2ANode::from_keyfile(
-                    &name,
-                    &format!("{} agent", name),
-                    caps,
-                    transport,
-                    &path,
-                )?
-            } else if encrypt {
-                WakuA2ANode::new_encrypted(&name, &format!("{} agent", name), caps, transport)
-            } else {
-                WakuA2ANode::new(&name, &format!("{} agent", name), caps, transport)
-            };
+            let node = build_node(&name, &format!("{} agent", name), caps, transport, identity)?;
+
+            if let Some(ref kf) = identity.keyfile {
+                println!("Using keyfile: {}", kf.display());
+            }
             println!("Agent: {}", node.card.name);
             println!("Pubkey: {}", node.pubkey());
-            if encrypt {
-                let bundle = node.card.intro_bundle.as_ref().unwrap();
-                println!("Encryption: ENABLED (X25519+ChaCha20-Poly1305)");
-                println!("X25519 pubkey: {}", bundle.agent_pubkey);
+            if identity.encrypt {
+                if let Some(ref bundle) = node.card.intro_bundle {
+                    println!("Encryption: ENABLED (X25519+ChaCha20-Poly1305)");
+                    println!("X25519 pubkey: {}", bundle.agent_pubkey);
+                }
             }
             println!("Listening for tasks...\n");
 
@@ -68,7 +58,7 @@ pub async fn handle(action: AgentAction, transport: LogosMessagingTransport) -> 
             }
         }
         AgentAction::Discover => {
-            let node = WakuA2ANode::new("discovery-client", "temporary", vec![], transport);
+            let node = build_node("discovery-client", "temporary", vec![], transport, identity)?;
             match node.discover().await {
                 Ok(cards) => {
                     if cards.is_empty() {
@@ -93,7 +83,11 @@ pub async fn handle(action: AgentAction, transport: LogosMessagingTransport) -> 
             }
         }
         AgentAction::Bundle => {
-            let node = WakuA2ANode::new_encrypted("bundle-gen", "temporary", vec![], transport);
+            let encrypt_id = IdentityConfig {
+                keyfile: identity.keyfile.clone(),
+                encrypt: true,
+            };
+            let node = build_node("bundle-gen", "temporary", vec![], transport, &encrypt_id)?;
             let bundle = node.card.intro_bundle.as_ref().unwrap();
             let json = serde_json::to_string_pretty(bundle)?;
             println!("{}", json);

--- a/crates/logos-messaging-a2a-cli/src/cli.rs
+++ b/crates/logos-messaging-a2a-cli/src/cli.rs
@@ -11,6 +11,16 @@ pub struct Cli {
     #[arg(long, default_value = "http://localhost:8645", global = true)]
     pub waku: String,
 
+    /// Path to a persistent identity keyfile (hex-encoded 32-byte signing key).
+    /// If the file does not exist, a new key is generated and saved.
+    /// When provided, all commands share the same identity.
+    #[arg(long, global = true)]
+    pub keyfile: Option<PathBuf>,
+
+    /// Enable X25519+ChaCha20-Poly1305 encryption for this identity.
+    #[arg(long, global = true)]
+    pub encrypt: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -44,13 +54,6 @@ pub enum AgentAction {
         /// Comma-separated capabilities
         #[arg(long, default_value = "text")]
         capabilities: String,
-        /// Enable X25519+ChaCha20-Poly1305 encryption
-        #[arg(long)]
-        encrypt: bool,
-        /// Path to a persistent identity keyfile (hex-encoded 32-byte signing key).
-        /// If the file does not exist, a new key is generated and saved.
-        #[arg(long)]
-        keyfile: Option<PathBuf>,
     },
     /// Discover agents on the network
     Discover,
@@ -102,9 +105,6 @@ pub enum PresenceAction {
         /// Keep re-announcing every ttl/2 seconds
         #[arg(long)]
         repeat: bool,
-        /// Generate encrypted identity (X25519+ChaCha20-Poly1305)
-        #[arg(long)]
-        encrypt: bool,
     },
     /// Listen for presence announcements
     Discover {
@@ -141,6 +141,48 @@ mod tests {
         Cli::try_parse_from(args)
     }
 
+    // ── Global identity flags ──
+
+    #[test]
+    fn global_keyfile_flag() {
+        let cli = try_parse(&["cli", "--keyfile", "/tmp/my.key", "agent", "discover"]).unwrap();
+        assert_eq!(cli.keyfile, Some(PathBuf::from("/tmp/my.key")));
+        assert!(!cli.encrypt);
+    }
+
+    #[test]
+    fn global_encrypt_flag() {
+        let cli = try_parse(&["cli", "--encrypt", "agent", "discover"]).unwrap();
+        assert!(cli.encrypt);
+        assert!(cli.keyfile.is_none());
+    }
+
+    #[test]
+    fn global_keyfile_and_encrypt() {
+        let cli = try_parse(&[
+            "cli",
+            "--keyfile",
+            "/tmp/id.key",
+            "--encrypt",
+            "task",
+            "send",
+            "--to",
+            "abc",
+            "--text",
+            "hi",
+        ])
+        .unwrap();
+        assert_eq!(cli.keyfile, Some(PathBuf::from("/tmp/id.key")));
+        assert!(cli.encrypt);
+    }
+
+    #[test]
+    fn global_flags_work_after_subcommand() {
+        // clap global flags can appear after the subcommand too
+        let cli = try_parse(&["cli", "agent", "discover", "--keyfile", "/tmp/late.key"]).unwrap();
+        assert_eq!(cli.keyfile, Some(PathBuf::from("/tmp/late.key")));
+    }
+
     // ── Presence Announce ──
 
     #[test]
@@ -160,14 +202,12 @@ mod tests {
                         capabilities,
                         ttl,
                         repeat,
-                        encrypt,
                     },
             } => {
                 assert_eq!(name, "echo");
                 assert_eq!(capabilities, "text");
                 assert_eq!(ttl, 300);
                 assert!(!repeat);
-                assert!(!encrypt);
             }
             _ => panic!("expected Presence Announce"),
         }
@@ -177,6 +217,7 @@ mod tests {
     fn presence_announce_all_flags() {
         let cli = try_parse(&[
             "cli",
+            "--encrypt",
             "presence",
             "announce",
             "--name",
@@ -186,9 +227,9 @@ mod tests {
             "--ttl",
             "600",
             "--repeat",
-            "--encrypt",
         ])
         .unwrap();
+        assert!(cli.encrypt);
         match cli.command {
             Commands::Presence {
                 action:
@@ -197,14 +238,12 @@ mod tests {
                         capabilities,
                         ttl,
                         repeat,
-                        encrypt,
                     },
             } => {
                 assert_eq!(name, "bot");
                 assert_eq!(capabilities, "text,code");
                 assert_eq!(ttl, 600);
                 assert!(repeat);
-                assert!(encrypt);
             }
             _ => panic!("expected Presence Announce"),
         }
@@ -383,64 +422,37 @@ mod tests {
         let cli = try_parse(&["cli", "agent", "run", "--name", "echo"]).unwrap();
         match cli.command {
             Commands::Agent {
-                action:
-                    AgentAction::Run {
-                        name,
-                        capabilities,
-                        encrypt,
-                        keyfile,
-                    },
+                action: AgentAction::Run { name, capabilities },
             } => {
                 assert_eq!(name, "echo");
                 assert_eq!(capabilities, "text");
-                assert!(!encrypt);
-                assert!(keyfile.is_none());
             }
             _ => panic!("expected Agent Run"),
         }
+        assert!(!cli.encrypt);
+        assert!(cli.keyfile.is_none());
     }
 
     #[test]
-    fn agent_run_with_encrypt() {
-        let cli = try_parse(&["cli", "agent", "run", "--name", "secure", "--encrypt"]).unwrap();
-        match cli.command {
-            Commands::Agent {
-                action: AgentAction::Run { encrypt, .. },
-            } => {
-                assert!(encrypt);
-            }
-            _ => panic!("expected Agent Run"),
-        }
+    fn agent_run_with_global_encrypt() {
+        let cli = try_parse(&["cli", "--encrypt", "agent", "run", "--name", "secure"]).unwrap();
+        assert!(cli.encrypt);
     }
 
     #[test]
-    fn agent_run_with_keyfile() {
+    fn agent_run_with_global_keyfile() {
         let cli = try_parse(&[
             "cli",
+            "--keyfile",
+            "/tmp/agent.key",
             "agent",
             "run",
             "--name",
             "persistent",
-            "--keyfile",
-            "/tmp/agent.key",
         ])
         .unwrap();
-        match cli.command {
-            Commands::Agent {
-                action:
-                    AgentAction::Run {
-                        name,
-                        keyfile,
-                        encrypt,
-                        ..
-                    },
-            } => {
-                assert_eq!(name, "persistent");
-                assert_eq!(keyfile, Some(PathBuf::from("/tmp/agent.key")));
-                assert!(!encrypt);
-            }
-            _ => panic!("expected Agent Run"),
-        }
+        assert_eq!(cli.keyfile, Some(PathBuf::from("/tmp/agent.key")));
+        assert!(!cli.encrypt);
     }
 
     // ── Task Send details ──

--- a/crates/logos-messaging-a2a-cli/src/common.rs
+++ b/crates/logos-messaging-a2a-cli/src/common.rs
@@ -1,6 +1,101 @@
+use anyhow::Result;
+use logos_messaging_a2a_node::WakuA2ANode;
+use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
+use std::path::PathBuf;
+
 pub fn parse_capabilities(capabilities: &str) -> Vec<String> {
     capabilities
         .split(',')
         .map(|s| s.trim().to_string())
         .collect()
+}
+
+/// Identity configuration extracted from global CLI flags.
+#[derive(Debug, Clone)]
+pub struct IdentityConfig {
+    pub keyfile: Option<PathBuf>,
+    pub encrypt: bool,
+}
+
+/// Build a [`WakuA2ANode`] using the global identity flags.
+///
+/// When `--keyfile` is provided, the node loads (or creates) a persistent
+/// signing key so that every CLI invocation shares the same pubkey and
+/// can therefore poll for responses to tasks it previously sent.
+///
+/// When `--encrypt` is set, the node generates an X25519 keypair for
+/// end-to-end encryption.
+pub fn build_node(
+    name: &str,
+    description: &str,
+    capabilities: Vec<String>,
+    transport: LogosMessagingTransport,
+    identity: &IdentityConfig,
+) -> Result<WakuA2ANode<LogosMessagingTransport>> {
+    let node = if let Some(ref path) = identity.keyfile {
+        WakuA2ANode::from_keyfile(name, description, capabilities, transport, path)?
+    } else if identity.encrypt {
+        WakuA2ANode::new_encrypted(name, description, capabilities, transport)
+    } else {
+        WakuA2ANode::new(name, description, capabilities, transport)
+    };
+    Ok(node)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_capability() {
+        assert_eq!(parse_capabilities("text"), vec!["text"]);
+    }
+
+    #[test]
+    fn parse_multiple_capabilities() {
+        assert_eq!(
+            parse_capabilities("text, code, search"),
+            vec!["text", "code", "search"]
+        );
+    }
+
+    #[test]
+    fn build_node_ephemeral() {
+        let transport = LogosMessagingTransport::new("http://localhost:8645");
+        let id = IdentityConfig {
+            keyfile: None,
+            encrypt: false,
+        };
+        let node = build_node("test", "test node", vec![], transport, &id).unwrap();
+        assert!(!node.pubkey().is_empty());
+    }
+
+    #[test]
+    fn build_node_encrypted() {
+        let transport = LogosMessagingTransport::new("http://localhost:8645");
+        let id = IdentityConfig {
+            keyfile: None,
+            encrypt: true,
+        };
+        let node = build_node("test", "test node", vec![], transport, &id).unwrap();
+        assert!(node.card.intro_bundle.is_some());
+    }
+
+    #[test]
+    fn build_node_with_keyfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let keypath = dir.path().join("test.key");
+        let transport = LogosMessagingTransport::new("http://localhost:8645");
+        let id = IdentityConfig {
+            keyfile: Some(keypath.clone()),
+            encrypt: false,
+        };
+        let node1 = build_node("test", "test node", vec![], transport, &id).unwrap();
+        let pk1 = node1.pubkey().to_string();
+
+        // Second build with same keyfile should produce same pubkey
+        let transport2 = LogosMessagingTransport::new("http://localhost:8645");
+        let node2 = build_node("test", "test node", vec![], transport2, &id).unwrap();
+        assert_eq!(pk1, node2.pubkey());
+    }
 }

--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -10,6 +10,7 @@ use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 use tracing_subscriber::EnvFilter;
 
 use cli::{Cli, Commands};
+use common::IdentityConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -20,10 +21,14 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
     let transport = LogosMessagingTransport::new(&cli.waku);
+    let identity = IdentityConfig {
+        keyfile: cli.keyfile,
+        encrypt: cli.encrypt,
+    };
 
     match cli.command {
-        Commands::Agent { action } => agent::handle(action, transport).await,
-        Commands::Task { action } => task::handle(action, transport).await,
-        Commands::Presence { action } => presence::handle(action, transport).await,
+        Commands::Agent { action } => agent::handle(action, transport, &identity).await,
+        Commands::Task { action } => task::handle(action, transport, &identity).await,
+        Commands::Presence { action } => presence::handle(action, transport, &identity).await,
     }
 }

--- a/crates/logos-messaging-a2a-cli/src/presence.rs
+++ b/crates/logos-messaging-a2a-cli/src/presence.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
-use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 use std::collections::HashSet;
 
 use crate::cli::PresenceAction;
-use crate::common::parse_capabilities;
+use crate::common::{build_node, parse_capabilities, IdentityConfig};
 
 fn print_peer(agent_id: &str, info: &logos_messaging_a2a_node::presence::PeerInfo) {
     let expired = if info.is_expired() { " [EXPIRED]" } else { "" };
@@ -17,26 +16,25 @@ fn print_peer(agent_id: &str, info: &logos_messaging_a2a_node::presence::PeerInf
     println!();
 }
 
-pub async fn handle(action: PresenceAction, transport: LogosMessagingTransport) -> Result<()> {
+pub async fn handle(
+    action: PresenceAction,
+    transport: LogosMessagingTransport,
+    identity: &IdentityConfig,
+) -> Result<()> {
     match action {
         PresenceAction::Announce {
             name,
             capabilities,
             ttl,
             repeat,
-            encrypt,
         } => {
             let caps = parse_capabilities(&capabilities);
-            let node = if encrypt {
-                WakuA2ANode::new_encrypted(&name, &format!("{} agent", name), caps, transport)
-            } else {
-                WakuA2ANode::new(&name, &format!("{} agent", name), caps, transport)
-            };
+            let node = build_node(&name, &format!("{} agent", name), caps, transport, identity)?;
 
             println!("Announcing presence: {}", node.card.name);
             println!("Pubkey: {}", node.pubkey());
             println!("TTL: {}s", ttl);
-            if encrypt {
+            if identity.encrypt {
                 println!("Encryption: ENABLED");
             }
 
@@ -65,7 +63,13 @@ pub async fn handle(action: PresenceAction, transport: LogosMessagingTransport) 
             watch,
             timeout,
         } => {
-            let node = WakuA2ANode::new("presence-discover", "temporary", vec![], transport);
+            let node = build_node(
+                "presence-discover",
+                "temporary",
+                vec![],
+                transport,
+                identity,
+            )?;
 
             if watch {
                 println!("Watching for presence announcements (Ctrl-C to stop)...\n");
@@ -123,7 +127,7 @@ pub async fn handle(action: PresenceAction, transport: LogosMessagingTransport) 
             watch,
             timeout,
         } => {
-            let node = WakuA2ANode::new("presence-peers", "temporary", vec![], transport);
+            let node = build_node("presence-peers", "temporary", vec![], transport, identity)?;
 
             if watch {
                 println!("Watching for unique peers (Ctrl-C to stop)...\n");

--- a/crates/logos-messaging-a2a-cli/src/task.rs
+++ b/crates/logos-messaging-a2a-cli/src/task.rs
@@ -1,15 +1,20 @@
 use anyhow::Result;
 use logos_messaging_a2a_core::Task;
-use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 
 use crate::cli::TaskAction;
+use crate::common::{build_node, IdentityConfig};
 
-pub async fn handle(action: TaskAction, transport: LogosMessagingTransport) -> Result<()> {
+pub async fn handle(
+    action: TaskAction,
+    transport: LogosMessagingTransport,
+    identity: &IdentityConfig,
+) -> Result<()> {
     match action {
         TaskAction::Send { to, text } => {
-            let node = WakuA2ANode::new("cli-sender", "CLI client", vec![], transport);
+            let node = build_node("cli-sender", "CLI client", vec![], transport, identity)?;
             println!("Sending task to {}...", &to[..12.min(to.len())]);
+            println!("From pubkey: {}", node.pubkey());
             let task = Task::new(node.pubkey(), &to, &text);
             match node.send_task(&task).await {
                 Ok(acked) => {
@@ -27,8 +32,9 @@ pub async fn handle(action: TaskAction, transport: LogosMessagingTransport) -> R
             }
         }
         TaskAction::Status { id } => {
-            let node = WakuA2ANode::new("cli-poller", "CLI client", vec![], transport);
+            let node = build_node("cli-poller", "CLI client", vec![], transport, identity)?;
             println!("Polling for task {} responses...", id);
+            println!("Listening as: {}", node.pubkey());
             match node.poll_tasks().await {
                 Ok(tasks) => {
                     let found: Vec<_> = tasks.iter().filter(|t| t.id == id).collect();
@@ -50,7 +56,7 @@ pub async fn handle(action: TaskAction, transport: LogosMessagingTransport) -> R
             }
         }
         TaskAction::Stream { id, timeout } => {
-            let node = WakuA2ANode::new("cli-stream", "CLI client", vec![], transport);
+            let node = build_node("cli-stream", "CLI client", vec![], transport, identity)?;
             println!(
                 "Following stream for task {} (timeout {}s)...\n",
                 id, timeout


### PR DESCRIPTION
## 🎯 Purpose

Fix a critical usability bug: each CLI subcommand created an **ephemeral node with a random keypair**, making it impossible to poll for responses to tasks you sent. Since Waku topic routing is pubkey-based, `task send` and `task status` were listening on different topics.

## ⚙️ Approach

- Move `--keyfile` and `--encrypt` from subcommand-level (`agent run`, `presence announce`) to **global CLI flags**
- Add `IdentityConfig` struct and `build_node()` helper in `common.rs` — single place to construct nodes with consistent identity
- All handlers (`agent`, `task`, `presence`) now use `build_node()` instead of ad-hoc `WakuA2ANode::new()` calls
- Print pubkey in `task send` and `task status` output for debugging

## 🧪 How to Test

```bash
# All tests pass
cargo test -p logos-messaging-a2a-cli

# Verify persistent identity works
lmao --keyfile /tmp/test.key task send --to <pubkey> --text "hello"
lmao --keyfile /tmp/test.key task status --id <task-id>
# Both commands now use the same pubkey

# Verify encryption flag
lmao --encrypt agent bundle
```

## 🔗 Dependencies

None — pure CLI refactor.

## 🔜 Future Work

- Auto-generate default keyfile in `~/.lmao/identity.key` if none specified
- Add `identity` subcommand to show/manage the current keypair
- Session-aware task tracking (list all sent/received tasks)

## 📋 Checklist

- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo test --workspace` — all pass (35 CLI tests, including 7 new ones)
- [x] No breaking changes to existing CLI usage (flags just moved to global scope)
- [x] Follows PR template