### PR TITLE
docs: add task delegation documentation and example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,7 @@ dependencies = [
  "chacha20poly1305",
  "criterion",
  "hex",
+ "proptest",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ path = "examples/two_agents.rs"
 [[example]]
 name = "presence_discovery"
 path = "examples/presence_discovery.rs"
+
+[[example]]
+name = "task_delegation"
+path = "examples/task_delegation.rs"

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ LOGOS_CORE_LIB_DIR=/path/to/sdk/lib make demo-logos-core-real
 | `logos-messaging-a2a-core` | A2A types: `AgentCard`, `Task`, `Message`, `Part` |
 | `logos-messaging-a2a-transport` | `Transport` trait + nwaku REST + `InMemoryTransport` + `LogosCoreDeliveryTransport` + SDS reliability |
 | `logos-messaging-a2a-storage` | `StorageBackend` trait + Logos Storage (Codex) REST + `LogosCoreStorageBackend` |
-| `logos-messaging-a2a-node` | A2A node: announce, discover, send/receive tasks, presence, payments |
+| `logos-messaging-a2a-node` | A2A node: announce, discover, send/receive tasks, presence, payments, delegation |
 | `logos-messaging-a2a-execution` | `ExecutionBackend` trait + Status Network (EVM) + LEZ backends for on-chain payments & agent registration |
 | `logos-messaging-a2a-cli` | CLI for interacting with the network |
 | `logos-messaging-a2a-mcp` | MCP bridge — expose agents as tools for Claude, Cursor, etc. |
@@ -296,6 +296,7 @@ cargo run -p logos-messaging-a2a-cli -- --waku http://localhost:8645 <command>
 | `task send --to <pubkey> --text <msg>` | Send a task to an agent |
 | `task status --id <uuid>` | Check task status / poll for response |
 | `task stream --id <uuid> [--timeout <s>]` | Follow a task's streaming output |
+| `task delegate --text <msg> [--to <pk>] [--capability <c>] [--broadcast]` | Delegate a subtask to a peer agent |
 | `presence announce --name <n>` | Announce this agent on the presence topic |
 | `presence discover [--capability <c>]` | Listen for presence announcements |
 | `presence peers [--capability <c>]` | Discover and list unique peers |
@@ -430,6 +431,63 @@ let sender = WakuA2ANode::new("client", "Client", vec![], transport.clone())
 Currently supported backends: `StatusNetworkBackend` (Status Network Sepolia).
 `LezExecutionBackend` is stubbed for future LEZ chain support.
 
+## Task Delegation
+
+An orchestrator agent can decompose work into subtasks and delegate them to
+peer agents discovered via presence. Delegation uses the live `PeerMap` to find
+suitable peers by capability and sends each subtask as a regular A2A `Task`,
+polling for the result within a configurable timeout.
+
+### Delegation strategies
+
+| Strategy | Behaviour |
+|----------|-----------|
+| `FirstAvailable` | Pick the first live peer (any capability) |
+| `CapabilityMatch { capability }` | Pick a peer that advertises a specific capability |
+| `BroadcastCollect` | Send the subtask to **all** matching peers and collect every response |
+
+### API usage
+
+```rust
+use logos_messaging_a2a::{DelegationRequest, DelegationStrategy, WakuA2ANode};
+
+// Build a delegation request
+let request = DelegationRequest {
+    parent_task_id: "task-001".to_string(),
+    subtask_text: "Summarize this document".to_string(),
+    strategy: DelegationStrategy::CapabilityMatch {
+        capability: "summarize".to_string(),
+    },
+    timeout_secs: 30,
+};
+
+// Delegate to a single matching peer
+let result = node.delegate_task(&request).await?;
+println!("success={} result={:?}", result.success, result.result_text);
+
+// Or broadcast to all matching peers
+let results = node.delegate_broadcast(&request).await?;
+for r in &results {
+    println!("[{}] {}", r.agent_id, r.result_text.as_deref().unwrap_or("–"));
+}
+```
+
+### CLI usage
+
+```bash
+# Delegate by capability (auto-discovers a peer)
+lmao task delegate --capability summarize --text "Summarize this"
+
+# Delegate to a specific agent
+lmao task delegate --to 02abcdef... --text "Do something"
+
+# Broadcast to all matching peers
+lmao task delegate --capability text --text "Hello everyone" --broadcast
+
+# Custom timeout and parent task ID
+lmao task delegate --capability code --text "Review PR" --parent-id task-42 --timeout 60
+```
+
 ## Task Streaming
 
 Agents can send partial results incrementally as **stream chunks** over
@@ -543,6 +601,7 @@ module/
 - [x] x402 payment flow — auto-pay, payment gating, on-chain verification, replay protection
 - [x] End-to-end demo — two agents, one task, payment flow, InMemoryTransport
 - [x] Task streaming — partial results over dedicated Waku stream topics
+- [x] Task delegation — multi-agent subtask forwarding with capability-based routing
 - [ ] Logos Chat SDK — Double Ratchet for forward secrecy
 - [ ] LEZ agent registry — on-chain AgentCards via SPELbook
 - [ ] Logos Core plugin — packaged `.lgx` module

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,7 @@
 │  │  • poll_tasks()   — receive incoming tasks              │         │
 │  │  • respond()      — reply to a task                     │         │
 │  │  • presence       — PeerMap with heartbeat broadcasts   │         │
+│  │  • delegate_task()— forward subtasks to capable peers  │         │
 │  │                                                         │         │
 │  │  Identity: secp256k1 keypair                            │         │
 │  │  Integrates: crypto, execution, storage, transport      │         │
@@ -382,6 +383,60 @@ deduplicates by public key:
 Implementation:
 - `logos-messaging-a2a-core::PresenceAnnouncement` — wire type + signing.
 - `logos-messaging-a2a-node::presence::{PeerInfo, PeerMap}` — live peer tracking.
+
+## Task Delegation
+
+An orchestrator agent decomposes a parent task into subtasks and forwards
+each subtask to a peer chosen from the live `PeerMap`.
+
+```
+Orchestrator               PeerMap                  Worker A / Worker B
+  │                           │                           │
+  │── DelegationRequest ─────▶│                           │
+  │   { parent_task_id,       │  strategy:                │
+  │     subtask_text,         │  FirstAvailable           │
+  │     strategy,             │  CapabilityMatch("code")  │
+  │     timeout_secs }        │  BroadcastCollect         │
+  │                           │                           │
+  │   select peer(s) ◀───────│                           │
+  │                           │                           │
+  │── Task(subtask) ─────────┼──────────────────────────▶│
+  │   via transport.publish   │                           │
+  │                           │                           │
+  │   poll_tasks() loop       │                           │
+  │   (up to timeout_secs)    │                           │
+  │                           │                           │
+  │◀── DelegationResult ─────┼───────────────────────────│
+  │   { success, result_text, │                           │
+  │     agent_id, error }     │                           │
+```
+
+### Key types
+
+```
+DelegationStrategy (tagged enum)
+├── FirstAvailable                pick any live peer
+├── CapabilityMatch { capability } pick a peer with matching capability
+└── BroadcastCollect              send to all, collect every response
+
+DelegationRequest
+├── parent_task_id: String
+├── subtask_text: String
+├── strategy: DelegationStrategy
+└── timeout_secs: u64             (0 = default 30s)
+
+DelegationResult
+├── parent_task_id: String
+├── subtask_id: String
+├── agent_id: String              pubkey of the worker
+├── result_text: Option<String>
+├── success: bool
+└── error: Option<String>
+```
+
+Implementation:
+- `logos-messaging-a2a-core::delegation` — wire types.
+- `logos-messaging-a2a-node::delegation` — `delegate_task()` and `delegate_broadcast()`.
 
 ## MCP Bridge Architecture
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,24 @@ Demonstrates the complete LMAO agent lifecycle: presence broadcast, peer discove
 cargo run --example presence_discovery
 ```
 
+## task_delegation — Multi-Agent Subtask Forwarding
+
+Demonstrates an orchestrator agent that decomposes a parent task into subtasks and delegates each one to a specialist peer discovered via presence — capability-based routing with `DelegationStrategy`.
+
+**What happens:**
+
+1. **Orchestrator**, **Summarizer**, and **Translator** are created with `InMemoryTransport`
+2. All three agents broadcast signed presence announcements
+3. Orchestrator discovers peers and their capabilities via the peer map
+4. Orchestrator delegates a summarization subtask — routed to the summarizer via `CapabilityMatch`
+5. Orchestrator delegates a translation subtask — routed to the translator via `CapabilityMatch`
+6. Each worker processes its subtask and responds
+7. Orchestrator collects `DelegationResult`s with success status and result text
+
+```bash
+cargo run --example task_delegation
+```
+
 ## echo_agent — Simple Echo
 
 Single agent that echoes back any message it receives.

--- a/examples/task_delegation.rs
+++ b/examples/task_delegation.rs
@@ -1,0 +1,166 @@
+//! Task delegation example: multi-agent subtask forwarding.
+//!
+//! Demonstrates an orchestrator agent that decomposes a task into subtasks
+//! and delegates them to specialist peers discovered via presence — all
+//! peer-to-peer over an in-memory transport with no external dependencies.
+//!
+//! Usage:
+//!   cargo run --example task_delegation
+
+use anyhow::Result;
+use logos_messaging_a2a::{DelegationRequest, DelegationStrategy, InMemoryTransport, WakuA2ANode};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("=== LMAO Task Delegation: Multi-Agent Subtask Forwarding ===\n");
+
+    // ── 1. Create three agents on the same in-memory transport ───────────
+    let transport = InMemoryTransport::new();
+
+    let orchestrator = WakuA2ANode::new(
+        "orchestrator",
+        "Orchestrator: decomposes and delegates tasks",
+        vec!["orchestration".to_string()],
+        transport.clone(),
+    );
+    let summarizer = WakuA2ANode::new(
+        "summarizer",
+        "Summarizer: produces summaries",
+        vec!["summarize".to_string()],
+        transport.clone(),
+    );
+    let translator = WakuA2ANode::new(
+        "translator",
+        "Translator: translates text",
+        vec!["translate".to_string()],
+        transport.clone(),
+    );
+
+    println!("Created orchestrator ({}...)", &orchestrator.pubkey()[..16]);
+    println!("Created summarizer   ({}...)", &summarizer.pubkey()[..16]);
+    println!("Created translator   ({}...)\n", &translator.pubkey()[..16]);
+
+    // ── 2. All agents broadcast presence ─────────────────────────────────
+    orchestrator.announce_presence().await?;
+    summarizer.announce_presence().await?;
+    translator.announce_presence().await?;
+    println!("[all]          Announced presence\n");
+
+    // ── 3. Orchestrator discovers peers ──────────────────────────────────
+    orchestrator.poll_presence().await?;
+
+    let all_peers = orchestrator.peers().all_live();
+    println!("[orchestrator] Discovered {} peer(s):", all_peers.len());
+    for (id, info) in &all_peers {
+        println!(
+            "               -> {} ({}...) capabilities: {:?}",
+            info.name,
+            &id[..16],
+            info.capabilities
+        );
+    }
+    println!();
+
+    // ── 4. Ensure workers are subscribed before delegation ───────────────
+    //
+    // In a real network, workers would already be polling. In this
+    // synchronous demo we trigger an initial poll so that the in-memory
+    // transport creates the subscription channel.
+    summarizer.poll_tasks().await?;
+    translator.poll_tasks().await?;
+
+    // ── 5. Spawn worker loops that respond to incoming tasks ─────────────
+    //
+    // Each worker runs in a background task, polling for incoming subtasks
+    // and responding with a simulated result.
+    let summarizer_handle = {
+        let transport = transport.clone();
+        let _ = transport; // keep transport alive
+        tokio::spawn(async move {
+            loop {
+                let tasks = summarizer.poll_tasks().await.unwrap();
+                for task in &tasks {
+                    let text = task.text().unwrap_or("");
+                    println!(
+                        "[summarizer]   Received subtask {}: \"{}\"",
+                        &task.id[..8],
+                        text
+                    );
+                    let summary = format!("Summary of: {text}");
+                    summarizer.respond(task, &summary).await.unwrap();
+                    println!("[summarizer]   Responded: \"{summary}\"");
+                }
+                if !tasks.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+    };
+
+    let translator_handle = {
+        let transport = transport.clone();
+        let _ = transport;
+        tokio::spawn(async move {
+            loop {
+                let tasks = translator.poll_tasks().await.unwrap();
+                for task in &tasks {
+                    let text = task.text().unwrap_or("");
+                    println!(
+                        "[translator]   Received subtask {}: \"{}\"",
+                        &task.id[..8],
+                        text
+                    );
+                    let translation = format!("Translated: {text}");
+                    translator.respond(task, &translation).await.unwrap();
+                    println!("[translator]   Responded: \"{translation}\"");
+                }
+                if !tasks.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+    };
+
+    // ── 6. Orchestrator delegates subtasks ────────────────────────────────
+
+    // 6a. Delegate a summarization subtask (capability-based routing)
+    println!("[orchestrator] Delegating summarization subtask...");
+    let summarize_request = DelegationRequest {
+        parent_task_id: "parent-001".to_string(),
+        subtask_text: "The LMAO protocol enables decentralized agent communication.".to_string(),
+        strategy: DelegationStrategy::CapabilityMatch {
+            capability: "summarize".to_string(),
+        },
+        timeout_secs: 5,
+    };
+    let summarize_result = orchestrator.delegate_task(&summarize_request).await?;
+    println!(
+        "[orchestrator] Summarization result: success={}, text={:?}\n",
+        summarize_result.success, summarize_result.result_text
+    );
+
+    // 6b. Delegate a translation subtask (capability-based routing)
+    println!("[orchestrator] Delegating translation subtask...");
+    let translate_request = DelegationRequest {
+        parent_task_id: "parent-001".to_string(),
+        subtask_text: "Hello, world!".to_string(),
+        strategy: DelegationStrategy::CapabilityMatch {
+            capability: "translate".to_string(),
+        },
+        timeout_secs: 5,
+    };
+    let translate_result = orchestrator.delegate_task(&translate_request).await?;
+    println!(
+        "[orchestrator] Translation result: success={}, text={:?}\n",
+        translate_result.success, translate_result.result_text
+    );
+
+    // ── 7. Wait for workers to finish ────────────────────────────────────
+    let _ = summarizer_handle.await;
+    let _ = translator_handle.await;
+
+    println!("Done! Orchestrator delegated subtasks to specialist agents via presence discovery.");
+    Ok(())
+}


### PR DESCRIPTION
## Purpose

Document the task delegation feature (merged in PR #118) in README.md, architecture docs, and add a runnable example.

## Approach

- Added **Task Delegation** section to README.md covering delegation strategies (`FirstAvailable`, `CapabilityMatch`, `BroadcastCollect`), API usage, and CLI commands
- Added `task delegate` to the CLI command table in README
- Updated the `logos-messaging-a2a-node` crate description to mention delegation
- Added delegation roadmap item as completed
- Added `examples/task_delegation.rs`: 3-agent demo (orchestrator/summarizer/translator) with capability-based subtask forwarding using `InMemoryTransport`
- Updated `examples/README.md` with the new example description
- Updated `docs/architecture.md` with delegation sequence diagram and key types

## How to Test

- [ ] `cargo build --examples` — compiles cleanly
- [ ] `cargo run --example task_delegation` — runs the 3-agent delegation demo
- [ ] `cargo clippy --workspace -- -D warnings` — no warnings
- [ ] `cargo test --workspace` — all tests pass
- [ ] Review README Task Delegation section for accuracy

## Dependencies

- PR #118 (task delegation feature) — already merged

## Future Work

- None — this is purely documentation and example code

## Checklist

- [x] Code compiles (`cargo build --examples`)
- [x] Formatted (`cargo fmt --all`)
- [x] Linted (`cargo clippy --workspace -- -D warnings`)
- [x] Tests pass (`cargo test --workspace`)
- [x] README updated
- [x] Example added and documented