### PR TITLE
feat(node): multi-agent task delegation (subtask forwarding)

### DIFF
--- a/crates/logos-messaging-a2a-cli/src/cli.rs
+++ b/crates/logos-messaging-a2a-cli/src/cli.rs
@@ -87,6 +87,27 @@ pub enum TaskAction {
         #[arg(long, default_value = "30")]
         timeout: u64,
     },
+    /// Delegate a subtask to a peer agent
+    Delegate {
+        /// Recipient agent public key (hex) — direct delegation
+        #[arg(long)]
+        to: Option<String>,
+        /// Required capability — discovery-based delegation
+        #[arg(long)]
+        capability: Option<String>,
+        /// Text of the subtask to delegate
+        #[arg(long)]
+        text: String,
+        /// Parent task ID this subtask belongs to
+        #[arg(long, default_value = "cli")]
+        parent_id: String,
+        /// Timeout in seconds for the delegation
+        #[arg(long, default_value = "30")]
+        timeout: u64,
+        /// Broadcast to all matching peers instead of just one
+        #[arg(long)]
+        broadcast: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -579,6 +600,128 @@ mod tests {
     #[test]
     fn task_stream_missing_id() {
         let err = try_parse(&["cli", "task", "stream"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    // ── Task Delegate ──
+
+    #[test]
+    fn task_delegate_with_to() {
+        let cli = try_parse(&[
+            "cli",
+            "task",
+            "delegate",
+            "--to",
+            "02abcdef",
+            "--text",
+            "do something",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Task {
+                action:
+                    TaskAction::Delegate {
+                        to,
+                        capability,
+                        text,
+                        parent_id,
+                        timeout,
+                        broadcast,
+                    },
+            } => {
+                assert_eq!(to, Some("02abcdef".to_string()));
+                assert!(capability.is_none());
+                assert_eq!(text, "do something");
+                assert_eq!(parent_id, "cli");
+                assert_eq!(timeout, 30);
+                assert!(!broadcast);
+            }
+            _ => panic!("expected Task Delegate"),
+        }
+    }
+
+    #[test]
+    fn task_delegate_with_capability() {
+        let cli = try_parse(&[
+            "cli",
+            "task",
+            "delegate",
+            "--capability",
+            "summarize",
+            "--text",
+            "summarize this",
+            "--parent-id",
+            "task-42",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Task {
+                action:
+                    TaskAction::Delegate {
+                        to,
+                        capability,
+                        text,
+                        parent_id,
+                        ..
+                    },
+            } => {
+                assert!(to.is_none());
+                assert_eq!(capability, Some("summarize".to_string()));
+                assert_eq!(text, "summarize this");
+                assert_eq!(parent_id, "task-42");
+            }
+            _ => panic!("expected Task Delegate"),
+        }
+    }
+
+    #[test]
+    fn task_delegate_broadcast_flag() {
+        let cli = try_parse(&[
+            "cli",
+            "task",
+            "delegate",
+            "--capability",
+            "text",
+            "--text",
+            "broadcast",
+            "--broadcast",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Task {
+                action: TaskAction::Delegate { broadcast, .. },
+            } => {
+                assert!(broadcast);
+            }
+            _ => panic!("expected Task Delegate"),
+        }
+    }
+
+    #[test]
+    fn task_delegate_custom_timeout() {
+        let cli = try_parse(&[
+            "cli",
+            "task",
+            "delegate",
+            "--text",
+            "quick",
+            "--timeout",
+            "5",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Task {
+                action: TaskAction::Delegate { timeout, .. },
+            } => {
+                assert_eq!(timeout, 5);
+            }
+            _ => panic!("expected Task Delegate"),
+        }
+    }
+
+    #[test]
+    fn task_delegate_missing_text() {
+        let err = try_parse(&["cli", "task", "delegate", "--to", "02ab"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     }
 }

--- a/crates/logos-messaging-a2a-cli/src/task.rs
+++ b/crates/logos-messaging-a2a-cli/src/task.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use logos_messaging_a2a_core::Task;
+use logos_messaging_a2a_core::{DelegationRequest, DelegationStrategy, Task};
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 
 use crate::cli::TaskAction;
@@ -89,6 +89,109 @@ pub async fn handle(
 
             if last_index.is_none() {
                 println!("No stream chunks received for task {}", id);
+            }
+        }
+        TaskAction::Delegate {
+            to,
+            capability,
+            text,
+            parent_id,
+            timeout,
+            broadcast,
+        } => {
+            let node = build_node(
+                "cli-delegator",
+                "CLI delegation client",
+                vec![],
+                transport,
+                identity,
+            )?;
+            println!("From pubkey: {}", node.pubkey());
+
+            // Build strategy from flags
+            let strategy = if let Some(ref agent_key) = to {
+                // Direct delegation — send task directly, skip presence lookup
+                println!(
+                    "Delegating directly to {}...",
+                    &agent_key[..12.min(agent_key.len())]
+                );
+                let task = Task::new(node.pubkey(), agent_key, &text);
+                println!("Subtask ID: {}", task.id);
+                match node.send_task(&task).await {
+                    Ok(acked) => {
+                        if acked {
+                            println!("Status: ACKed by recipient");
+                        } else {
+                            println!("Status: Sent (no ACK)");
+                        }
+                        println!("Parent task: {}", parent_id);
+                    }
+                    Err(e) => eprintln!("Failed to delegate: {}", e),
+                }
+                return Ok(());
+            } else if let Some(ref cap) = capability {
+                DelegationStrategy::CapabilityMatch {
+                    capability: cap.clone(),
+                }
+            } else {
+                DelegationStrategy::FirstAvailable
+            };
+
+            // Presence-based delegation
+            println!("Discovering peers via presence...");
+            let poll_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+            while tokio::time::Instant::now() < poll_deadline {
+                node.poll_presence().await?;
+                if !node.peers().all_live().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+            let live = node.peers().all_live();
+            println!("Found {} live peer(s)", live.len());
+
+            let request = DelegationRequest {
+                parent_task_id: parent_id.clone(),
+                subtask_text: text,
+                strategy,
+                timeout_secs: timeout,
+            };
+
+            if broadcast {
+                println!("Broadcasting to all matching peers...");
+                match node.delegate_broadcast(&request).await {
+                    Ok(results) => {
+                        println!("Received {} result(s):", results.len());
+                        for r in &results {
+                            let status = if r.success { "OK" } else { "FAIL" };
+                            let agent = &r.agent_id[..12.min(r.agent_id.len())];
+                            println!("  [{status}] agent={agent} subtask={}", r.subtask_id);
+                            if let Some(ref text) = r.result_text {
+                                println!("    Result: {text}");
+                            }
+                            if let Some(ref err) = r.error {
+                                println!("    Error: {err}");
+                            }
+                        }
+                    }
+                    Err(e) => eprintln!("Broadcast delegation failed: {}", e),
+                }
+            } else {
+                println!("Delegating to single peer...");
+                match node.delegate_task(&request).await {
+                    Ok(r) => {
+                        let status = if r.success { "OK" } else { "FAIL" };
+                        let agent = &r.agent_id[..12.min(r.agent_id.len())];
+                        println!("[{status}] agent={agent} subtask={}", r.subtask_id);
+                        if let Some(ref text) = r.result_text {
+                            println!("Result: {text}");
+                        }
+                        if let Some(ref err) = r.error {
+                            println!("Error: {err}");
+                        }
+                    }
+                    Err(e) => eprintln!("Delegation failed: {}", e),
+                }
             }
         }
     }

--- a/crates/logos-messaging-a2a-core/src/delegation.rs
+++ b/crates/logos-messaging-a2a-core/src/delegation.rs
@@ -1,0 +1,226 @@
+use serde::{Deserialize, Serialize};
+
+/// Strategy for selecting which peer(s) to delegate a subtask to.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DelegationStrategy {
+    /// Pick the first available peer (any capability).
+    FirstAvailable,
+    /// Broadcast to all matching peers and collect responses.
+    BroadcastCollect,
+    /// Pick a peer that advertises a specific capability.
+    CapabilityMatch {
+        /// The required capability string.
+        capability: String,
+    },
+}
+
+/// A request to delegate a subtask to one or more peers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DelegationRequest {
+    /// Identifier of the parent task that spawned this subtask.
+    pub parent_task_id: String,
+    /// Text content of the subtask to be delegated.
+    pub subtask_text: String,
+    /// Strategy for selecting the delegate(s).
+    pub strategy: DelegationStrategy,
+    /// How long to wait (seconds) for the delegate to respond.
+    /// `0` means use the default timeout.
+    pub timeout_secs: u64,
+}
+
+/// The result of a delegated subtask, including which agent handled it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DelegationResult {
+    /// ID of the parent task.
+    pub parent_task_id: String,
+    /// ID of the subtask that was delegated.
+    pub subtask_id: String,
+    /// Public key (hex) of the agent that processed the subtask.
+    pub agent_id: String,
+    /// The text result returned by the delegate agent, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_text: Option<String>,
+    /// Whether the delegation succeeded.
+    pub success: bool,
+    /// Error message if the delegation failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_delegation_strategy_first_available_serialization() {
+        let strategy = DelegationStrategy::FirstAvailable;
+        let json = serde_json::to_string(&strategy).unwrap();
+        assert!(json.contains("\"type\":\"first_available\""));
+        let deserialized: DelegationStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(strategy, deserialized);
+    }
+
+    #[test]
+    fn test_delegation_strategy_broadcast_collect_serialization() {
+        let strategy = DelegationStrategy::BroadcastCollect;
+        let json = serde_json::to_string(&strategy).unwrap();
+        assert!(json.contains("\"type\":\"broadcast_collect\""));
+        let deserialized: DelegationStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(strategy, deserialized);
+    }
+
+    #[test]
+    fn test_delegation_strategy_capability_match_serialization() {
+        let strategy = DelegationStrategy::CapabilityMatch {
+            capability: "summarize".to_string(),
+        };
+        let json = serde_json::to_string(&strategy).unwrap();
+        assert!(json.contains("\"type\":\"capability_match\""));
+        assert!(json.contains("\"capability\":\"summarize\""));
+        let deserialized: DelegationStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(strategy, deserialized);
+    }
+
+    #[test]
+    fn test_delegation_request_serialization() {
+        let req = DelegationRequest {
+            parent_task_id: "parent-123".to_string(),
+            subtask_text: "Summarize this document".to_string(),
+            strategy: DelegationStrategy::CapabilityMatch {
+                capability: "summarize".to_string(),
+            },
+            timeout_secs: 30,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let deserialized: DelegationRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req, deserialized);
+    }
+
+    #[test]
+    fn test_delegation_result_success_serialization() {
+        let result = DelegationResult {
+            parent_task_id: "parent-123".to_string(),
+            subtask_id: "subtask-456".to_string(),
+            agent_id: "02abcdef".to_string(),
+            result_text: Some("Summary: ...".to_string()),
+            success: true,
+            error: None,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(!json.contains("error"));
+        let deserialized: DelegationResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result, deserialized);
+    }
+
+    #[test]
+    fn test_delegation_result_failure_serialization() {
+        let result = DelegationResult {
+            parent_task_id: "parent-123".to_string(),
+            subtask_id: "subtask-456".to_string(),
+            agent_id: "02abcdef".to_string(),
+            result_text: None,
+            success: false,
+            error: Some("timeout".to_string()),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(!json.contains("result_text"));
+        assert!(json.contains("\"error\":\"timeout\""));
+        let deserialized: DelegationResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result, deserialized);
+    }
+
+    #[test]
+    fn test_delegation_request_zero_timeout() {
+        let req = DelegationRequest {
+            parent_task_id: "p".to_string(),
+            subtask_text: "task".to_string(),
+            strategy: DelegationStrategy::FirstAvailable,
+            timeout_secs: 0,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let deserialized: DelegationRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.timeout_secs, 0);
+    }
+
+    #[test]
+    fn test_delegation_strategy_clone_and_debug() {
+        let strategy = DelegationStrategy::BroadcastCollect;
+        let cloned = strategy.clone();
+        assert_eq!(strategy, cloned);
+        let debug = format!("{:?}", strategy);
+        assert!(debug.contains("BroadcastCollect"));
+    }
+
+    #[test]
+    fn test_delegation_request_clone_and_debug() {
+        let req = DelegationRequest {
+            parent_task_id: "p".to_string(),
+            subtask_text: "t".to_string(),
+            strategy: DelegationStrategy::FirstAvailable,
+            timeout_secs: 10,
+        };
+        let cloned = req.clone();
+        assert_eq!(req, cloned);
+        let debug = format!("{:?}", req);
+        assert!(debug.contains("DelegationRequest"));
+    }
+
+    #[test]
+    fn test_delegation_result_clone_and_debug() {
+        let result = DelegationResult {
+            parent_task_id: "p".to_string(),
+            subtask_id: "s".to_string(),
+            agent_id: "02ab".to_string(),
+            result_text: Some("ok".to_string()),
+            success: true,
+            error: None,
+        };
+        let cloned = result.clone();
+        assert_eq!(result, cloned);
+        let debug = format!("{:?}", result);
+        assert!(debug.contains("DelegationResult"));
+    }
+
+    #[test]
+    fn test_delegation_strategy_all_variants_distinct_type_tags() {
+        let variants: Vec<DelegationStrategy> = vec![
+            DelegationStrategy::FirstAvailable,
+            DelegationStrategy::BroadcastCollect,
+            DelegationStrategy::CapabilityMatch {
+                capability: "x".to_string(),
+            },
+        ];
+        let mut tags: Vec<String> = Vec::new();
+        for v in variants {
+            let json = serde_json::to_string(&v).unwrap();
+            let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+            tags.push(val["type"].as_str().unwrap().to_string());
+        }
+        let unique: std::collections::HashSet<&String> = tags.iter().collect();
+        assert_eq!(unique.len(), tags.len());
+    }
+
+    #[test]
+    fn test_delegation_strategy_invalid_type_tag_fails() {
+        let json = r#"{"type":"nonexistent"}"#;
+        let result = serde_json::from_str::<DelegationStrategy>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delegation_request_missing_fields_fails() {
+        let json = r#"{"parent_task_id":"p"}"#;
+        let result = serde_json::from_str::<DelegationRequest>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delegation_result_backward_compat_without_optional_fields() {
+        let json = r#"{"parent_task_id":"p","subtask_id":"s","agent_id":"02ab","success":true}"#;
+        let result: DelegationResult = serde_json::from_str(json).unwrap();
+        assert!(result.result_text.is_none());
+        assert!(result.error.is_none());
+        assert!(result.success);
+    }
+}

--- a/crates/logos-messaging-a2a-core/src/lib.rs
+++ b/crates/logos-messaging-a2a-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! # Modules
 //!
 //! - [`agent`] — Agent identity and capability advertisement ([`AgentCard`]).
+//! - [`delegation`] — Multi-agent task delegation types ([`DelegationRequest`], [`DelegationResult`], [`DelegationStrategy`]).
 //! - [`envelope`] — Wire envelope ([`A2AEnvelope`]) for all Waku messages.
 //! - [`task`] — Task lifecycle types ([`Task`], [`TaskState`], [`Message`], [`Part`]).
 //! - [`topics`] — Waku content topic string helpers.
@@ -16,6 +17,7 @@
 //! - [`retry`] — Exponential-backoff retry configuration.
 
 pub mod agent;
+pub mod delegation;
 pub mod envelope;
 pub mod presence;
 pub mod registry;
@@ -25,6 +27,7 @@ pub mod topics;
 
 // Re-export everything at crate root so existing imports don't break.
 pub use agent::*;
+pub use delegation::*;
 pub use envelope::*;
 pub use presence::*;
 pub use retry::*;

--- a/crates/logos-messaging-a2a-node/src/delegation.rs
+++ b/crates/logos-messaging-a2a-node/src/delegation.rs
@@ -1,0 +1,171 @@
+//! Multi-agent task delegation: decompose tasks into subtasks and forward
+//! them to capable peers discovered via presence.
+
+use anyhow::{Context, Result};
+use logos_messaging_a2a_core::{
+    topics, A2AEnvelope, DelegationRequest, DelegationResult, DelegationStrategy, Task,
+};
+use logos_messaging_a2a_transport::Transport;
+use std::time::Duration;
+
+use crate::WakuA2ANode;
+
+/// Default timeout for delegation when none is specified (30 seconds).
+const DEFAULT_DELEGATION_TIMEOUT_SECS: u64 = 30;
+
+impl<T: Transport> WakuA2ANode<T> {
+    /// Delegate a subtask to a single peer based on the delegation strategy.
+    ///
+    /// Looks up peers from the live peer map, picks one according to the
+    /// strategy, sends the subtask, and waits for a response within the
+    /// specified timeout.
+    pub async fn delegate_task(&self, request: &DelegationRequest) -> Result<DelegationResult> {
+        let timeout_secs = if request.timeout_secs == 0 {
+            DEFAULT_DELEGATION_TIMEOUT_SECS
+        } else {
+            request.timeout_secs
+        };
+
+        // Find a suitable peer based on strategy
+        let peer_id = match &request.strategy {
+            DelegationStrategy::FirstAvailable => {
+                let peers = self.peers().all_live();
+                peers
+                    .into_iter()
+                    .map(|(id, _)| id)
+                    .next()
+                    .context("no live peers available for delegation")?
+            }
+            DelegationStrategy::CapabilityMatch { capability } => {
+                let peers = self.find_peers_by_capability(capability);
+                peers
+                    .into_iter()
+                    .map(|(id, _)| id)
+                    .next()
+                    .with_context(|| {
+                        format!("no live peers with capability '{capability}' for delegation")
+                    })?
+            }
+            DelegationStrategy::BroadcastCollect => {
+                // For single delegation, broadcast acts like first-available
+                let peers = self.peers().all_live();
+                peers
+                    .into_iter()
+                    .map(|(id, _)| id)
+                    .next()
+                    .context("no live peers available for broadcast delegation")?
+            }
+        };
+
+        self.delegate_to_peer(request, &peer_id, timeout_secs).await
+    }
+
+    /// Delegate a subtask to all matching peers and collect responses.
+    ///
+    /// Distributes the subtask to every peer that matches the delegation
+    /// strategy and waits up to `timeout_secs` for responses from all of them.
+    pub async fn delegate_broadcast(
+        &self,
+        request: &DelegationRequest,
+    ) -> Result<Vec<DelegationResult>> {
+        let timeout_secs = if request.timeout_secs == 0 {
+            DEFAULT_DELEGATION_TIMEOUT_SECS
+        } else {
+            request.timeout_secs
+        };
+
+        let peer_ids: Vec<String> = match &request.strategy {
+            DelegationStrategy::CapabilityMatch { capability } => self
+                .find_peers_by_capability(capability)
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect(),
+            _ => self
+                .peers()
+                .all_live()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect(),
+        };
+
+        if peer_ids.is_empty() {
+            anyhow::bail!("no live peers available for broadcast delegation");
+        }
+
+        let mut results = Vec::new();
+        for peer_id in peer_ids {
+            let result = self.delegate_to_peer(request, &peer_id, timeout_secs).await;
+            match result {
+                Ok(r) => results.push(r),
+                Err(e) => results.push(DelegationResult {
+                    parent_task_id: request.parent_task_id.clone(),
+                    subtask_id: String::new(),
+                    agent_id: peer_id,
+                    result_text: None,
+                    success: false,
+                    error: Some(e.to_string()),
+                }),
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Send a subtask to a specific peer and wait for a response.
+    ///
+    /// Uses fire-and-forget send (like `respond`) rather than SDS reliable
+    /// delivery, since delegation already has its own response-based timeout.
+    async fn delegate_to_peer(
+        &self,
+        request: &DelegationRequest,
+        peer_id: &str,
+        timeout_secs: u64,
+    ) -> Result<DelegationResult> {
+        let task = Task::new(self.pubkey(), peer_id, &request.subtask_text);
+        let subtask_id = task.id.clone();
+
+        // Publish directly to transport (bypassing SDS reliable delivery)
+        // since delegation already polls for the response with its own timeout.
+        let topic = topics::task_topic(peer_id);
+        let envelope = A2AEnvelope::Task(task);
+        let payload =
+            serde_json::to_vec(&envelope).context("failed to serialize delegated subtask")?;
+        self.channel()
+            .transport()
+            .publish(&topic, &payload)
+            .await
+            .context("failed to send delegated subtask")?;
+
+        // Poll for response with timeout
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+
+        while tokio::time::Instant::now() < deadline {
+            let tasks = self
+                .poll_tasks()
+                .await
+                .context("failed to poll for delegation response")?;
+            for received in &tasks {
+                if received.id == subtask_id {
+                    return Ok(DelegationResult {
+                        parent_task_id: request.parent_task_id.clone(),
+                        subtask_id: subtask_id.clone(),
+                        agent_id: peer_id.to_string(),
+                        result_text: received.result_text().map(String::from),
+                        success: true,
+                        error: None,
+                    });
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        Ok(DelegationResult {
+            parent_task_id: request.parent_task_id.clone(),
+            subtask_id,
+            agent_id: peer_id.to_string(),
+            result_text: None,
+            success: false,
+            error: Some("delegation timed out".to_string()),
+        })
+    }
+}

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -7,6 +7,7 @@
 //! sessions, stream responses, and handle payments over a Waku-compatible
 //! transport layer.
 
+pub mod delegation;
 pub mod discovery;
 pub mod payment;
 pub mod presence;

--- a/crates/logos-messaging-a2a-node/tests/delegation.rs
+++ b/crates/logos-messaging-a2a-node/tests/delegation.rs
@@ -1,0 +1,341 @@
+//! Integration tests for multi-agent task delegation.
+
+use logos_messaging_a2a_core::{DelegationRequest, DelegationStrategy};
+use logos_messaging_a2a_node::WakuA2ANode;
+use logos_messaging_a2a_transport::memory::InMemoryTransport;
+use logos_messaging_a2a_transport::sds::ChannelConfig;
+use std::time::Duration;
+
+/// Fast SDS config that doesn't block on ACK, suitable for tests.
+fn fast_config() -> ChannelConfig {
+    ChannelConfig {
+        ack_timeout: Duration::from_millis(1),
+        max_retries: 0,
+        ..Default::default()
+    }
+}
+
+/// Helper: create a node with fast SDS config and announce its presence.
+async fn make_announced_node(
+    name: &str,
+    capabilities: Vec<&str>,
+    transport: InMemoryTransport,
+) -> WakuA2ANode<InMemoryTransport> {
+    let caps = capabilities.into_iter().map(String::from).collect();
+    let node = WakuA2ANode::with_config(
+        name,
+        &format!("{name} agent"),
+        caps,
+        transport,
+        fast_config(),
+    );
+    node.announce_presence().await.unwrap();
+    // Subscribe to own task topic (lazy init)
+    node.poll_tasks().await.unwrap();
+    node
+}
+
+/// Helper: run a simple echo-agent loop that responds to one task.
+async fn echo_once(node: &WakuA2ANode<InMemoryTransport>) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while tokio::time::Instant::now() < deadline {
+        let tasks = node.poll_tasks().await.unwrap();
+        for task in &tasks {
+            if task.result.is_none() {
+                let reply = format!("echo: {}", task.text().unwrap_or(""));
+                node.respond(task, &reply).await.unwrap();
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("echo_once timed out waiting for a task");
+}
+
+#[tokio::test]
+async fn delegate_task_to_first_available_peer() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+
+    // Orchestrator polls presence to discover worker
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-001".to_string(),
+        subtask_text: "Hello worker".to_string(),
+        strategy: DelegationStrategy::FirstAvailable,
+        timeout_secs: 5,
+    };
+
+    // Worker echoes in background
+    let worker_handle = tokio::spawn(async move {
+        echo_once(&worker).await;
+    });
+
+    let result = orchestrator.delegate_task(&request).await.unwrap();
+    worker_handle.await.unwrap();
+
+    assert!(result.success);
+    assert_eq!(result.parent_task_id, "parent-001");
+    assert!(result.result_text.is_some());
+    assert!(result.result_text.unwrap().contains("echo: Hello worker"));
+    assert!(result.error.is_none());
+}
+
+#[tokio::test]
+async fn delegate_task_with_capability_match() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let summarizer = make_announced_node("summarizer", vec!["summarize"], transport.clone()).await;
+    let _coder = make_announced_node("coder", vec!["code"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-002".to_string(),
+        subtask_text: "Summarize this".to_string(),
+        strategy: DelegationStrategy::CapabilityMatch {
+            capability: "summarize".to_string(),
+        },
+        timeout_secs: 5,
+    };
+
+    let summarizer_handle = tokio::spawn(async move {
+        echo_once(&summarizer).await;
+    });
+
+    let result = orchestrator.delegate_task(&request).await.unwrap();
+    summarizer_handle.await.unwrap();
+
+    assert!(result.success);
+    assert_eq!(result.parent_task_id, "parent-002");
+    assert!(result.result_text.unwrap().contains("echo: Summarize this"));
+}
+
+#[tokio::test]
+async fn delegate_task_no_peers_fails() {
+    let transport = InMemoryTransport::new();
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+
+    // Don't create any workers — no peers in the map
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-003".to_string(),
+        subtask_text: "Nobody home".to_string(),
+        strategy: DelegationStrategy::FirstAvailable,
+        timeout_secs: 1,
+    };
+
+    let err = orchestrator.delegate_task(&request).await.unwrap_err();
+    assert!(err.to_string().contains("no live peers"));
+}
+
+#[tokio::test]
+async fn delegate_task_no_matching_capability_fails() {
+    let transport = InMemoryTransport::new();
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let _worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-004".to_string(),
+        subtask_text: "Need image processing".to_string(),
+        strategy: DelegationStrategy::CapabilityMatch {
+            capability: "image".to_string(),
+        },
+        timeout_secs: 1,
+    };
+
+    let err = orchestrator.delegate_task(&request).await.unwrap_err();
+    assert!(err.to_string().contains("no live peers with capability"));
+}
+
+#[tokio::test]
+async fn delegate_task_timeout_returns_failure_result() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    // Worker announces but never responds
+    let _silent_worker = make_announced_node("silent", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-005".to_string(),
+        subtask_text: "No reply expected".to_string(),
+        strategy: DelegationStrategy::FirstAvailable,
+        timeout_secs: 1,
+    };
+
+    let result = orchestrator.delegate_task(&request).await.unwrap();
+    assert!(!result.success);
+    assert_eq!(result.error, Some("delegation timed out".to_string()));
+    assert!(result.result_text.is_none());
+}
+
+#[tokio::test]
+async fn delegate_broadcast_collects_multiple_responses() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker_a = make_announced_node("worker-a", vec!["text"], transport.clone()).await;
+    let worker_b = make_announced_node("worker-b", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-006".to_string(),
+        subtask_text: "Broadcast task".to_string(),
+        strategy: DelegationStrategy::CapabilityMatch {
+            capability: "text".to_string(),
+        },
+        timeout_secs: 10,
+    };
+
+    // Both workers echo in background
+    let ha = tokio::spawn(async move { echo_once(&worker_a).await });
+    let hb = tokio::spawn(async move { echo_once(&worker_b).await });
+
+    let results = orchestrator.delegate_broadcast(&request).await.unwrap();
+    ha.await.unwrap();
+    hb.await.unwrap();
+
+    assert_eq!(results.len(), 2);
+    // At least one should succeed (both workers are echoing)
+    let successes: Vec<_> = results.iter().filter(|r| r.success).collect();
+    assert!(
+        !successes.is_empty(),
+        "at least one broadcast delegate should succeed"
+    );
+    for r in &successes {
+        assert_eq!(r.parent_task_id, "parent-006");
+        assert!(r
+            .result_text
+            .as_ref()
+            .unwrap()
+            .contains("echo: Broadcast task"));
+    }
+}
+
+#[tokio::test]
+async fn delegate_broadcast_no_peers_fails() {
+    let transport = InMemoryTransport::new();
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-007".to_string(),
+        subtask_text: "Nobody".to_string(),
+        strategy: DelegationStrategy::BroadcastCollect,
+        timeout_secs: 1,
+    };
+
+    let err = orchestrator.delegate_broadcast(&request).await.unwrap_err();
+    assert!(err.to_string().contains("no live peers"));
+}
+
+#[tokio::test]
+async fn delegate_task_default_timeout_when_zero() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-008".to_string(),
+        subtask_text: "Quick task".to_string(),
+        strategy: DelegationStrategy::FirstAvailable,
+        timeout_secs: 0, // should use default
+    };
+
+    let worker_handle = tokio::spawn(async move {
+        echo_once(&worker).await;
+    });
+
+    let result = orchestrator.delegate_task(&request).await.unwrap();
+    worker_handle.await.unwrap();
+
+    assert!(result.success);
+}
+
+#[tokio::test]
+async fn delegate_broadcast_partial_timeout() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+    // silent_worker announces but never responds
+    let _silent = make_announced_node("silent", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-009".to_string(),
+        subtask_text: "Partial broadcast".to_string(),
+        strategy: DelegationStrategy::CapabilityMatch {
+            capability: "text".to_string(),
+        },
+        timeout_secs: 2,
+    };
+
+    let worker_handle = tokio::spawn(async move {
+        echo_once(&worker).await;
+    });
+
+    let results = orchestrator.delegate_broadcast(&request).await.unwrap();
+    worker_handle.await.unwrap();
+
+    assert_eq!(results.len(), 2);
+    let successes = results.iter().filter(|r| r.success).count();
+    let failures = results.iter().filter(|r| !r.success).count();
+    // One should succeed (worker), one should fail (silent)
+    assert_eq!(successes, 1);
+    assert_eq!(failures, 1);
+}
+
+#[tokio::test]
+async fn delegation_result_carries_correct_subtask_id() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "parent-010".to_string(),
+        subtask_text: "Check subtask ID".to_string(),
+        strategy: DelegationStrategy::FirstAvailable,
+        timeout_secs: 5,
+    };
+
+    let worker_handle = tokio::spawn(async move {
+        echo_once(&worker).await;
+    });
+
+    let result = orchestrator.delegate_task(&request).await.unwrap();
+    worker_handle.await.unwrap();
+
+    assert!(result.success);
+    // subtask_id should be a valid UUID (not empty)
+    assert!(!result.subtask_id.is_empty());
+    assert_ne!(result.subtask_id, result.parent_task_id);
+}


### PR DESCRIPTION
## Purpose

Implements #117: multi-agent task delegation. Allows an orchestrator node to decompose tasks into subtasks and forward them to capable peers discovered via presence, collecting results with configurable timeouts.

## Approach

- **Core types** (`logos-messaging-a2a-core`): Added `DelegationStrategy` (FirstAvailable, BroadcastCollect, CapabilityMatch), `DelegationRequest`, and `DelegationResult` with serde serialization following existing envelope patterns.
- **Node delegation** (`logos-messaging-a2a-node`): Added `delegate_task()` for single-peer delegation and `delegate_broadcast()` for multi-peer fan-out on `WakuA2ANode<T>`. Uses raw transport publish (bypasses SDS) since delegation has its own timeout-based response polling.
- **CLI subcommand** (`logos-messaging-a2a-cli`): Added `task delegate` with `--to`, `--capability`, `--broadcast`, `--timeout`, and `--parent-id` flags.

## How to Test

```bash
# Unit tests (core serialization + edge cases)
~/.cargo/bin/cargo test -p logos-messaging-a2a-core -- delegation

# Integration tests (10 tests using InMemoryTransport)
~/.cargo/bin/cargo test -p logos-messaging-a2a-node --test delegation

# Full workspace
~/.cargo/bin/cargo test --workspace
```

## Dependencies

No new crate dependencies. Uses existing `anyhow`, `serde`, `serde_json`, `tokio`, and workspace crates.

## Future Work

- Weighted/round-robin delegation strategies
- Retry with fallback peers on delegation failure
- Delegation chain depth limits
- Metrics/tracing for delegation latency

## Checklist

- [x] Core types with serde serialization and unit tests
- [x] Node delegation module following existing patterns (presence, discovery)
- [x] 10 integration tests covering happy path, error cases, timeouts, broadcast
- [x] CLI subcommand with clap derive
- [x] `cargo fmt`, `cargo clippy`, `cargo test --workspace` all pass
- [x] P2P only — no HTTP endpoints