### PR TITLE
feat(cli): add session list and show subcommands

### DIFF
--- a/crates/logos-messaging-a2a-cli/src/cli.rs
+++ b/crates/logos-messaging-a2a-cli/src/cli.rs
@@ -42,6 +42,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: PresenceAction,
     },
+    /// Session management
+    Session {
+        #[command(subcommand)]
+        action: SessionAction,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -153,6 +158,18 @@ pub enum PresenceAction {
         /// How long to listen in one-shot mode (seconds)
         #[arg(long, default_value = "10")]
         timeout: u64,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SessionAction {
+    /// List all active sessions
+    List,
+    /// Show details of a specific session
+    Show {
+        /// Session ID (UUID)
+        #[arg(long)]
+        id: String,
     },
 }
 
@@ -751,5 +768,67 @@ mod tests {
     fn task_delegate_missing_text() {
         let err = try_parse(&["cli", "task", "delegate", "--to", "02ab"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    // ── Session List ──
+
+    #[test]
+    fn session_list_parses() {
+        let cli = try_parse(&["cli", "session", "list"]).unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::List,
+            } => {}
+            _ => panic!("expected Session List"),
+        }
+    }
+
+    // ── Session Show ──
+
+    #[test]
+    fn session_show_parses() {
+        let cli = try_parse(&[
+            "cli",
+            "session",
+            "show",
+            "--id",
+            "550e8400-e29b-41d4-a716-446655440000",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::Show { id },
+            } => {
+                assert_eq!(id, "550e8400-e29b-41d4-a716-446655440000");
+            }
+            _ => panic!("expected Session Show"),
+        }
+    }
+
+    #[test]
+    fn session_show_missing_id() {
+        let err = try_parse(&["cli", "session", "show"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn session_list_with_global_flags() {
+        let cli = try_parse(&[
+            "cli",
+            "--keyfile",
+            "/tmp/s.key",
+            "--encrypt",
+            "session",
+            "list",
+        ])
+        .unwrap();
+        assert_eq!(cli.keyfile, Some(PathBuf::from("/tmp/s.key")));
+        assert!(cli.encrypt);
+        match cli.command {
+            Commands::Session {
+                action: SessionAction::List,
+            } => {}
+            _ => panic!("expected Session List"),
+        }
     }
 }

--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -2,6 +2,7 @@ mod agent;
 mod cli;
 mod common;
 mod presence;
+mod session;
 mod task;
 
 use anyhow::Result;
@@ -30,5 +31,6 @@ async fn main() -> Result<()> {
         Commands::Agent { action } => agent::handle(action, transport, &identity).await,
         Commands::Task { action } => task::handle(action, transport, &identity).await,
         Commands::Presence { action } => presence::handle(action, transport, &identity).await,
+        Commands::Session { action } => session::handle(action, transport, &identity).await,
     }
 }

--- a/crates/logos-messaging-a2a-cli/src/session.rs
+++ b/crates/logos-messaging-a2a-cli/src/session.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
+
+use crate::cli::SessionAction;
+use crate::common::{build_node, IdentityConfig};
+
+pub async fn handle(
+    action: SessionAction,
+    transport: LogosMessagingTransport,
+    identity: &IdentityConfig,
+) -> Result<()> {
+    let node = build_node("cli-session", "CLI client", vec![], transport, identity)?;
+
+    match action {
+        SessionAction::List => {
+            let sessions = node.list_sessions();
+            if sessions.is_empty() {
+                println!("No active sessions.");
+            } else {
+                println!("{} session(s):", sessions.len());
+                for s in &sessions {
+                    println!("  {} peer={} tasks={}", s.id, s.peer, s.task_ids.len());
+                }
+            }
+        }
+        SessionAction::Show { id } => match node.get_session(&id) {
+            Some(s) => {
+                println!("{}", serde_json::to_string_pretty(&s)?);
+            }
+            None => {
+                eprintln!("Session {} not found.", id);
+            }
+        },
+    }
+
+    Ok(())
+}

--- a/crates/logos-messaging-a2a-node/src/session.rs
+++ b/crates/logos-messaging-a2a-node/src/session.rs
@@ -1,9 +1,10 @@
 //! Multi-turn conversation sessions between agents.
 
+use serde::Serialize;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A multi-turn conversation session between two agents.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Session {
     /// Unique session identifier (UUID v4).
     pub id: String,


### PR DESCRIPTION
## Summary
- Add `session list` and `session show --id <UUID>` CLI subcommands that wire up the existing `list_sessions()` and `get_session()` node-crate methods
- Derive `Serialize` on `Session` so `show` can emit pretty-printed JSON
- Add CLI parsing tests for session commands (list, show, missing id, global flags)

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all existing + new session tests)

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)