### PR TITLE
feat(delegation): add RoundRobin strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ polling for the result within a configurable timeout.
 | `FirstAvailable` | Pick the first live peer (any capability) |
 | `CapabilityMatch { capability }` | Pick a peer that advertises a specific capability |
 | `BroadcastCollect` | Send the subtask to **all** matching peers and collect every response |
+| `RoundRobin` | Distribute subtasks evenly across peers using an atomic rotating counter |
 
 ### API usage
 
@@ -486,6 +487,9 @@ lmao task delegate --capability text --text "Hello everyone" --broadcast
 
 # Custom timeout and parent task ID
 lmao task delegate --capability code --text "Review PR" --parent-id task-42 --timeout 60
+
+# Round-robin across all live peers
+lmao task delegate --strategy round-robin --text "Distribute this evenly"
 ```
 
 ## Task Streaming

--- a/crates/logos-messaging-a2a-cli/src/cli.rs
+++ b/crates/logos-messaging-a2a-cli/src/cli.rs
@@ -107,6 +107,9 @@ pub enum TaskAction {
         /// Broadcast to all matching peers instead of just one
         #[arg(long)]
         broadcast: bool,
+        /// Delegation strategy: first-available, broadcast, round-robin
+        #[arg(long)]
+        strategy: Option<String>,
     },
 }
 
@@ -627,6 +630,7 @@ mod tests {
                         parent_id,
                         timeout,
                         broadcast,
+                        strategy,
                     },
             } => {
                 assert_eq!(to, Some("02abcdef".to_string()));
@@ -635,6 +639,7 @@ mod tests {
                 assert_eq!(parent_id, "cli");
                 assert_eq!(timeout, 30);
                 assert!(!broadcast);
+                assert!(strategy.is_none());
             }
             _ => panic!("expected Task Delegate"),
         }
@@ -714,6 +719,29 @@ mod tests {
                 action: TaskAction::Delegate { timeout, .. },
             } => {
                 assert_eq!(timeout, 5);
+            }
+            _ => panic!("expected Task Delegate"),
+        }
+    }
+
+    #[test]
+    fn task_delegate_round_robin_strategy() {
+        let cli = try_parse(&[
+            "cli",
+            "task",
+            "delegate",
+            "--text",
+            "round robin task",
+            "--strategy",
+            "round-robin",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Task {
+                action: TaskAction::Delegate { strategy, text, .. },
+            } => {
+                assert_eq!(strategy, Some("round-robin".to_string()));
+                assert_eq!(text, "round robin task");
             }
             _ => panic!("expected Task Delegate"),
         }

--- a/crates/logos-messaging-a2a-cli/src/task.rs
+++ b/crates/logos-messaging-a2a-cli/src/task.rs
@@ -98,6 +98,7 @@ pub async fn handle(
             parent_id,
             timeout,
             broadcast,
+            strategy,
         } => {
             let node = build_node(
                 "cli-delegator",
@@ -129,6 +130,22 @@ pub async fn handle(
                     Err(e) => eprintln!("Failed to delegate: {}", e),
                 }
                 return Ok(());
+            } else if let Some(ref s) = strategy {
+                match s.as_str() {
+                    "round-robin" => DelegationStrategy::RoundRobin,
+                    "broadcast" => DelegationStrategy::BroadcastCollect,
+                    "first-available" => DelegationStrategy::FirstAvailable,
+                    other => {
+                        if let Some(ref cap) = capability {
+                            DelegationStrategy::CapabilityMatch {
+                                capability: cap.clone(),
+                            }
+                        } else {
+                            eprintln!("Unknown strategy '{other}', using first-available");
+                            DelegationStrategy::FirstAvailable
+                        }
+                    }
+                }
             } else if let Some(ref cap) = capability {
                 DelegationStrategy::CapabilityMatch {
                     capability: cap.clone(),

--- a/crates/logos-messaging-a2a-core/src/delegation.rs
+++ b/crates/logos-messaging-a2a-core/src/delegation.rs
@@ -8,6 +8,8 @@ pub enum DelegationStrategy {
     FirstAvailable,
     /// Broadcast to all matching peers and collect responses.
     BroadcastCollect,
+    /// Distribute subtasks evenly across peers using round-robin rotation.
+    RoundRobin,
     /// Pick a peer that advertises a specific capability.
     CapabilityMatch {
         /// The required capability string.
@@ -66,6 +68,15 @@ mod tests {
         let strategy = DelegationStrategy::BroadcastCollect;
         let json = serde_json::to_string(&strategy).unwrap();
         assert!(json.contains("\"type\":\"broadcast_collect\""));
+        let deserialized: DelegationStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(strategy, deserialized);
+    }
+
+    #[test]
+    fn test_delegation_strategy_round_robin_serialization() {
+        let strategy = DelegationStrategy::RoundRobin;
+        let json = serde_json::to_string(&strategy).unwrap();
+        assert!(json.contains("\"type\":\"round_robin\""));
         let deserialized: DelegationStrategy = serde_json::from_str(&json).unwrap();
         assert_eq!(strategy, deserialized);
     }
@@ -187,6 +198,7 @@ mod tests {
         let variants: Vec<DelegationStrategy> = vec![
             DelegationStrategy::FirstAvailable,
             DelegationStrategy::BroadcastCollect,
+            DelegationStrategy::RoundRobin,
             DelegationStrategy::CapabilityMatch {
                 capability: "x".to_string(),
             },

--- a/crates/logos-messaging-a2a-node/src/delegation.rs
+++ b/crates/logos-messaging-a2a-node/src/delegation.rs
@@ -6,6 +6,7 @@ use logos_messaging_a2a_core::{
     topics, A2AEnvelope, DelegationRequest, DelegationResult, DelegationStrategy, Task,
 };
 use logos_messaging_a2a_transport::Transport;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use crate::WakuA2ANode;
@@ -55,6 +56,19 @@ impl<T: Transport> WakuA2ANode<T> {
                     .next()
                     .context("no live peers available for broadcast delegation")?
             }
+            DelegationStrategy::RoundRobin => {
+                let peers: Vec<String> = self
+                    .peers()
+                    .all_live()
+                    .into_iter()
+                    .map(|(id, _)| id)
+                    .collect();
+                if peers.is_empty() {
+                    anyhow::bail!("no live peers available for round-robin delegation");
+                }
+                let idx = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) % peers.len();
+                peers.into_iter().nth(idx).unwrap()
+            }
         };
 
         self.delegate_to_peer(request, &peer_id, timeout_secs).await
@@ -80,6 +94,7 @@ impl<T: Transport> WakuA2ANode<T> {
                 .into_iter()
                 .map(|(id, _)| id)
                 .collect(),
+            // RoundRobin, BroadcastCollect, FirstAvailable all broadcast to every peer
             _ => self
                 .peers()
                 .all_live()

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -29,6 +29,7 @@ use logos_messaging_a2a_transport::sds::{ChannelConfig, MessageChannel};
 use logos_messaging_a2a_transport::Transport;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -74,6 +75,8 @@ pub struct WakuA2ANode<T: Transport> {
     /// Optional retry configuration for exponential-backoff retries of
     /// transport send failures.
     retry_config: Option<RetryConfig>,
+    /// Atomic counter for round-robin delegation peer selection.
+    round_robin_counter: AtomicUsize,
 }
 
 impl<T: Transport> WakuA2ANode<T> {
@@ -115,6 +118,7 @@ impl<T: Transport> WakuA2ANode<T> {
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
             retry_config: None,
+            round_robin_counter: AtomicUsize::new(0),
         }
     }
 
@@ -164,6 +168,7 @@ impl<T: Transport> WakuA2ANode<T> {
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
             retry_config: None,
+            round_robin_counter: AtomicUsize::new(0),
         }
     }
 
@@ -210,6 +215,7 @@ impl<T: Transport> WakuA2ANode<T> {
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
             retry_config: None,
+            round_robin_counter: AtomicUsize::new(0),
         }
     }
 
@@ -327,6 +333,7 @@ impl<T: Transport> WakuA2ANode<T> {
             registry: None,
             stream_chunks: std::sync::Mutex::new(HashMap::new()),
             retry_config: None,
+            round_robin_counter: AtomicUsize::new(0),
         }
     }
 
@@ -391,6 +398,11 @@ impl<T: Transport> WakuA2ANode<T> {
     /// Get the current retry configuration, if any.
     pub fn retry_config(&self) -> Option<&RetryConfig> {
         self.retry_config.as_ref()
+    }
+
+    /// Get a reference to the round-robin counter (for delegation).
+    pub fn round_robin_counter(&self) -> &AtomicUsize {
+        &self.round_robin_counter
     }
 
     /// Create a new conversation session with a peer.

--- a/crates/logos-messaging-a2a-node/tests/delegation.rs
+++ b/crates/logos-messaging-a2a-node/tests/delegation.rs
@@ -339,3 +339,209 @@ async fn delegation_result_carries_correct_subtask_id() {
     assert!(!result.subtask_id.is_empty());
     assert_ne!(result.subtask_id, result.parent_task_id);
 }
+
+// ── Round-Robin Delegation Tests ──
+
+/// Helper: run an echo-agent loop that responds to N tasks.
+async fn echo_n(node: &WakuA2ANode<InMemoryTransport>, n: usize) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut count = 0;
+    while count < n && tokio::time::Instant::now() < deadline {
+        let tasks = node.poll_tasks().await.unwrap();
+        for task in &tasks {
+            if task.result.is_none() {
+                let reply = format!(
+                    "echo from {}: {}",
+                    node.card.name,
+                    task.text().unwrap_or("")
+                );
+                node.respond(task, &reply).await.unwrap();
+                count += 1;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(count, n, "echo_n: expected {n} tasks but got {count}");
+}
+
+#[tokio::test]
+async fn round_robin_distributes_evenly() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker_a = make_announced_node("worker-a", vec!["text"], transport.clone()).await;
+    let worker_b = make_announced_node("worker-b", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let peers = orchestrator.peers().all_live();
+    assert_eq!(peers.len(), 2, "should see exactly 2 workers");
+
+    // Collect peer IDs in the order the peer map returns them
+    let peer_ids: Vec<String> = peers.into_iter().map(|(id, _)| id).collect();
+
+    // Spawn workers: each expects 2 tasks (4 total / 2 workers)
+    let wa = worker_a;
+    let wb = worker_b;
+    let ha = tokio::spawn(async move { echo_n(&wa, 2).await });
+    let hb = tokio::spawn(async move { echo_n(&wb, 2).await });
+
+    // Send 4 round-robin delegations
+    let mut agent_ids = Vec::new();
+    for i in 0..4 {
+        let request = DelegationRequest {
+            parent_task_id: format!("rr-parent-{i}"),
+            subtask_text: format!("round-robin task {i}"),
+            strategy: DelegationStrategy::RoundRobin,
+            timeout_secs: 5,
+        };
+        let result = orchestrator.delegate_task(&request).await.unwrap();
+        assert!(result.success, "task {i} should succeed");
+        agent_ids.push(result.agent_id);
+    }
+
+    ha.await.unwrap();
+    hb.await.unwrap();
+
+    // Should alternate: peer0, peer1, peer0, peer1
+    assert_eq!(agent_ids[0], peer_ids[0]);
+    assert_eq!(agent_ids[1], peer_ids[1]);
+    assert_eq!(agent_ids[2], peer_ids[0]);
+    assert_eq!(agent_ids[3], peer_ids[1]);
+}
+
+#[tokio::test]
+async fn round_robin_wraps_around() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker_a = make_announced_node("worker-a", vec!["text"], transport.clone()).await;
+    let worker_b = make_announced_node("worker-b", vec!["text"], transport.clone()).await;
+    let worker_c = make_announced_node("worker-c", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let peers = orchestrator.peers().all_live();
+    assert_eq!(peers.len(), 3, "should see exactly 3 workers");
+
+    let peer_ids: Vec<String> = peers.into_iter().map(|(id, _)| id).collect();
+
+    // Each worker expects 2 tasks (6 total / 3 workers)
+    let ha = tokio::spawn(async move { echo_n(&worker_a, 2).await });
+    let hb = tokio::spawn(async move { echo_n(&worker_b, 2).await });
+    let hc = tokio::spawn(async move { echo_n(&worker_c, 2).await });
+
+    // Send 6 round-robin delegations to wrap around twice
+    let mut agent_ids = Vec::new();
+    for i in 0..6 {
+        let request = DelegationRequest {
+            parent_task_id: format!("rr-wrap-{i}"),
+            subtask_text: format!("wrap task {i}"),
+            strategy: DelegationStrategy::RoundRobin,
+            timeout_secs: 5,
+        };
+        let result = orchestrator.delegate_task(&request).await.unwrap();
+        assert!(result.success, "task {i} should succeed");
+        agent_ids.push(result.agent_id);
+    }
+
+    ha.await.unwrap();
+    hb.await.unwrap();
+    hc.await.unwrap();
+
+    // Should cycle: 0, 1, 2, 0, 1, 2
+    for i in 0..6 {
+        assert_eq!(
+            agent_ids[i],
+            peer_ids[i % 3],
+            "task {i} should go to peer {}",
+            i % 3
+        );
+    }
+}
+
+#[tokio::test]
+async fn round_robin_single_peer() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker = make_announced_node("solo-worker", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let worker_pubkey = worker.pubkey().to_string();
+
+    // Worker expects 3 tasks
+    let wh = tokio::spawn(async move { echo_n(&worker, 3).await });
+
+    // All 3 tasks should go to the single peer
+    for i in 0..3 {
+        let request = DelegationRequest {
+            parent_task_id: format!("rr-single-{i}"),
+            subtask_text: format!("solo task {i}"),
+            strategy: DelegationStrategy::RoundRobin,
+            timeout_secs: 5,
+        };
+        let result = orchestrator.delegate_task(&request).await.unwrap();
+        assert!(result.success, "task {i} should succeed");
+        assert_eq!(
+            result.agent_id, worker_pubkey,
+            "all tasks should go to the single worker"
+        );
+    }
+
+    wh.await.unwrap();
+}
+
+#[tokio::test]
+async fn round_robin_no_peers_fails() {
+    let transport = InMemoryTransport::new();
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "rr-none".to_string(),
+        subtask_text: "Nobody home".to_string(),
+        strategy: DelegationStrategy::RoundRobin,
+        timeout_secs: 1,
+    };
+
+    let err = orchestrator.delegate_task(&request).await.unwrap_err();
+    assert!(err.to_string().contains("no live peers"));
+}
+
+#[tokio::test]
+async fn round_robin_broadcast_sends_to_all() {
+    let transport = InMemoryTransport::new();
+
+    let orchestrator =
+        make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+    let worker_a = make_announced_node("worker-a", vec!["text"], transport.clone()).await;
+    let worker_b = make_announced_node("worker-b", vec!["text"], transport.clone()).await;
+
+    orchestrator.poll_presence().await.unwrap();
+
+    let request = DelegationRequest {
+        parent_task_id: "rr-broadcast".to_string(),
+        subtask_text: "Broadcast via round-robin".to_string(),
+        strategy: DelegationStrategy::RoundRobin,
+        timeout_secs: 5,
+    };
+
+    let ha = tokio::spawn(async move { echo_once(&worker_a).await });
+    let hb = tokio::spawn(async move { echo_once(&worker_b).await });
+
+    let results = orchestrator.delegate_broadcast(&request).await.unwrap();
+    ha.await.unwrap();
+    hb.await.unwrap();
+
+    // Broadcast should send to all peers, like BroadcastCollect
+    assert_eq!(results.len(), 2);
+    let successes: Vec<_> = results.iter().filter(|r| r.success).collect();
+    assert!(!successes.is_empty(), "at least one should succeed");
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -397,6 +397,7 @@ Orchestrator               PeerMap                  Worker A / Worker B
   │     subtask_text,         │  FirstAvailable           │
   │     strategy,             │  CapabilityMatch("code")  │
   │     timeout_secs }        │  BroadcastCollect         │
+  │                           │  RoundRobin               │
   │                           │                           │
   │   select peer(s) ◀───────│                           │
   │                           │                           │
@@ -417,7 +418,8 @@ Orchestrator               PeerMap                  Worker A / Worker B
 DelegationStrategy (tagged enum)
 ├── FirstAvailable                pick any live peer
 ├── CapabilityMatch { capability } pick a peer with matching capability
-└── BroadcastCollect              send to all, collect every response
+├── BroadcastCollect              send to all, collect every response
+└── RoundRobin                    rotate through peers with atomic counter
 
 DelegationRequest
 ├── parent_task_id: String


### PR DESCRIPTION
## Purpose

Adds a `RoundRobin` delegation strategy that distributes subtasks evenly across available peers using an atomic rotating counter. This complements the existing `FirstAvailable`, `BroadcastCollect`, and `CapabilityMatch` strategies.

## Approach

- **Core type**: Added `RoundRobin` variant to `DelegationStrategy` tagged enum with serde support (`round_robin`)
- **Node state**: Added `AtomicUsize` round-robin counter to `WakuA2ANode`, initialized to 0 in all constructors
- **`delegate_task()`**: RoundRobin collects all live peers, picks one via `counter.fetch_add(1, Relaxed) % len`, ensuring even rotation
- **`delegate_broadcast()`**: RoundRobin falls through to broadcast-to-all behavior (same as BroadcastCollect)
- **CLI**: Added `--strategy` flag accepting `round-robin`, `broadcast`, `first-available`
- **Docs**: Updated README.md delegation table and CLI examples, updated docs/architecture.md diagram and key types

## How to Test

```bash
# Unit tests
cargo test -p logos-messaging-a2a-core delegation
# Integration tests (includes 5 new round-robin tests)
cargo test -p logos-messaging-a2a-node --test delegation
# Full workspace
cargo test --workspace
# CLI parsing
cargo test -p logos-messaging-a2a-cli
```

New round-robin integration tests:
- `round_robin_distributes_evenly` — 4 tasks across 2 peers, verifies alternating assignment
- `round_robin_wraps_around` — 6 tasks across 3 peers, verifies correct cycling
- `round_robin_single_peer` — all tasks go to the sole peer
- `round_robin_no_peers_fails` — errors when no peers available
- `round_robin_broadcast_sends_to_all` — broadcast mode sends to all peers

## Dependencies

None — uses only `std::sync::atomic::AtomicUsize` from stdlib.

## Future Work

- Weighted round-robin (priority-based distribution)
- Sticky round-robin with capability filtering

## Checklist

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace` passes (zero warnings)
- [x] `cargo test --workspace` passes (all tests green)
- [x] Documentation updated (README.md, docs/architecture.md)
- [x] New tests cover: even distribution, wrap-around, single peer, no peers, broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)