### PR TITLE
test(delegation): add inline unit tests for delegation module

### DIFF
--- a/crates/logos-messaging-a2a-node/src/delegation.rs
+++ b/crates/logos-messaging-a2a-node/src/delegation.rs
@@ -128,6 +128,9 @@ impl<T: Transport> WakuA2ANode<T> {
 
     /// Send a subtask to a specific peer and wait for a response.
     ///
+    /// This is an internal helper used by both [`delegate_task`] and
+    /// [`delegate_broadcast`].
+    ///
     /// Uses fire-and-forget send (like `respond`) rather than SDS reliable
     /// delivery, since delegation already has its own response-based timeout.
     async fn delegate_to_peer(
@@ -182,5 +185,399 @@ impl<T: Transport> WakuA2ANode<T> {
             success: false,
             error: Some("delegation timed out".to_string()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::WakuA2ANode;
+    use logos_messaging_a2a_core::{DelegationRequest, DelegationStrategy};
+    use logos_messaging_a2a_transport::memory::InMemoryTransport;
+    use logos_messaging_a2a_transport::sds::ChannelConfig;
+    use std::time::Duration;
+
+    /// Fast SDS config that skips ACK waits — suitable for in-process tests.
+    fn fast_config() -> ChannelConfig {
+        ChannelConfig {
+            ack_timeout: Duration::from_millis(1),
+            max_retries: 0,
+            ..Default::default()
+        }
+    }
+
+    /// Create a node with fast SDS config, announce presence, and subscribe
+    /// to its own task topic (lazy-init).
+    async fn make_announced_node(
+        name: &str,
+        capabilities: Vec<&str>,
+        transport: InMemoryTransport,
+    ) -> WakuA2ANode<InMemoryTransport> {
+        let caps = capabilities.into_iter().map(String::from).collect();
+        let node = WakuA2ANode::with_config(
+            name,
+            &format!("{name} agent"),
+            caps,
+            transport,
+            fast_config(),
+        );
+        node.announce_presence().await.unwrap();
+        node.poll_tasks().await.unwrap();
+        node
+    }
+
+    /// Poll for one incoming task and respond with an echo.
+    async fn echo_once(node: &WakuA2ANode<InMemoryTransport>) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        while tokio::time::Instant::now() < deadline {
+            let tasks = node.poll_tasks().await.unwrap();
+            for task in &tasks {
+                if task.result.is_none() {
+                    let reply = format!("echo: {}", task.text().unwrap_or(""));
+                    node.respond(task, &reply).await.unwrap();
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("echo_once timed out waiting for a task");
+    }
+
+    /// Poll for exactly `n` incoming tasks and respond to each.
+    async fn echo_n(node: &WakuA2ANode<InMemoryTransport>, n: usize) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut count = 0;
+        while count < n && tokio::time::Instant::now() < deadline {
+            let tasks = node.poll_tasks().await.unwrap();
+            for task in &tasks {
+                if task.result.is_none() {
+                    let reply = format!(
+                        "echo from {}: {}",
+                        node.card.name,
+                        task.text().unwrap_or("")
+                    );
+                    node.respond(task, &reply).await.unwrap();
+                    count += 1;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(count, n, "echo_n: expected {n} tasks but got {count}");
+    }
+
+    // ── 1. FirstAvailable — success ──
+
+    #[tokio::test]
+    async fn delegate_task_first_available_success() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        let worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-001".into(),
+            subtask_text: "Hello worker".into(),
+            strategy: DelegationStrategy::FirstAvailable,
+            timeout_secs: 5,
+        };
+
+        let wh = tokio::spawn(async move { echo_once(&worker).await });
+        let result = orchestrator.delegate_task(&request).await.unwrap();
+        wh.await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.parent_task_id, "p-001");
+        assert!(result.result_text.unwrap().contains("echo: Hello worker"));
+        assert!(result.error.is_none());
+    }
+
+    // ── 2. CapabilityMatch — correct peer selected ──
+
+    #[tokio::test]
+    async fn delegate_task_capability_match_finds_correct_peer() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        let summarizer =
+            make_announced_node("summarizer", vec!["summarize"], transport.clone()).await;
+        let _coder = make_announced_node("coder", vec!["code"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let summarizer_pubkey = summarizer.pubkey().to_string();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-002".into(),
+            subtask_text: "Summarize this".into(),
+            strategy: DelegationStrategy::CapabilityMatch {
+                capability: "summarize".into(),
+            },
+            timeout_secs: 5,
+        };
+
+        let sh = tokio::spawn(async move { echo_once(&summarizer).await });
+        let result = orchestrator.delegate_task(&request).await.unwrap();
+        sh.await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.agent_id, summarizer_pubkey);
+        assert!(result.result_text.unwrap().contains("echo: Summarize this"));
+    }
+
+    // ── 3. CapabilityMatch — no matching peers ──
+
+    #[tokio::test]
+    async fn delegate_task_capability_match_no_matching_peers() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        let _worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-003".into(),
+            subtask_text: "Need image processing".into(),
+            strategy: DelegationStrategy::CapabilityMatch {
+                capability: "image".into(),
+            },
+            timeout_secs: 1,
+        };
+
+        let err = orchestrator.delegate_task(&request).await.unwrap_err();
+        assert!(
+            err.to_string().contains("no live peers with capability"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // ── 4. No live peers at all ──
+
+    #[tokio::test]
+    async fn delegate_task_no_live_peers_error() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+
+        // No other nodes — peer map is empty
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-004".into(),
+            subtask_text: "Nobody home".into(),
+            strategy: DelegationStrategy::FirstAvailable,
+            timeout_secs: 1,
+        };
+
+        let err = orchestrator.delegate_task(&request).await.unwrap_err();
+        assert!(
+            err.to_string().contains("no live peers"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // ── 5. RoundRobin — distributes across peers ──
+
+    #[tokio::test]
+    async fn delegate_task_round_robin_distributes() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        let worker_a = make_announced_node("worker-a", vec!["text"], transport.clone()).await;
+        let worker_b = make_announced_node("worker-b", vec!["text"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let peer_ids: Vec<String> = orchestrator
+            .peers()
+            .all_live()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(peer_ids.len(), 2);
+
+        // Each worker handles 2 tasks (4 total / 2 workers)
+        let ha = tokio::spawn(async move { echo_n(&worker_a, 2).await });
+        let hb = tokio::spawn(async move { echo_n(&worker_b, 2).await });
+
+        let mut agent_ids = Vec::new();
+        for i in 0..4 {
+            let request = DelegationRequest {
+                parent_task_id: format!("rr-{i}"),
+                subtask_text: format!("round-robin task {i}"),
+                strategy: DelegationStrategy::RoundRobin,
+                timeout_secs: 5,
+            };
+            let result = orchestrator.delegate_task(&request).await.unwrap();
+            assert!(result.success, "task {i} should succeed");
+            agent_ids.push(result.agent_id);
+        }
+
+        ha.await.unwrap();
+        hb.await.unwrap();
+
+        // Should alternate: peer0, peer1, peer0, peer1
+        assert_eq!(agent_ids[0], peer_ids[0]);
+        assert_eq!(agent_ids[1], peer_ids[1]);
+        assert_eq!(agent_ids[2], peer_ids[0]);
+        assert_eq!(agent_ids[3], peer_ids[1]);
+    }
+
+    // ── 6. Timeout — peer does not respond ──
+
+    #[tokio::test]
+    async fn delegate_task_timeout_returns_failure() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        // Silent worker announces but never responds to tasks
+        let _silent = make_announced_node("silent", vec!["text"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-006".into(),
+            subtask_text: "No reply expected".into(),
+            strategy: DelegationStrategy::FirstAvailable,
+            timeout_secs: 1,
+        };
+
+        let result = orchestrator.delegate_task(&request).await.unwrap();
+        assert!(!result.success);
+        assert_eq!(result.error.as_deref(), Some("delegation timed out"));
+        assert!(result.result_text.is_none());
+    }
+
+    // ── 7. Broadcast — collects multiple responses ──
+
+    #[tokio::test]
+    async fn delegate_broadcast_collects_results() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        let worker_a = make_announced_node("worker-a", vec!["text"], transport.clone()).await;
+        let worker_b = make_announced_node("worker-b", vec!["text"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-007".into(),
+            subtask_text: "Broadcast task".into(),
+            strategy: DelegationStrategy::BroadcastCollect,
+            timeout_secs: 10,
+        };
+
+        let ha = tokio::spawn(async move { echo_once(&worker_a).await });
+        let hb = tokio::spawn(async move { echo_once(&worker_b).await });
+
+        let results = orchestrator.delegate_broadcast(&request).await.unwrap();
+        ha.await.unwrap();
+        hb.await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        let successes: Vec<_> = results.iter().filter(|r| r.success).collect();
+        assert!(
+            !successes.is_empty(),
+            "at least one broadcast result should succeed"
+        );
+        for r in &successes {
+            assert_eq!(r.parent_task_id, "p-007");
+            assert!(r
+                .result_text
+                .as_ref()
+                .unwrap()
+                .contains("echo: Broadcast task"));
+        }
+    }
+
+    // ── 8. Broadcast — no peers ──
+
+    #[tokio::test]
+    async fn delegate_broadcast_no_peers_error() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-008".into(),
+            subtask_text: "Nobody".into(),
+            strategy: DelegationStrategy::BroadcastCollect,
+            timeout_secs: 1,
+        };
+
+        let err = orchestrator.delegate_broadcast(&request).await.unwrap_err();
+        assert!(
+            err.to_string().contains("no live peers"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // ── 9. Broadcast — mixed success/failure ──
+
+    #[tokio::test]
+    async fn delegate_broadcast_mixed_success_failure() {
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        let worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+        // silent announces but never responds
+        let _silent = make_announced_node("silent", vec!["text"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-009".into(),
+            subtask_text: "Partial broadcast".into(),
+            strategy: DelegationStrategy::CapabilityMatch {
+                capability: "text".into(),
+            },
+            timeout_secs: 2,
+        };
+
+        let wh = tokio::spawn(async move { echo_once(&worker).await });
+        let results = orchestrator.delegate_broadcast(&request).await.unwrap();
+        wh.await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        let successes = results.iter().filter(|r| r.success).count();
+        let failures = results.iter().filter(|r| !r.success).count();
+        assert_eq!(successes, 1);
+        assert_eq!(failures, 1);
+
+        // The failing result should carry a timeout error
+        let fail = results.iter().find(|r| !r.success).unwrap();
+        assert_eq!(fail.error.as_deref(), Some("delegation timed out"));
+    }
+
+    // ── 10. Default timeout when request.timeout_secs == 0 ──
+
+    #[tokio::test]
+    async fn default_timeout_used_when_request_timeout_is_zero() {
+        // Verify the constant is 30 seconds.
+        assert_eq!(super::DEFAULT_DELEGATION_TIMEOUT_SECS, 30);
+
+        let transport = InMemoryTransport::new();
+        let orchestrator =
+            make_announced_node("orchestrator", vec!["coordinate"], transport.clone()).await;
+        let worker = make_announced_node("worker", vec!["text"], transport.clone()).await;
+
+        orchestrator.poll_presence().await.unwrap();
+
+        let request = DelegationRequest {
+            parent_task_id: "p-010".into(),
+            subtask_text: "Quick task".into(),
+            strategy: DelegationStrategy::FirstAvailable,
+            timeout_secs: 0, // should fall back to DEFAULT_DELEGATION_TIMEOUT_SECS
+        };
+
+        let wh = tokio::spawn(async move { echo_once(&worker).await });
+        let result = orchestrator.delegate_task(&request).await.unwrap();
+        wh.await.unwrap();
+
+        // If the default were 0, this would have timed out immediately.
+        assert!(result.success);
     }
 }


### PR DESCRIPTION
## Purpose

Add comprehensive inline unit tests to `crates/logos-messaging-a2a-node/src/delegation.rs`, which previously had zero tests in-module. These tests complement the existing integration tests in `tests/delegation.rs` and follow the same `#[cfg(test)]` patterns used in `streaming.rs` and `discovery.rs`.

## Approach

Added 10 test cases covering all delegation code paths:

1. **FirstAvailable — success**: peer responds with echo
2. **CapabilityMatch — correct peer**: selects the peer with the matching capability
3. **CapabilityMatch — no match**: returns error when no peer has the requested capability
4. **No live peers**: returns error when peer map is empty
5. **RoundRobin — distribution**: alternates tasks across peers in order
6. **Timeout**: returns `DelegationResult { success: false }` when peer doesn't respond
7. **Broadcast — collects results**: sends to all peers via `delegate_broadcast`
8. **Broadcast — no peers**: returns error for empty peer map
9. **Broadcast — mixed results**: one peer responds, one times out; validates both outcomes
10. **Default timeout (zero)**: verifies `DEFAULT_DELEGATION_TIMEOUT_SECS` constant and fallback behavior

Uses `InMemoryTransport` with fast SDS config (`ack_timeout: 1ms, max_retries: 0`) and the `make_announced_node` / `echo_once` / `echo_n` helper pattern.

## How to Test

```bash
cargo test -p logos-messaging-a2a-node delegation::tests
cargo clippy --workspace -- -D warnings
```

## Dependencies

None — uses only existing crate infrastructure.

## Future Work

- Could add tests for `delegate_to_peer` private method directly (accessible from inline tests)
- Property-based tests for round-robin counter wraparound at large values

## Checklist

- [x] `cargo fmt` — passes
- [x] `cargo clippy --workspace -- -D warnings` — passes
- [x] `cargo test --workspace` — all tests pass
- [x] No new dependencies added
- [x] Follows existing test patterns (streaming.rs, discovery.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)