### PR TITLE
docs: add missing documentation for public API items

### DIFF
--- a/crates/logos-messaging-a2a-core/src/lib.rs
+++ b/crates/logos-messaging-a2a-core/src/lib.rs
@@ -16,12 +16,18 @@
 //! - [`registry`] — Persistent agent registry trait and in-memory implementation.
 //! - [`retry`] — Exponential-backoff retry configuration.
 
+/// Agent identity and capability advertisement types.
 pub mod agent;
+/// Multi-agent task delegation types and strategies.
 pub mod delegation;
+/// Wire envelope for all Waku messages.
 pub mod envelope;
+/// Signed presence announcements for ephemeral peer discovery.
 pub mod presence;
 pub mod registry;
+/// Exponential-backoff retry configuration.
 pub mod retry;
+/// Task lifecycle types and message parts.
 pub mod task;
 pub mod topics;
 

--- a/crates/logos-messaging-a2a-core/src/presence.rs
+++ b/crates/logos-messaging-a2a-core/src/presence.rs
@@ -5,18 +5,23 @@ use serde::{Deserialize, Serialize};
 /// Errors that can occur during presence verification.
 #[derive(Debug, thiserror::Error)]
 pub enum PresenceError {
+    /// The announcement has no signature field set.
     #[error("missing signature")]
     MissingSignature,
 
+    /// The `agent_id` field is not valid hexadecimal.
     #[error("agent_id is not valid hex: {0}")]
     InvalidHex(#[from] hex::FromHexError),
 
+    /// The `agent_id` hex does not decode to a valid secp256k1 public key.
     #[error("agent_id is not a valid secp256k1 public key: {0}")]
     InvalidPublicKey(#[source] k256::ecdsa::Error),
 
+    /// The signature bytes are not valid DER-encoded ECDSA.
     #[error("signature is not valid DER: {0}")]
     InvalidSignature(#[source] k256::ecdsa::Error),
 
+    /// The signature does not match the announcement contents and public key.
     #[error("signature verification failed: {0}")]
     VerificationFailed(#[source] k256::ecdsa::Error),
 }

--- a/crates/logos-messaging-a2a-crypto/src/lib.rs
+++ b/crates/logos-messaging-a2a-crypto/src/lib.rs
@@ -20,18 +20,23 @@ use x25519_dalek::{PublicKey, StaticSecret};
 /// Errors that can occur during cryptographic operations.
 #[derive(Debug, thiserror::Error)]
 pub enum CryptoError {
+    /// The input string is not valid hexadecimal.
     #[error("invalid hex: {0}")]
     Hex(#[from] hex::FromHexError),
 
+    /// A key has the wrong byte length (e.g. not 32 bytes for X25519).
     #[error("{0}")]
     InvalidKeyLength(String),
 
+    /// An error from the ChaCha20-Poly1305 AEAD cipher.
     #[error("cipher error: {0}")]
     Cipher(String),
 
+    /// The nonce field is not valid base64.
     #[error("invalid base64 nonce")]
     InvalidBase64Nonce(#[source] base64::DecodeError),
 
+    /// The ciphertext field is not valid base64.
     #[error("invalid base64 ciphertext")]
     InvalidBase64Ciphertext(#[source] base64::DecodeError),
 }

--- a/crates/logos-messaging-a2a-execution/src/lib.rs
+++ b/crates/logos-messaging-a2a-execution/src/lib.rs
@@ -16,9 +16,11 @@ use std::fmt;
 /// Errors that can occur during execution backend operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ExecutionError {
+    /// An error returned by the JSON-RPC provider.
     #[error("RPC error: {0}")]
     Rpc(String),
 
+    /// A catch-all error with a freeform message.
     #[error("{0}")]
     Other(String),
 }

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -20,24 +20,31 @@ mod tasks;
 /// Errors that can occur in node operations.
 #[derive(Debug, thiserror::Error)]
 pub enum NodeError {
+    /// An error originating from the transport layer.
     #[error("transport error: {0}")]
     Transport(#[from] logos_messaging_a2a_transport::TransportError),
 
+    /// An error originating from the crypto layer.
     #[error("crypto error: {0}")]
     Crypto(#[from] logos_messaging_a2a_crypto::CryptoError),
 
+    /// A JSON serialization or deserialization error.
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    /// An error originating from the execution backend.
     #[error("execution error: {0}")]
     Execution(#[from] logos_messaging_a2a_execution::ExecutionError),
 
+    /// An error originating from presence verification.
     #[error("presence error: {0}")]
     Presence(#[from] logos_messaging_a2a_core::PresenceError),
 
+    /// An I/O error (e.g. reading a keyfile).
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// A catch-all error with a freeform message.
     #[error("{0}")]
     Other(String),
 }

--- a/crates/logos-messaging-a2a-transport/src/lib.rs
+++ b/crates/logos-messaging-a2a-transport/src/lib.rs
@@ -15,12 +15,15 @@ use async_trait::async_trait;
 /// Errors that can occur during transport operations.
 #[derive(Debug, thiserror::Error)]
 pub enum TransportError {
+    /// An error from the underlying transport backend (e.g. nwaku REST, IPC).
     #[error("{0}")]
     Transport(String),
 
+    /// A JSON serialization or deserialization error.
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    /// A catch-all error with a freeform message.
     #[error("{0}")]
     Other(String),
 }


### PR DESCRIPTION
## 🎯 Purpose
Add documentation for all undocumented public enum variants and modules across library crates.

## ⚙️ Approach
- Added /// doc comments to all public enum variants missing documentation
- Added //! module docs where missing
- No behavioral changes

## 🧪 How to Test
```bash
RUSTDOCFLAGS="-W missing-docs" cargo doc --workspace --no-deps
cargo test --workspace
```

## 🔗 Dependencies
None

## 🔜 Future Work
- Add #[warn(missing_docs)] lint to library crates to prevent regression

## 📋 Checklist
- [x] cargo fmt
- [x] cargo clippy -- -D warnings
- [x] cargo test --workspace (all pass)
- [x] No missing-docs warnings for library crates