### PR TITLE
refactor: replace anyhow with thiserror in library crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,6 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 name = "lmao-ffi"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "cbindgen",
  "logos-messaging-a2a-core",
  "logos-messaging-a2a-node",
@@ -2427,7 +2426,6 @@ dependencies = [
 name = "logos-messaging-a2a-core"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "criterion",
  "hex",
@@ -2435,6 +2433,7 @@ dependencies = [
  "logos-messaging-a2a-crypto",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]
@@ -2443,7 +2442,6 @@ dependencies = [
 name = "logos-messaging-a2a-crypto"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "base64 0.22.1",
  "chacha20poly1305",
  "criterion",
@@ -2452,6 +2450,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "x25519-dalek",
 ]
 
@@ -2461,7 +2460,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "anyhow",
  "async-trait",
  "hex",
  "log",
@@ -2469,6 +2467,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "wiremock",
 ]
@@ -2510,7 +2509,6 @@ dependencies = [
 name = "logos-messaging-a2a-node"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "fastrand",
  "hex",
@@ -2523,6 +2521,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -2545,7 +2544,6 @@ dependencies = [
 name = "logos-messaging-a2a-transport"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bloomfilter",
@@ -2555,6 +2553,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ clap = { version = "4", features = ["derive"] }
 k256 = "0.13"
 hex = "0.4"
 anyhow = "1"
+thiserror = "2"
 async-trait = "0.1"
 sha2 = "0.10"
 bloomfilter = "1"

--- a/crates/lmao-ffi/Cargo.toml
+++ b/crates/lmao-ffi/Cargo.toml
@@ -14,7 +14,6 @@ logos-messaging-a2a-transport = { path = "../logos-messaging-a2a-transport" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-anyhow = { workspace = true }
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/crates/logos-messaging-a2a-core/Cargo.toml
+++ b/crates/logos-messaging-a2a-core/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 k256 = { workspace = true }
 hex = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 
 [dev-dependencies]

--- a/crates/logos-messaging-a2a-core/src/presence.rs
+++ b/crates/logos-messaging-a2a-core/src/presence.rs
@@ -1,7 +1,25 @@
-use anyhow::{Context, Result};
 use k256::ecdsa::signature::Verifier;
 use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
+
+/// Errors that can occur during presence verification.
+#[derive(Debug, thiserror::Error)]
+pub enum PresenceError {
+    #[error("missing signature")]
+    MissingSignature,
+
+    #[error("agent_id is not valid hex: {0}")]
+    InvalidHex(#[from] hex::FromHexError),
+
+    #[error("agent_id is not a valid secp256k1 public key: {0}")]
+    InvalidPublicKey(#[source] k256::ecdsa::Error),
+
+    #[error("signature is not valid DER: {0}")]
+    InvalidSignature(#[source] k256::ecdsa::Error),
+
+    #[error("signature verification failed: {0}")]
+    VerificationFailed(#[source] k256::ecdsa::Error),
+}
 
 /// Presence announcement broadcast on the well-known presence topic.
 ///
@@ -47,7 +65,7 @@ impl PresenceAnnouncement {
     ///
     /// Computes `canonical_bytes()` and signs with the provided key,
     /// setting the `signature` field to the DER-encoded signature bytes.
-    pub fn sign(&mut self, signing_key: &SigningKey) -> Result<()> {
+    pub fn sign(&mut self, signing_key: &SigningKey) -> Result<(), PresenceError> {
         use k256::ecdsa::signature::Signer;
         let message = self.canonical_bytes();
         let sig: Signature = signing_key.sign(&message);
@@ -59,19 +77,22 @@ impl PresenceAnnouncement {
     ///
     /// Returns `Ok(())` if the signature is present and valid, or an error
     /// describing why verification failed.
-    pub fn verify(&self) -> Result<()> {
-        let sig_bytes = self.signature.as_ref().context("missing signature")?;
+    pub fn verify(&self) -> Result<(), PresenceError> {
+        let sig_bytes = self
+            .signature
+            .as_ref()
+            .ok_or(PresenceError::MissingSignature)?;
 
-        let pubkey_bytes = hex::decode(&self.agent_id).context("agent_id is not valid hex")?;
+        let pubkey_bytes = hex::decode(&self.agent_id)?;
         let verifying_key = VerifyingKey::from_sec1_bytes(&pubkey_bytes)
-            .context("agent_id is not a valid secp256k1 public key")?;
+            .map_err(PresenceError::InvalidPublicKey)?;
 
-        let signature = Signature::from_der(sig_bytes).context("signature is not valid DER")?;
+        let signature = Signature::from_der(sig_bytes).map_err(PresenceError::InvalidSignature)?;
 
         let message = self.canonical_bytes();
         verifying_key
             .verify(&message, &signature)
-            .context("signature verification failed")?;
+            .map_err(PresenceError::VerificationFailed)?;
 
         Ok(())
     }

--- a/crates/logos-messaging-a2a-crypto/Cargo.toml
+++ b/crates/logos-messaging-a2a-crypto/Cargo.toml
@@ -10,7 +10,7 @@ rand = "0.8"
 serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 base64 = "0.22"
 
 [dev-dependencies]

--- a/crates/logos-messaging-a2a-crypto/src/lib.rs
+++ b/crates/logos-messaging-a2a-crypto/src/lib.rs
@@ -9,7 +9,6 @@
 //! AEAD. The [`IntroBundle`] type carries the public key material exchanged
 //! out-of-band to bootstrap a session.
 
-use anyhow::{Context, Result};
 use chacha20poly1305::{
     aead::{Aead, KeyInit, OsRng},
     ChaCha20Poly1305, Nonce,
@@ -17,6 +16,28 @@ use chacha20poly1305::{
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use x25519_dalek::{PublicKey, StaticSecret};
+
+/// Errors that can occur during cryptographic operations.
+#[derive(Debug, thiserror::Error)]
+pub enum CryptoError {
+    #[error("invalid hex: {0}")]
+    Hex(#[from] hex::FromHexError),
+
+    #[error("{0}")]
+    InvalidKeyLength(String),
+
+    #[error("cipher error: {0}")]
+    Cipher(String),
+
+    #[error("invalid base64 nonce")]
+    InvalidBase64Nonce(#[source] base64::DecodeError),
+
+    #[error("invalid base64 ciphertext")]
+    InvalidBase64Ciphertext(#[source] base64::DecodeError),
+}
+
+/// Alias for results returned by cryptographic operations.
+pub type Result<T> = std::result::Result<T, CryptoError>;
 
 /// Agent identity keypair (X25519 for ECDH key agreement).
 pub struct AgentIdentity {
@@ -40,10 +61,10 @@ impl AgentIdentity {
 
     /// Reconstruct from hex-encoded secret key (32 bytes = 64 hex chars). For testing.
     pub fn from_hex(secret_hex: &str) -> Result<Self> {
-        let bytes = hex::decode(secret_hex).context("invalid hex for secret key")?;
+        let bytes = hex::decode(secret_hex)?;
         let arr: [u8; 32] = bytes
             .try_into()
-            .map_err(|_| anyhow::anyhow!("secret key must be 32 bytes"))?;
+            .map_err(|_| CryptoError::InvalidKeyLength("secret key must be 32 bytes".into()))?;
         let secret = StaticSecret::from(arr);
         let public = PublicKey::from(&secret);
         Ok(Self { secret, public })
@@ -51,10 +72,10 @@ impl AgentIdentity {
 
     /// Parse a hex-encoded X25519 public key.
     pub fn parse_public_key(hex_str: &str) -> Result<PublicKey> {
-        let bytes = hex::decode(hex_str).context("invalid hex for public key")?;
+        let bytes = hex::decode(hex_str)?;
         let arr: [u8; 32] = bytes
             .try_into()
-            .map_err(|_| anyhow::anyhow!("public key must be 32 bytes"))?;
+            .map_err(|_| CryptoError::InvalidKeyLength("public key must be 32 bytes".into()))?;
         Ok(PublicKey::from(arr))
     }
 
@@ -73,7 +94,7 @@ impl SessionKey {
     #[allow(deprecated)]
     pub fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptedPayload> {
         let cipher = ChaCha20Poly1305::new_from_slice(&self.0)
-            .map_err(|e| anyhow::anyhow!("cipher init: {}", e))?;
+            .map_err(|e| CryptoError::Cipher(format!("cipher init: {}", e)))?;
 
         let mut nonce_bytes = [0u8; 12];
         rand::thread_rng().fill_bytes(&mut nonce_bytes);
@@ -81,7 +102,7 @@ impl SessionKey {
 
         let ciphertext = cipher
             .encrypt(nonce, plaintext)
-            .map_err(|e| anyhow::anyhow!("encrypt: {}", e))?;
+            .map_err(|e| CryptoError::Cipher(format!("encrypt: {}", e)))?;
 
         Ok(EncryptedPayload {
             nonce: base64::Engine::encode(&base64::engine::general_purpose::STANDARD, nonce_bytes),
@@ -96,22 +117,22 @@ impl SessionKey {
     #[allow(deprecated)]
     pub fn decrypt(&self, payload: &EncryptedPayload) -> Result<Vec<u8>> {
         let cipher = ChaCha20Poly1305::new_from_slice(&self.0)
-            .map_err(|e| anyhow::anyhow!("cipher init: {}", e))?;
+            .map_err(|e| CryptoError::Cipher(format!("cipher init: {}", e)))?;
 
         let nonce_bytes =
             base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &payload.nonce)
-                .context("invalid base64 nonce")?;
+                .map_err(CryptoError::InvalidBase64Nonce)?;
         let nonce = Nonce::from_slice(&nonce_bytes);
 
         let ciphertext = base64::Engine::decode(
             &base64::engine::general_purpose::STANDARD,
             &payload.ciphertext,
         )
-        .context("invalid base64 ciphertext")?;
+        .map_err(CryptoError::InvalidBase64Ciphertext)?;
 
         cipher
             .decrypt(nonce, ciphertext.as_ref())
-            .map_err(|e| anyhow::anyhow!("decrypt: {}", e))
+            .map_err(|e| CryptoError::Cipher(format!("decrypt: {}", e)))
     }
 }
 

--- a/crates/logos-messaging-a2a-execution/Cargo.toml
+++ b/crates/logos-messaging-a2a-execution/Cargo.toml
@@ -12,7 +12,7 @@ lez = []
 [dependencies]
 logos-messaging-a2a-core = { path = "../logos-messaging-a2a-core" }
 async-trait = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/logos-messaging-a2a-execution/src/lez.rs
+++ b/crates/logos-messaging-a2a-execution/src/lez.rs
@@ -8,7 +8,7 @@
 use async_trait::async_trait;
 use logos_messaging_a2a_core::AgentCard;
 
-use crate::{AgentId, ExecutionBackend, TransferDetails, TxHash};
+use crate::{AgentId, ExecutionBackend, ExecutionError, TransferDetails, TxHash};
 
 /// LEZ execution backend (stub).
 ///
@@ -36,22 +36,22 @@ impl Default for LezExecutionBackend {
 #[async_trait]
 impl ExecutionBackend for LezExecutionBackend {
     /// Register an agent on the LEZ chain. (Not yet implemented — see issue #4.)
-    async fn register_agent(&self, _card: &AgentCard) -> anyhow::Result<TxHash> {
+    async fn register_agent(&self, _card: &AgentCard) -> Result<TxHash, ExecutionError> {
         unimplemented!("LEZ execution backend not yet available — tracking in issue #4")
     }
 
     /// Pay another agent via LEZ tokens. (Not yet implemented — see issue #4.)
-    async fn pay(&self, _to: &AgentId, _amount: u64) -> anyhow::Result<TxHash> {
+    async fn pay(&self, _to: &AgentId, _amount: u64) -> Result<TxHash, ExecutionError> {
         unimplemented!("LEZ execution backend not yet available — tracking in issue #4")
     }
 
     /// Query agent balance on LEZ. (Not yet implemented — see issue #4.)
-    async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(&self, _agent: &AgentId) -> Result<u64, ExecutionError> {
         unimplemented!("LEZ execution backend not yet available — tracking in issue #4")
     }
 
     /// Verify a transfer on the LEZ chain. (Not yet implemented — see issue #4.)
-    async fn verify_transfer(&self, _tx_hash: &str) -> anyhow::Result<TransferDetails> {
+    async fn verify_transfer(&self, _tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
         unimplemented!("LEZ execution backend not yet available — tracking in issue #4")
     }
 }

--- a/crates/logos-messaging-a2a-execution/src/lib.rs
+++ b/crates/logos-messaging-a2a-execution/src/lib.rs
@@ -13,6 +13,16 @@ use logos_messaging_a2a_core::AgentCard;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Errors that can occur during execution backend operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ExecutionError {
+    #[error("RPC error: {0}")]
+    Rpc(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
 /// Newtype wrapper for an agent identity (secp256k1 compressed public key hex).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AgentId(pub String);
@@ -66,20 +76,20 @@ pub struct TransferDetails {
 #[async_trait]
 pub trait ExecutionBackend: Send + Sync {
     /// Register an agent's card on-chain for permanent, discoverable identity.
-    async fn register_agent(&self, card: &AgentCard) -> anyhow::Result<TxHash>;
+    async fn register_agent(&self, card: &AgentCard) -> Result<TxHash, ExecutionError>;
 
     /// Transfer `amount` tokens to another agent.
-    async fn pay(&self, to: &AgentId, amount: u64) -> anyhow::Result<TxHash>;
+    async fn pay(&self, to: &AgentId, amount: u64) -> Result<TxHash, ExecutionError>;
 
     /// Query the token balance for an agent.
-    async fn balance(&self, agent: &AgentId) -> anyhow::Result<u64>;
+    async fn balance(&self, agent: &AgentId) -> Result<u64, ExecutionError>;
 
     /// Verify a transaction hash corresponds to a valid ERC-20 transfer.
     ///
     /// Queries the chain for the transaction receipt, decodes the `Transfer`
     /// event log, and returns the transfer details. Returns an error if the
     /// transaction doesn't exist, failed, or contains no valid transfer event.
-    async fn verify_transfer(&self, tx_hash: &str) -> anyhow::Result<TransferDetails>;
+    async fn verify_transfer(&self, tx_hash: &str) -> Result<TransferDetails, ExecutionError>;
 }
 
 /// Status Network EVM execution backend (gasless, EVM-compatible).
@@ -138,16 +148,16 @@ mod tests {
 
     #[async_trait]
     impl ExecutionBackend for MockBackend {
-        async fn register_agent(&self, _card: &AgentCard) -> anyhow::Result<TxHash> {
+        async fn register_agent(&self, _card: &AgentCard) -> Result<TxHash, ExecutionError> {
             Ok(TxHash([0; 32]))
         }
-        async fn pay(&self, _to: &AgentId, _amount: u64) -> anyhow::Result<TxHash> {
+        async fn pay(&self, _to: &AgentId, _amount: u64) -> Result<TxHash, ExecutionError> {
             Ok(TxHash([1; 32]))
         }
-        async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+        async fn balance(&self, _agent: &AgentId) -> Result<u64, ExecutionError> {
             Ok(42)
         }
-        async fn verify_transfer(&self, _tx_hash: &str) -> anyhow::Result<TransferDetails> {
+        async fn verify_transfer(&self, _tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
             Ok(TransferDetails {
                 from: "0xsender".into(),
                 to: "0xrecipient".into(),

--- a/crates/logos-messaging-a2a-execution/src/status_network.rs
+++ b/crates/logos-messaging-a2a-execution/src/status_network.rs
@@ -19,7 +19,7 @@
 use async_trait::async_trait;
 use logos_messaging_a2a_core::AgentCard;
 
-use crate::{AgentId, ExecutionBackend, TransferDetails, TxHash};
+use crate::{AgentId, ExecutionBackend, ExecutionError, TransferDetails, TxHash};
 
 /// Default Status Network Sepolia RPC endpoint.
 pub const DEFAULT_RPC_URL: &str = "https://public.sepolia.rpc.status.network";
@@ -74,7 +74,7 @@ impl StatusNetworkBackend {
         &self,
         method: &str,
         params: serde_json::Value,
-    ) -> anyhow::Result<serde_json::Value> {
+    ) -> Result<serde_json::Value, ExecutionError> {
         let body = serde_json::json!({
             "jsonrpc": "2.0",
             "method": method,
@@ -87,17 +87,19 @@ impl StatusNetworkBackend {
             .post(&self.rpc_url)
             .json(&body)
             .send()
-            .await?
+            .await
+            .map_err(|e| ExecutionError::Rpc(e.to_string()))?
             .json()
-            .await?;
+            .await
+            .map_err(|e| ExecutionError::Rpc(e.to_string()))?;
 
         if let Some(error) = resp.get("error") {
-            anyhow::bail!("RPC error: {}", error);
+            return Err(ExecutionError::Rpc(format!("{}", error)));
         }
 
         resp.get("result")
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("Missing result in RPC response"))
+            .ok_or_else(|| ExecutionError::Rpc("Missing result in RPC response".into()))
     }
 
     /// Parse an ERC-20 Transfer event from transaction receipt logs.
@@ -107,7 +109,7 @@ impl StatusNetworkBackend {
     fn parse_transfer_log(
         &self,
         logs: &[serde_json::Value],
-    ) -> anyhow::Result<(String, String, u64)> {
+    ) -> Result<(String, String, u64), ExecutionError> {
         for log in logs {
             let topics = log
                 .get("topics")
@@ -154,7 +156,9 @@ impl StatusNetworkBackend {
             return Ok((from, to, amount));
         }
 
-        anyhow::bail!("No Transfer event found in transaction logs")
+        Err(ExecutionError::Other(
+            "No Transfer event found in transaction logs".into(),
+        ))
     }
 }
 
@@ -167,7 +171,7 @@ impl ExecutionBackend for StatusNetworkBackend {
     ///
     /// Note: Full transaction submission requires a signer (future work).
     /// Currently performs an `eth_call` dry-run against the registry contract.
-    async fn register_agent(&self, card: &AgentCard) -> anyhow::Result<TxHash> {
+    async fn register_agent(&self, card: &AgentCard) -> Result<TxHash, ExecutionError> {
         use alloy_primitives::FixedBytes;
         use alloy_sol_types::{sol, SolCall};
 
@@ -214,7 +218,7 @@ impl ExecutionBackend for StatusNetworkBackend {
     /// Send tokens to another agent via the ERC-20 token contract.
     ///
     /// Currently a stub that verifies RPC connectivity.
-    async fn pay(&self, to: &AgentId, amount: u64) -> anyhow::Result<TxHash> {
+    async fn pay(&self, to: &AgentId, amount: u64) -> Result<TxHash, ExecutionError> {
         let _chain_id = self.rpc_call("eth_chainId", serde_json::json!([])).await?;
 
         let mut hash = [0u8; 32];
@@ -225,7 +229,7 @@ impl ExecutionBackend for StatusNetworkBackend {
     }
 
     /// Query the token balance for an agent.
-    async fn balance(&self, agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(&self, agent: &AgentId) -> Result<u64, ExecutionError> {
         let padded_addr = format!("{:0>64}", agent.0.trim_start_matches("0x"));
         let calldata = format!("0x70a08231{}", padded_addr);
 
@@ -249,7 +253,7 @@ impl ExecutionBackend for StatusNetworkBackend {
     ///
     /// Fetches the receipt, checks that the transaction succeeded (status 0x1),
     /// and parses the ERC-20 Transfer event from the logs.
-    async fn verify_transfer(&self, tx_hash: &str) -> anyhow::Result<TransferDetails> {
+    async fn verify_transfer(&self, tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
         // Normalise tx hash
         let tx_hash = if tx_hash.starts_with("0x") {
             tx_hash.to_string()
@@ -263,7 +267,10 @@ impl ExecutionBackend for StatusNetworkBackend {
             .await?;
 
         if receipt.is_null() {
-            anyhow::bail!("Transaction {} not found (not mined yet?)", tx_hash);
+            return Err(ExecutionError::Other(format!(
+                "Transaction {} not found (not mined yet?)",
+                tx_hash
+            )));
         }
 
         // Check status (0x1 = success)
@@ -272,7 +279,10 @@ impl ExecutionBackend for StatusNetworkBackend {
             .and_then(|s| s.as_str())
             .unwrap_or("0x0");
         if status != "0x1" {
-            anyhow::bail!("Transaction {} failed (status: {})", tx_hash, status);
+            return Err(ExecutionError::Other(format!(
+                "Transaction {} failed (status: {})",
+                tx_hash, status
+            )));
         }
 
         // Get block number

--- a/crates/logos-messaging-a2a-node/Cargo.toml
+++ b/crates/logos-messaging-a2a-node/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 k256 = { workspace = true }
 hex = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 fastrand = "2"
 tracing = { workspace = true }

--- a/crates/logos-messaging-a2a-node/src/delegation.rs
+++ b/crates/logos-messaging-a2a-node/src/delegation.rs
@@ -1,7 +1,6 @@
 //! Multi-agent task delegation: decompose tasks into subtasks and forward
 //! them to capable peers discovered via presence.
 
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::{
     topics, A2AEnvelope, DelegationRequest, DelegationResult, DelegationStrategy, Task,
 };
@@ -9,7 +8,7 @@ use logos_messaging_a2a_transport::Transport;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use crate::WakuA2ANode;
+use crate::{NodeError, Result, WakuA2ANode};
 
 /// Default timeout for delegation when none is specified (30 seconds).
 const DEFAULT_DELEGATION_TIMEOUT_SECS: u64 = 30;
@@ -31,30 +30,24 @@ impl<T: Transport> WakuA2ANode<T> {
         let peer_id = match &request.strategy {
             DelegationStrategy::FirstAvailable => {
                 let peers = self.peers().all_live();
-                peers
-                    .into_iter()
-                    .map(|(id, _)| id)
-                    .next()
-                    .context("no live peers available for delegation")?
+                peers.into_iter().map(|(id, _)| id).next().ok_or_else(|| {
+                    NodeError::Other("no live peers available for delegation".into())
+                })?
             }
             DelegationStrategy::CapabilityMatch { capability } => {
                 let peers = self.find_peers_by_capability(capability);
-                peers
-                    .into_iter()
-                    .map(|(id, _)| id)
-                    .next()
-                    .with_context(|| {
-                        format!("no live peers with capability '{capability}' for delegation")
-                    })?
+                peers.into_iter().map(|(id, _)| id).next().ok_or_else(|| {
+                    NodeError::Other(format!(
+                        "no live peers with capability '{capability}' for delegation"
+                    ))
+                })?
             }
             DelegationStrategy::BroadcastCollect => {
                 // For single delegation, broadcast acts like first-available
                 let peers = self.peers().all_live();
-                peers
-                    .into_iter()
-                    .map(|(id, _)| id)
-                    .next()
-                    .context("no live peers available for broadcast delegation")?
+                peers.into_iter().map(|(id, _)| id).next().ok_or_else(|| {
+                    NodeError::Other("no live peers available for broadcast delegation".into())
+                })?
             }
             DelegationStrategy::RoundRobin => {
                 let peers: Vec<String> = self
@@ -64,7 +57,9 @@ impl<T: Transport> WakuA2ANode<T> {
                     .map(|(id, _)| id)
                     .collect();
                 if peers.is_empty() {
-                    anyhow::bail!("no live peers available for round-robin delegation");
+                    return Err(NodeError::Other(
+                        "no live peers available for round-robin delegation".into(),
+                    ));
                 }
                 let idx = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) % peers.len();
                 peers.into_iter().nth(idx).unwrap()
@@ -104,7 +99,9 @@ impl<T: Transport> WakuA2ANode<T> {
         };
 
         if peer_ids.is_empty() {
-            anyhow::bail!("no live peers available for broadcast delegation");
+            return Err(NodeError::Other(
+                "no live peers available for broadcast delegation".into(),
+            ));
         }
 
         let mut results = Vec::new();
@@ -143,22 +140,14 @@ impl<T: Transport> WakuA2ANode<T> {
         // since delegation already polls for the response with its own timeout.
         let topic = topics::task_topic(peer_id);
         let envelope = A2AEnvelope::Task(task);
-        let payload =
-            serde_json::to_vec(&envelope).context("failed to serialize delegated subtask")?;
-        self.channel()
-            .transport()
-            .publish(&topic, &payload)
-            .await
-            .context("failed to send delegated subtask")?;
+        let payload = serde_json::to_vec(&envelope)?;
+        self.channel().transport().publish(&topic, &payload).await?;
 
         // Poll for response with timeout
         let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
 
         while tokio::time::Instant::now() < deadline {
-            let tasks = self
-                .poll_tasks()
-                .await
-                .context("failed to poll for delegation response")?;
+            let tasks = self.poll_tasks().await?;
             for received in &tasks {
                 if received.id == subtask_id {
                     return Ok(DelegationResult {

--- a/crates/logos-messaging-a2a-node/src/discovery.rs
+++ b/crates/logos-messaging-a2a-node/src/discovery.rs
@@ -1,12 +1,11 @@
 //! Discovery, presence, and registry operations for [`WakuA2ANode`].
 
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::{topics, A2AEnvelope, AgentCard, PresenceAnnouncement};
 use logos_messaging_a2a_transport::Transport;
 use std::collections::HashMap;
 
 use crate::presence;
-use crate::WakuA2ANode;
+use crate::{NodeError, Result, WakuA2ANode};
 
 impl<T: Transport> WakuA2ANode<T> {
     /// Broadcast this agent's card on the discovery topic.
@@ -15,12 +14,11 @@ impl<T: Transport> WakuA2ANode<T> {
     /// broadcast to unknown peers who may not speak SDS yet.
     pub async fn announce(&self) -> Result<()> {
         let envelope = A2AEnvelope::AgentCard(self.card.clone());
-        let payload = serde_json::to_vec(&envelope).context("Failed to serialize AgentCard")?;
+        let payload = serde_json::to_vec(&envelope)?;
         self.channel
             .transport()
             .publish(topics::DISCOVERY, &payload)
-            .await
-            .context("Failed to announce AgentCard")?;
+            .await?;
         tracing::info!(name = %self.card.name, pubkey = %self.pubkey(), "Announced");
         Ok(())
     }
@@ -56,29 +54,38 @@ impl<T: Transport> WakuA2ANode<T> {
     /// is already registered (use [`update_registry`](Self::update_registry)
     /// to update an existing registration).
     pub async fn register_in_registry(&self) -> Result<()> {
-        let registry = self.registry.as_ref().context("no registry configured")?;
+        let registry = self
+            .registry
+            .as_ref()
+            .ok_or_else(|| NodeError::Other("no registry configured".into()))?;
         registry
             .register(self.card.clone())
             .await
-            .map_err(|e| anyhow::anyhow!("{}", e))
+            .map_err(|e| NodeError::Other(format!("{}", e)))
     }
 
     /// Update this node's AgentCard in the persistent registry.
     pub async fn update_registry(&self) -> Result<()> {
-        let registry = self.registry.as_ref().context("no registry configured")?;
+        let registry = self
+            .registry
+            .as_ref()
+            .ok_or_else(|| NodeError::Other("no registry configured".into()))?;
         registry
             .update(self.card.clone())
             .await
-            .map_err(|e| anyhow::anyhow!("{}", e))
+            .map_err(|e| NodeError::Other(format!("{}", e)))
     }
 
     /// Remove this node from the persistent registry.
     pub async fn deregister_from_registry(&self) -> Result<()> {
-        let registry = self.registry.as_ref().context("no registry configured")?;
+        let registry = self
+            .registry
+            .as_ref()
+            .ok_or_else(|| NodeError::Other("no registry configured".into()))?;
         registry
             .deregister(&self.card.public_key)
             .await
-            .map_err(|e| anyhow::anyhow!("{}", e))
+            .map_err(|e| NodeError::Other(format!("{}", e)))
     }
 
     /// Discover agents from all sources: Waku ephemeral discovery + persistent registry.
@@ -130,17 +137,13 @@ impl<T: Transport> WakuA2ANode<T> {
             ttl_secs,
             signature: None,
         };
-        announcement
-            .sign(&self.signing_key)
-            .context("Failed to sign presence announcement")?;
+        announcement.sign(&self.signing_key)?;
         let envelope = A2AEnvelope::Presence(announcement);
-        let payload =
-            serde_json::to_vec(&envelope).context("Failed to serialize presence announcement")?;
+        let payload = serde_json::to_vec(&envelope)?;
         self.channel
             .transport()
             .publish(topics::PRESENCE, &payload)
-            .await
-            .context("Failed to publish presence announcement")?;
+            .await?;
         tracing::info!(name = %self.card.name, ttl_secs, "Presence announced");
         Ok(())
     }

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -17,7 +17,34 @@ pub mod storage;
 mod streaming;
 mod tasks;
 
-use anyhow::{Context, Result};
+/// Errors that can occur in node operations.
+#[derive(Debug, thiserror::Error)]
+pub enum NodeError {
+    #[error("transport error: {0}")]
+    Transport(#[from] logos_messaging_a2a_transport::TransportError),
+
+    #[error("crypto error: {0}")]
+    Crypto(#[from] logos_messaging_a2a_crypto::CryptoError),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("execution error: {0}")]
+    Execution(#[from] logos_messaging_a2a_execution::ExecutionError),
+
+    #[error("presence error: {0}")]
+    Presence(#[from] logos_messaging_a2a_core::PresenceError),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Alias for results returned by node operations.
+pub type Result<T> = std::result::Result<T, NodeError>;
+
 use k256::ecdsa::SigningKey;
 use logos_messaging_a2a_core::registry::AgentRegistry;
 use logos_messaging_a2a_core::AgentCard;
@@ -240,19 +267,22 @@ impl<T: Transport> WakuA2ANode<T> {
         path: &Path,
     ) -> Result<Self> {
         let signing_key = if path.exists() {
-            let hex_str = std::fs::read_to_string(path)
-                .with_context(|| format!("failed to read keyfile {}", path.display()))?;
-            let bytes = hex::decode(hex_str.trim())
-                .with_context(|| format!("invalid hex in keyfile {}", path.display()))?;
+            let hex_str = std::fs::read_to_string(path).map_err(|e| {
+                NodeError::Other(format!("failed to read keyfile {}: {}", path.display(), e))
+            })?;
+            let bytes = hex::decode(hex_str.trim()).map_err(|e| {
+                NodeError::Other(format!("invalid hex in keyfile {}: {}", path.display(), e))
+            })?;
             if bytes.len() != 32 {
-                anyhow::bail!(
+                return Err(NodeError::Other(format!(
                     "keyfile {} contains {} bytes, expected 32",
                     path.display(),
                     bytes.len()
-                );
+                )));
             }
-            SigningKey::from_bytes(bytes.as_slice().into())
-                .with_context(|| format!("invalid signing key in {}", path.display()))?
+            SigningKey::from_bytes(bytes.as_slice().into()).map_err(|e| {
+                NodeError::Other(format!("invalid signing key in {}: {}", path.display(), e))
+            })?
         } else {
             let key = SigningKey::random(&mut rand_core());
             let hex_str = hex::encode(key.to_bytes());
@@ -260,20 +290,30 @@ impl<T: Transport> WakuA2ANode<T> {
             // Write atomically: create file, set perms, write content
             {
                 use std::io::Write;
-                let mut file = std::fs::File::create(path)
-                    .with_context(|| format!("failed to create keyfile {}", path.display()))?;
+                let mut file = std::fs::File::create(path).map_err(|e| {
+                    NodeError::Other(format!(
+                        "failed to create keyfile {}: {}",
+                        path.display(),
+                        e
+                    ))
+                })?;
 
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
                     file.set_permissions(std::fs::Permissions::from_mode(0o600))
-                        .with_context(|| {
-                            format!("failed to set permissions on {}", path.display())
+                        .map_err(|e| {
+                            NodeError::Other(format!(
+                                "failed to set permissions on {}: {}",
+                                path.display(),
+                                e
+                            ))
                         })?;
                 }
 
-                file.write_all(hex_str.as_bytes())
-                    .with_context(|| format!("failed to write keyfile {}", path.display()))?;
+                file.write_all(hex_str.as_bytes()).map_err(|e| {
+                    NodeError::Other(format!("failed to write keyfile {}: {}", path.display(), e))
+                })?;
             }
 
             key

--- a/crates/logos-messaging-a2a-node/src/retry.rs
+++ b/crates/logos-messaging-a2a-node/src/retry.rs
@@ -4,11 +4,12 @@
 //! failed `send_reliable` call with exponential backoff according to a
 //! [`RetryConfig`].
 
-use anyhow::Result;
 use logos_messaging_a2a_core::RetryConfig;
 use logos_messaging_a2a_transport::sds::MessageChannel;
 use logos_messaging_a2a_transport::Transport;
 use std::time::Duration;
+
+use crate::{NodeError, Result};
 
 /// Retry wrapper around [`MessageChannel::send_reliable`].
 ///
@@ -59,9 +60,11 @@ impl<'a, T: Transport> RetryLayer<'a, T> {
             }
         }
 
-        Err(last_err
-            .unwrap()
-            .context(format!("all {} attempts failed", self.config.max_attempts)))
+        Err(NodeError::Other(format!(
+            "all {} attempts failed: {}",
+            self.config.max_attempts,
+            last_err.unwrap()
+        )))
     }
 
     /// Compute the delay for a given 0-indexed attempt, with optional jitter.
@@ -89,14 +92,21 @@ mod tests {
 
     #[async_trait]
     impl Transport for DummyTransport {
-        async fn publish(&self, _topic: &str, _payload: &[u8]) -> anyhow::Result<()> {
+        async fn publish(
+            &self,
+            _topic: &str,
+            _payload: &[u8],
+        ) -> logos_messaging_a2a_transport::Result<()> {
             Ok(())
         }
-        async fn subscribe(&self, _topic: &str) -> anyhow::Result<mpsc::Receiver<Vec<u8>>> {
+        async fn subscribe(
+            &self,
+            _topic: &str,
+        ) -> logos_messaging_a2a_transport::Result<mpsc::Receiver<Vec<u8>>> {
             let (_, rx) = mpsc::channel(1);
             Ok(rx)
         }
-        async fn unsubscribe(&self, _topic: &str) -> anyhow::Result<()> {
+        async fn unsubscribe(&self, _topic: &str) -> logos_messaging_a2a_transport::Result<()> {
             Ok(())
         }
     }

--- a/crates/logos-messaging-a2a-node/src/streaming.rs
+++ b/crates/logos-messaging-a2a-node/src/streaming.rs
@@ -1,10 +1,9 @@
 //! Streaming operations for [`WakuA2ANode`](crate::WakuA2ANode).
 
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::{topics, A2AEnvelope, Task, TaskStreamChunk};
 use logos_messaging_a2a_transport::Transport;
 
-use crate::WakuA2ANode;
+use crate::{Result, WakuA2ANode};
 
 impl<T: Transport> WakuA2ANode<T> {
     /// Publish a sequence of stream chunks for a task.
@@ -23,13 +22,8 @@ impl<T: Transport> WakuA2ANode<T> {
                 is_final: i == total - 1,
             };
             let envelope = A2AEnvelope::StreamChunk(chunk);
-            let payload =
-                serde_json::to_vec(&envelope).context("Failed to serialize stream chunk")?;
-            self.channel
-                .transport()
-                .publish(&topic, &payload)
-                .await
-                .context("Failed to publish stream chunk")?;
+            let payload = serde_json::to_vec(&envelope)?;
+            self.channel.transport().publish(&topic, &payload).await?;
         }
         tracing::info!(task_id = %task.id, chunks = total, "Streamed chunks for task");
         Ok(())

--- a/crates/logos-messaging-a2a-node/src/tasks/helpers.rs
+++ b/crates/logos-messaging-a2a-node/src/tasks/helpers.rs
@@ -1,9 +1,8 @@
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::{A2AEnvelope, AgentCard, Message, Task};
 use logos_messaging_a2a_crypto::AgentIdentity;
 use logos_messaging_a2a_transport::Transport;
 
-use crate::WakuA2ANode;
+use crate::{NodeError, Result, WakuA2ANode};
 
 impl<T: Transport> WakuA2ANode<T> {
     /// Serialize a task into an envelope, offloading to storage if needed.
@@ -17,18 +16,16 @@ impl<T: Transport> WakuA2ANode<T> {
         recipient_card: Option<&AgentCard>,
     ) -> Result<Vec<u8>> {
         let envelope = self.maybe_encrypt_task(task, recipient_card)?;
-        let payload = serde_json::to_vec(&envelope).context("Failed to serialize envelope")?;
+        let payload = serde_json::to_vec(&envelope)?;
 
         if let Some(ref offload) = self.storage_offload {
             if payload.len() > offload.threshold_bytes {
                 // Upload the original task (plaintext) to storage
-                let task_bytes =
-                    serde_json::to_vec(task).context("Failed to serialize task for storage")?;
-                let cid = offload
-                    .backend
-                    .upload(task_bytes)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("storage offload upload failed: {e}"))?;
+                let task_bytes = serde_json::to_vec(task)?;
+                let cid =
+                    offload.backend.upload(task_bytes).await.map_err(|e| {
+                        NodeError::Other(format!("storage offload upload failed: {e}"))
+                    })?;
 
                 // Build a slim task with the CID and cleared content
                 let mut slim = task.clone();
@@ -42,8 +39,7 @@ impl<T: Transport> WakuA2ANode<T> {
                 }
 
                 let slim_envelope = self.maybe_encrypt_task(&slim, recipient_card)?;
-                return serde_json::to_vec(&slim_envelope)
-                    .context("Failed to serialize slim envelope");
+                return Ok(serde_json::to_vec(&slim_envelope)?);
             }
         }
 
@@ -81,8 +77,7 @@ impl<T: Transport> WakuA2ANode<T> {
         let their_pubkey = AgentIdentity::parse_public_key(sender_pubkey_hex)?;
         let session_key = identity.shared_key(&their_pubkey);
         let plaintext = session_key.decrypt(encrypted)?;
-        let task: Task =
-            serde_json::from_slice(&plaintext).context("Failed to deserialize decrypted task")?;
+        let task: Task = serde_json::from_slice(&plaintext)?;
         Ok(task)
     }
 }

--- a/crates/logos-messaging-a2a-node/src/tasks/payment.rs
+++ b/crates/logos-messaging-a2a-node/src/tasks/payment.rs
@@ -1,9 +1,8 @@
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::Task;
 use logos_messaging_a2a_execution::AgentId;
 use logos_messaging_a2a_transport::Transport;
 
-use crate::WakuA2ANode;
+use crate::{Result, WakuA2ANode};
 
 impl<T: Transport> WakuA2ANode<T> {
     /// If auto-pay is enabled, call `backend.pay()` and attach proof to the task.
@@ -14,8 +13,7 @@ impl<T: Transport> WakuA2ANode<T> {
                 let tx_hash = pay_cfg
                     .backend
                     .pay(&recipient, pay_cfg.auto_pay_amount)
-                    .await
-                    .context("auto-pay failed")?;
+                    .await?;
                 let mut task = task.clone();
                 task.payment_tx = Some(tx_hash.to_string());
                 task.payment_amount = Some(pay_cfg.auto_pay_amount);
@@ -1003,8 +1001,11 @@ mod tests {
         let result = node.maybe_auto_pay(&task).await;
         assert!(result.is_err(), "backend.pay() failure should propagate");
         assert!(
-            result.unwrap_err().to_string().contains("auto-pay failed"),
-            "error should contain context"
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("insufficient funds"),
+            "error should contain backend failure reason"
         );
     }
 }

--- a/crates/logos-messaging-a2a-node/src/tasks/poll.rs
+++ b/crates/logos-messaging-a2a-node/src/tasks/poll.rs
@@ -1,9 +1,8 @@
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::{A2AEnvelope, Task};
 use logos_messaging_a2a_transport::Transport;
 
 use crate::session::Session;
-use crate::WakuA2ANode;
+use crate::{NodeError, Result, WakuA2ANode};
 
 impl<T: Transport> WakuA2ANode<T> {
     /// Poll for incoming tasks addressed to this agent.
@@ -131,13 +130,11 @@ impl<T: Transport> WakuA2ANode<T> {
     async fn maybe_fetch_offloaded(&self, task: Task) -> Result<Option<Task>> {
         if let Some(ref cid) = task.payload_cid {
             if let Some(ref offload) = self.storage_offload {
-                let data = offload
-                    .backend
-                    .download(cid)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("storage fetch by CID failed: {e}"))?;
-                let original: Task = serde_json::from_slice(&data)
-                    .context("Failed to deserialize offloaded task")?;
+                let data =
+                    offload.backend.download(cid).await.map_err(|e| {
+                        NodeError::Other(format!("storage fetch by CID failed: {e}"))
+                    })?;
+                let original: Task = serde_json::from_slice(&data)?;
                 return Ok(Some(original));
             }
             tracing::warn!(payload_cid = %cid, "Task has payload_cid but no storage backend configured");

--- a/crates/logos-messaging-a2a-node/src/tasks/respond.rs
+++ b/crates/logos-messaging-a2a-node/src/tasks/respond.rs
@@ -1,8 +1,7 @@
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::{topics, AgentCard, Task};
 use logos_messaging_a2a_transport::Transport;
 
-use crate::WakuA2ANode;
+use crate::{Result, WakuA2ANode};
 
 impl<T: Transport> WakuA2ANode<T> {
     /// Respond to a task: send back a completed task with result.
@@ -25,10 +24,7 @@ impl<T: Transport> WakuA2ANode<T> {
         let payload = self.prepare_payload(&response, sender_card).await?;
 
         // Use causal send for responses (maintains ordering, no retransmit block)
-        self.channel
-            .send(&topic, &payload)
-            .await
-            .context("Failed to send response")?;
+        self.channel.send(&topic, &payload).await?;
 
         tracing::info!(task_id = %task.id, "Responded to task");
         Ok(())

--- a/crates/logos-messaging-a2a-node/src/tasks/send.rs
+++ b/crates/logos-messaging-a2a-node/src/tasks/send.rs
@@ -1,9 +1,8 @@
-use anyhow::{Context, Result};
 use logos_messaging_a2a_core::{topics, AgentCard, Task};
 use logos_messaging_a2a_transport::Transport;
 
 use crate::retry;
-use crate::WakuA2ANode;
+use crate::{NodeError, Result, WakuA2ANode};
 
 impl<T: Transport> WakuA2ANode<T> {
     /// Send a task to another agent. Uses SDS reliable delivery with
@@ -34,13 +33,9 @@ impl<T: Transport> WakuA2ANode<T> {
         let (_msg, acked) = if let Some(ref retry_cfg) = self.retry_config {
             retry::RetryLayer::new(&self.channel, retry_cfg)
                 .send_reliable(&topic, &payload)
-                .await
-                .context("SDS publish failed (after retries)")?
+                .await?
         } else {
-            self.channel
-                .send_reliable(&topic, &payload)
-                .await
-                .context("SDS publish failed")?
+            self.channel.send_reliable(&topic, &payload).await?
         };
 
         if acked {
@@ -57,7 +52,7 @@ impl<T: Transport> WakuA2ANode<T> {
             let sessions = self.sessions.lock().unwrap();
             let session = sessions
                 .get(session_id)
-                .ok_or_else(|| anyhow::anyhow!("Session {} not found", session_id))?;
+                .ok_or_else(|| NodeError::Other(format!("Session {} not found", session_id)))?;
             session.peer.clone()
         };
         let task = Task::new_in_session(self.pubkey(), &peer, text, session_id);

--- a/crates/logos-messaging-a2a-node/src/tasks/test_support.rs
+++ b/crates/logos-messaging-a2a-node/src/tasks/test_support.rs
@@ -1,9 +1,10 @@
 //! Shared test infrastructure for task submodule tests.
 
-use anyhow::Result;
 use async_trait::async_trait;
 use logos_messaging_a2a_core::AgentCard;
-use logos_messaging_a2a_execution::{AgentId, ExecutionBackend, TransferDetails, TxHash};
+use logos_messaging_a2a_execution::{
+    AgentId, ExecutionBackend, ExecutionError, TransferDetails, TxHash,
+};
 use logos_messaging_a2a_storage::StorageBackend;
 use logos_messaging_a2a_transport::Transport;
 use std::collections::HashMap;
@@ -57,7 +58,11 @@ impl Clone for MockTransport {
 
 #[async_trait]
 impl Transport for MockTransport {
-    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+    async fn publish(
+        &self,
+        topic: &str,
+        payload: &[u8],
+    ) -> logos_messaging_a2a_transport::Result<()> {
         let data = payload.to_vec();
         self.published
             .lock()
@@ -76,7 +81,10 @@ impl Transport for MockTransport {
         Ok(())
     }
 
-    async fn subscribe(&self, topic: &str) -> Result<mpsc::Receiver<Vec<u8>>> {
+    async fn subscribe(
+        &self,
+        topic: &str,
+    ) -> logos_messaging_a2a_transport::Result<mpsc::Receiver<Vec<u8>>> {
         let mut state = self.state.lock().unwrap();
         let (tx, rx) = mpsc::channel(1024);
         if let Some(history) = state.history.get(topic) {
@@ -92,7 +100,7 @@ impl Transport for MockTransport {
         Ok(rx)
     }
 
-    async fn unsubscribe(&self, topic: &str) -> Result<()> {
+    async fn unsubscribe(&self, topic: &str) -> logos_messaging_a2a_transport::Result<()> {
         let mut state = self.state.lock().unwrap();
         state.subscribers.remove(topic);
         Ok(())
@@ -152,16 +160,16 @@ pub struct MockExecutionBackend;
 
 #[async_trait]
 impl ExecutionBackend for MockExecutionBackend {
-    async fn register_agent(&self, _card: &AgentCard) -> anyhow::Result<TxHash> {
+    async fn register_agent(&self, _card: &AgentCard) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0; 32]))
     }
-    async fn pay(&self, _to: &AgentId, _amount: u64) -> anyhow::Result<TxHash> {
+    async fn pay(&self, _to: &AgentId, _amount: u64) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0xab; 32]))
     }
-    async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(&self, _agent: &AgentId) -> Result<u64, ExecutionError> {
         Ok(1000)
     }
-    async fn verify_transfer(&self, _tx_hash: &str) -> anyhow::Result<TransferDetails> {
+    async fn verify_transfer(&self, _tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
         Ok(TransferDetails {
             from: "0xsender".into(),
             to: "0xrecipient".into(),
@@ -178,16 +186,16 @@ pub struct VerifyingBackend {
 
 #[async_trait]
 impl ExecutionBackend for VerifyingBackend {
-    async fn register_agent(&self, _card: &AgentCard) -> anyhow::Result<TxHash> {
+    async fn register_agent(&self, _card: &AgentCard) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0; 32]))
     }
-    async fn pay(&self, _to: &AgentId, _amount: u64) -> anyhow::Result<TxHash> {
+    async fn pay(&self, _to: &AgentId, _amount: u64) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0; 32]))
     }
-    async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(&self, _agent: &AgentId) -> Result<u64, ExecutionError> {
         Ok(0)
     }
-    async fn verify_transfer(&self, _tx_hash: &str) -> anyhow::Result<TransferDetails> {
+    async fn verify_transfer(&self, _tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
         Ok(self.details.clone())
     }
 }
@@ -197,16 +205,18 @@ pub struct FailingPayBackend;
 
 #[async_trait]
 impl ExecutionBackend for FailingPayBackend {
-    async fn register_agent(&self, _card: &AgentCard) -> anyhow::Result<TxHash> {
+    async fn register_agent(&self, _card: &AgentCard) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0; 32]))
     }
-    async fn pay(&self, _to: &AgentId, _amount: u64) -> anyhow::Result<TxHash> {
-        anyhow::bail!("payment failed: insufficient funds")
+    async fn pay(&self, _to: &AgentId, _amount: u64) -> Result<TxHash, ExecutionError> {
+        Err(ExecutionError::Other(
+            "payment failed: insufficient funds".into(),
+        ))
     }
-    async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(&self, _agent: &AgentId) -> Result<u64, ExecutionError> {
         Ok(0)
     }
-    async fn verify_transfer(&self, _tx_hash: &str) -> anyhow::Result<TransferDetails> {
+    async fn verify_transfer(&self, _tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
         Ok(TransferDetails {
             from: String::new(),
             to: String::new(),
@@ -221,17 +231,20 @@ pub struct FailingVerifyBackend;
 
 #[async_trait]
 impl ExecutionBackend for FailingVerifyBackend {
-    async fn register_agent(&self, _card: &AgentCard) -> anyhow::Result<TxHash> {
+    async fn register_agent(&self, _card: &AgentCard) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0; 32]))
     }
-    async fn pay(&self, _to: &AgentId, _amount: u64) -> anyhow::Result<TxHash> {
+    async fn pay(&self, _to: &AgentId, _amount: u64) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0; 32]))
     }
-    async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(&self, _agent: &AgentId) -> Result<u64, ExecutionError> {
         Ok(0)
     }
-    async fn verify_transfer(&self, tx_hash: &str) -> anyhow::Result<TransferDetails> {
-        anyhow::bail!("Transaction {} not found", tx_hash)
+    async fn verify_transfer(&self, tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
+        Err(ExecutionError::Other(format!(
+            "Transaction {} not found",
+            tx_hash
+        )))
     }
 }
 

--- a/crates/logos-messaging-a2a-node/tests/full_lifecycle.rs
+++ b/crates/logos-messaging-a2a-node/tests/full_lifecycle.rs
@@ -32,20 +32,33 @@ impl MockPaymentBackend {
 
 #[async_trait]
 impl ExecutionBackend for MockPaymentBackend {
-    async fn register_agent(&self, _card: &AgentCard) -> anyhow::Result<TxHash> {
+    async fn register_agent(
+        &self,
+        _card: &AgentCard,
+    ) -> Result<TxHash, logos_messaging_a2a_execution::ExecutionError> {
         Ok(TxHash([0xaa; 32]))
     }
 
-    async fn pay(&self, to: &AgentId, amount: u64) -> anyhow::Result<TxHash> {
+    async fn pay(
+        &self,
+        to: &AgentId,
+        amount: u64,
+    ) -> Result<TxHash, logos_messaging_a2a_execution::ExecutionError> {
         self.transfers.lock().unwrap().push((to.0.clone(), amount));
         Ok(TxHash([0xbb; 32]))
     }
 
-    async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(
+        &self,
+        _agent: &AgentId,
+    ) -> Result<u64, logos_messaging_a2a_execution::ExecutionError> {
         Ok(1000)
     }
 
-    async fn verify_transfer(&self, _tx_hash: &str) -> anyhow::Result<TransferDetails> {
+    async fn verify_transfer(
+        &self,
+        _tx_hash: &str,
+    ) -> Result<TransferDetails, logos_messaging_a2a_execution::ExecutionError> {
         Ok(TransferDetails {
             from: "0xsender".into(),
             to: "0xreceiver".into(),

--- a/crates/logos-messaging-a2a-node/tests/retry.rs
+++ b/crates/logos-messaging-a2a-node/tests/retry.rs
@@ -1,10 +1,9 @@
 //! Integration tests for message retry with exponential backoff.
 
-use anyhow::Result;
 use async_trait::async_trait;
 use logos_messaging_a2a_core::RetryConfig;
 use logos_messaging_a2a_node::WakuA2ANode;
-use logos_messaging_a2a_transport::Transport;
+use logos_messaging_a2a_transport::{Transport, TransportError};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -46,15 +45,19 @@ impl FailNTransport {
 
 #[async_trait]
 impl Transport for FailNTransport {
-    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+    async fn publish(
+        &self,
+        topic: &str,
+        payload: &[u8],
+    ) -> logos_messaging_a2a_transport::Result<()> {
         let attempt = self.attempts.fetch_add(1, Ordering::SeqCst);
         let fail_count = self.state.lock().unwrap().fail_count;
 
         if attempt < fail_count {
-            return Err(anyhow::anyhow!(
+            return Err(TransportError::Other(format!(
                 "simulated transport failure (attempt {})",
                 attempt + 1
-            ));
+            )));
         }
 
         let data = payload.to_vec();
@@ -70,7 +73,10 @@ impl Transport for FailNTransport {
         Ok(())
     }
 
-    async fn subscribe(&self, topic: &str) -> Result<mpsc::Receiver<Vec<u8>>> {
+    async fn subscribe(
+        &self,
+        topic: &str,
+    ) -> logos_messaging_a2a_transport::Result<mpsc::Receiver<Vec<u8>>> {
         let mut state = self.state.lock().unwrap();
         let (tx, rx) = mpsc::channel(1024);
         if let Some(history) = state.history.get(topic) {
@@ -86,7 +92,7 @@ impl Transport for FailNTransport {
         Ok(rx)
     }
 
-    async fn unsubscribe(&self, topic: &str) -> Result<()> {
+    async fn unsubscribe(&self, topic: &str) -> logos_messaging_a2a_transport::Result<()> {
         let mut state = self.state.lock().unwrap();
         state.subscribers.remove(topic);
         Ok(())

--- a/crates/logos-messaging-a2a-transport/Cargo.toml
+++ b/crates/logos-messaging-a2a-transport/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true, optional = true }
 uuid = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/logos-messaging-a2a-transport/src/lib.rs
+++ b/crates/logos-messaging-a2a-transport/src/lib.rs
@@ -10,8 +10,23 @@
 //! The [`sds`] submodule implements the SDS (Scalable Data Sync) reliability layer on top of
 //! any `Transport`, adding causal ordering, bloom-filter deduplication, and retransmission.
 
-use anyhow::Result;
 use async_trait::async_trait;
+
+/// Errors that can occur during transport operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error("{0}")]
+    Transport(String),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Alias for results returned by transport operations.
+pub type Result<T> = std::result::Result<T, TransportError>;
 use tokio::sync::mpsc;
 
 pub mod memory;

--- a/crates/logos-messaging-a2a-transport/src/logos_core_transport.rs
+++ b/crates/logos-messaging-a2a-transport/src/logos_core_transport.rs
@@ -6,7 +6,7 @@
 
 use crate::logos_core;
 use crate::Transport;
-use anyhow::{bail, Result};
+use crate::{Result, TransportError};
 use async_trait::async_trait;
 use base64::Engine;
 use std::collections::HashMap;
@@ -49,17 +49,27 @@ impl LogosCoreDeliveryTransport {
         let result =
             logos_core::call_plugin_method(PLUGIN, "createNode", &params_json(&[("cfg", cfg)]))
                 .await
-                .map_err(|e| anyhow::anyhow!("delivery_module createNode failed: {}", e))?;
+                .map_err(|e| {
+                    TransportError::Transport(format!("delivery_module createNode failed: {}", e))
+                })?;
         if result != "true" {
-            bail!("delivery_module createNode returned: {}", result);
+            return Err(TransportError::Transport(format!(
+                "delivery_module createNode returned: {}",
+                result
+            )));
         }
 
         // start
         let result = logos_core::call_plugin_method(PLUGIN, "start", "[]")
             .await
-            .map_err(|e| anyhow::anyhow!("delivery_module start failed: {}", e))?;
+            .map_err(|e| {
+                TransportError::Transport(format!("delivery_module start failed: {}", e))
+            })?;
         if result != "true" {
-            bail!("delivery_module start returned: {}", result);
+            return Err(TransportError::Transport(format!(
+                "delivery_module start returned: {}",
+                result
+            )));
         }
 
         let subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>> =
@@ -113,10 +123,13 @@ impl Transport for LogosCoreDeliveryTransport {
             &params_json(&[("contentTopic", topic), ("payload", &payload_b64)]),
         )
         .await
-        .map_err(|e| anyhow::anyhow!("delivery_module send failed: {}", e))?;
+        .map_err(|e| TransportError::Transport(format!("delivery_module send failed: {}", e)))?;
 
         if result.starts_with("error") || result.starts_with("Error") {
-            bail!("delivery_module send returned error: {}", result);
+            return Err(TransportError::Transport(format!(
+                "delivery_module send returned error: {}",
+                result
+            )));
         }
         Ok(())
     }
@@ -128,9 +141,14 @@ impl Transport for LogosCoreDeliveryTransport {
             &params_json(&[("contentTopic", topic)]),
         )
         .await
-        .map_err(|e| anyhow::anyhow!("delivery_module subscribe failed: {}", e))?;
+        .map_err(|e| {
+            TransportError::Transport(format!("delivery_module subscribe failed: {}", e))
+        })?;
         if result != "true" {
-            bail!("delivery_module subscribe returned: {}", result);
+            return Err(TransportError::Transport(format!(
+                "delivery_module subscribe returned: {}",
+                result
+            )));
         }
 
         let (tx, rx_unbounded) = mpsc::unbounded_channel();
@@ -161,9 +179,14 @@ impl Transport for LogosCoreDeliveryTransport {
             &params_json(&[("contentTopic", topic)]),
         )
         .await
-        .map_err(|e| anyhow::anyhow!("delivery_module unsubscribe failed: {}", e))?;
+        .map_err(|e| {
+            TransportError::Transport(format!("delivery_module unsubscribe failed: {}", e))
+        })?;
         if result != "true" {
-            bail!("delivery_module unsubscribe returned: {}", result);
+            return Err(TransportError::Transport(format!(
+                "delivery_module unsubscribe returned: {}",
+                result
+            )));
         }
         Ok(())
     }
@@ -204,7 +227,7 @@ mod tests {
     #[test]
     fn params_json_is_valid_json() {
         let result = params_json(&[("a", "1"), ("b", "2"), ("c", "3")]);
-        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&result);
+        let parsed: std::result::Result<serde_json::Value, _> = serde_json::from_str(&result);
         assert!(parsed.is_ok(), "params_json should produce valid JSON");
     }
 

--- a/crates/logos-messaging-a2a-transport/src/memory.rs
+++ b/crates/logos-messaging-a2a-transport/src/memory.rs
@@ -4,8 +4,8 @@
 //! New subscribers receive all historical messages (replay), making it suitable for
 //! tests where publish may happen before subscribe.
 
+use crate::Result;
 use crate::Transport;
-use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/crates/logos-messaging-a2a-transport/src/nwaku_rest.rs
+++ b/crates/logos-messaging-a2a-transport/src/nwaku_rest.rs
@@ -5,7 +5,7 @@
 //! integration (Issue #1).
 
 use crate::Transport;
-use anyhow::{Context, Result};
+use crate::{Result, TransportError};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -129,12 +129,15 @@ async fn poll_rest_messages(
         .get(&url)
         .send()
         .await
-        .context("Failed to poll nwaku")?;
+        .map_err(|e| TransportError::Transport(format!("Failed to poll nwaku: {}", e)))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("nwaku poll failed ({}): {}", status, body);
+        return Err(TransportError::Transport(format!(
+            "nwaku poll failed ({}): {}",
+            status, body
+        )));
     }
 
     let messages: Vec<WakuMessageResponse> = resp.json().await.unwrap_or_default();
@@ -179,12 +182,15 @@ impl Transport for LogosMessagingTransport {
             .json(&msg)
             .send()
             .await
-            .context("Failed to publish to nwaku")?;
+            .map_err(|e| TransportError::Transport(format!("Failed to publish to nwaku: {}", e)))?;
 
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("nwaku publish failed ({}): {}", status, body);
+            return Err(TransportError::Transport(format!(
+                "nwaku publish failed ({}): {}",
+                status, body
+            )));
         }
         Ok(())
     }

--- a/crates/logos-messaging-a2a-transport/src/sds/channel.rs
+++ b/crates/logos-messaging-a2a-transport/src/sds/channel.rs
@@ -13,7 +13,7 @@
 //! Reference: <https://forum.research.logos.co/t/introducing-the-reliable-channel-api/580>
 
 use crate::Transport;
-use anyhow::{Context, Result};
+use crate::{Result, TransportError};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -222,10 +222,9 @@ impl<T: Transport> MessageChannel<T> {
 
         // Serialize and publish
         let encoded = serde_json::to_vec(&SdsMessage::Content(msg.clone()))?;
-        self.transport
-            .publish(topic, &encoded)
-            .await
-            .context("SDS: failed to publish content message")?;
+        self.transport.publish(topic, &encoded).await.map_err(|e| {
+            TransportError::Transport(format!("SDS: failed to publish content message: {}", e))
+        })?;
 
         // Record in local state
         self.bloom.set(&message_id);
@@ -277,7 +276,7 @@ impl<T: Transport> MessageChannel<T> {
             self.transport
                 .publish(topic, &encoded)
                 .await
-                .context("SDS: publish failed")?;
+                .map_err(|e| TransportError::Transport(format!("SDS: publish failed: {}", e)))?;
 
             match tokio::time::timeout(self.config.ack_timeout, ack_rx.recv()).await {
                 Ok(Some(ack_data)) => {

--- a/crates/logos-messaging-a2a-transport/src/sds/mod.rs
+++ b/crates/logos-messaging-a2a-transport/src/sds/mod.rs
@@ -15,7 +15,7 @@
 //! use logos_messaging_a2a_transport::sds::channel::MessageChannel;
 //! use logos_messaging_a2a_transport::memory::InMemoryTransport;
 //!
-//! # async fn example() -> anyhow::Result<()> {
+//! # async fn example() -> Result<(), logos_messaging_a2a_transport::TransportError> {
 //! let transport = InMemoryTransport::new();
 //! let channel = MessageChannel::new(
 //!     "my-channel".to_string(),

--- a/crates/logos-messaging-a2a-transport/src/waku_bindings_transport.rs
+++ b/crates/logos-messaging-a2a-transport/src/waku_bindings_transport.rs
@@ -8,7 +8,7 @@
 //! See: <https://github.com/logos-messaging/logos-delivery-rust-bindings>
 
 use crate::Transport;
-use anyhow::{Context, Result};
+use crate::{Result, TransportError};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::future::Future;
@@ -64,7 +64,7 @@ impl NativeWakuTransport {
     pub async fn new(config: WakuNodeConfig) -> Result<Self> {
         let node = waku_new(Some(config))
             .await
-            .map_err(|e| anyhow::anyhow!("waku_new failed: {}", e))?;
+            .map_err(|e| TransportError::Transport(format!("waku_new failed: {}", e)))?;
 
         let senders: Arc<Mutex<HashMap<String, mpsc::Sender<Vec<u8>>>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -85,27 +85,29 @@ impl NativeWakuTransport {
                 }
             }
         })
-        .map_err(|e| anyhow::anyhow!("set_event_callback failed: {}", e))?;
+        .map_err(|e| TransportError::Transport(format!("set_event_callback failed: {}", e)))?;
 
         // SAFETY: waku FFI futures are safe to send across threads
         let node = unsafe { assert_send(node.start()) }
             .await
-            .map_err(|e| anyhow::anyhow!("waku start failed: {}", e))?;
+            .map_err(|e| TransportError::Transport(format!("waku start failed: {}", e)))?;
 
         unsafe { assert_send(node.relay_subscribe(&PubsubTopic::new(DEFAULT_PUBSUB_TOPIC))) }
             .await
-            .map_err(|e| anyhow::anyhow!("relay_subscribe failed: {}", e))?;
+            .map_err(|e| TransportError::Transport(format!("relay_subscribe failed: {}", e)))?;
 
         Ok(Self { node, senders })
     }
 
     /// Connect to a peer by multiaddress.
     pub async fn connect(&self, addr: &str) -> Result<()> {
-        let multiaddr: waku_bindings::Multiaddr = addr.parse().context("invalid multiaddress")?;
+        let multiaddr: waku_bindings::Multiaddr = addr
+            .parse()
+            .map_err(|e| TransportError::Transport(format!("invalid multiaddress: {}", e)))?;
         // SAFETY: waku FFI futures are safe to send across threads
         unsafe { assert_send(self.node.connect(&multiaddr, None)) }
             .await
-            .map_err(|e| anyhow::anyhow!("connect failed: {}", e))
+            .map_err(|e| TransportError::Transport(format!("connect failed: {}", e)))
     }
 
     /// Get the listening multiaddresses of this node.
@@ -113,7 +115,7 @@ impl NativeWakuTransport {
         // SAFETY: waku FFI futures are safe to send across threads
         let addrs = unsafe { assert_send(self.node.listen_addresses()) }
             .await
-            .map_err(|e| anyhow::anyhow!("listen_addresses failed: {}", e))?;
+            .map_err(|e| TransportError::Transport(format!("listen_addresses failed: {}", e)))?;
         Ok(addrs.into_iter().map(|a| a.to_string()).collect())
     }
 }
@@ -143,7 +145,7 @@ impl Transport for NativeWakuTransport {
             )
         }
         .await
-        .map_err(|e| anyhow::anyhow!("publish failed: {}", e))?;
+        .map_err(|e| TransportError::Transport(format!("publish failed: {}", e)))?;
         Ok(())
     }
 
@@ -155,7 +157,7 @@ impl Transport for NativeWakuTransport {
 
         self.senders
             .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?
+            .map_err(|e| TransportError::Transport(format!("lock poisoned: {}", e)))?
             .insert(content_topic_str, tx);
 
         Ok(rx)
@@ -167,7 +169,7 @@ impl Transport for NativeWakuTransport {
 
         self.senders
             .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?
+            .map_err(|e| TransportError::Transport(format!("lock poisoned: {}", e)))?
             .remove(&content_topic_str);
 
         Ok(())

--- a/examples/two_agents.rs
+++ b/examples/two_agents.rs
@@ -10,7 +10,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use logos_messaging_a2a::{
-    A2AEnvelope, AgentId, ExecutionBackend, InMemoryTransport, PaymentConfig, Task,
+    A2AEnvelope, AgentId, ExecutionBackend, ExecutionError, InMemoryTransport, PaymentConfig, Task,
     TransferDetails, Transport, TxHash, WakuA2ANode,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -37,11 +37,11 @@ impl ExecutionBackend for MockPaymentBackend {
     async fn register_agent(
         &self,
         _card: &logos_messaging_a2a::AgentCard,
-    ) -> anyhow::Result<TxHash> {
+    ) -> Result<TxHash, ExecutionError> {
         Ok(TxHash([0; 32]))
     }
 
-    async fn pay(&self, _to: &AgentId, amount: u64) -> anyhow::Result<TxHash> {
+    async fn pay(&self, _to: &AgentId, amount: u64) -> Result<TxHash, ExecutionError> {
         let prev = self.balance_a.fetch_sub(amount, Ordering::Relaxed);
         self.balance_b.fetch_add(amount, Ordering::Relaxed);
         println!(
@@ -53,11 +53,11 @@ impl ExecutionBackend for MockPaymentBackend {
         Ok(TxHash([0xaa; 32]))
     }
 
-    async fn balance(&self, _agent: &AgentId) -> anyhow::Result<u64> {
+    async fn balance(&self, _agent: &AgentId) -> Result<u64, ExecutionError> {
         Ok(self.balance_a.load(Ordering::Relaxed))
     }
 
-    async fn verify_transfer(&self, _tx_hash: &str) -> anyhow::Result<TransferDetails> {
+    async fn verify_transfer(&self, _tx_hash: &str) -> Result<TransferDetails, ExecutionError> {
         Ok(TransferDetails {
             from: "0xagent_a".into(),
             to: "0xagent_b".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@
 
 pub use logos_messaging_a2a_core::*;
 pub use logos_messaging_a2a_crypto::{AgentIdentity, EncryptedPayload, IntroBundle, SessionKey};
-pub use logos_messaging_a2a_execution::{AgentId, ExecutionBackend, TransferDetails, TxHash};
+pub use logos_messaging_a2a_execution::{
+    AgentId, ExecutionBackend, ExecutionError, TransferDetails, TxHash,
+};
 pub use logos_messaging_a2a_node::{PaymentConfig, WakuA2ANode};
 pub use logos_messaging_a2a_storage::{
     maybe_offload, LogosStorageRest, StorageBackend, StorageError, DEFAULT_OFFLOAD_THRESHOLD,


### PR DESCRIPTION
## 🎯 Purpose
Replace anyhow with thiserror in library crates for proper error types.

## ⚙️ Approach
Defined dedicated error enums per crate using thiserror.

## 🧪 How to Test
cargo test --workspace

## 🔗 Dependencies
thiserror crate

## 🔜 Future Work
None

## 📋 Checklist
- [x] Tests pass
- [x] Clippy clean
- [x] Formatted