### PR TITLE
feat(cli): skill marketplace phase 1 — publish, list, info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,11 +1291,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1306,7 +1327,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2417,8 +2438,10 @@ name = "logos-messaging-a2a-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "clap_complete",
+ "dirs 5.0.1",
  "hex",
  "k256 0.13.4",
  "logos-messaging-a2a-core",
@@ -2428,9 +2451,11 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -3371,6 +3396,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4206,7 +4242,7 @@ dependencies = [
  "bindgen 0.72.1",
  "bytesize",
  "cc",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures",
  "hex",
@@ -5127,6 +5163,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5150,6 +5195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5187,6 +5247,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5199,6 +5265,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5208,6 +5280,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5235,6 +5313,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5244,6 +5328,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5259,6 +5349,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5268,6 +5364,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/logos-messaging-a2a-cli/Cargo.toml
+++ b/crates/logos-messaging-a2a-cli/Cargo.toml
@@ -22,6 +22,10 @@ hex = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
+sha2 = { workspace = true }
+dirs = "5"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/logos-messaging-a2a-cli/src/cli.rs
+++ b/crates/logos-messaging-a2a-cli/src/cli.rs
@@ -64,6 +64,11 @@ pub enum Commands {
     },
     /// Display agent identity and topic configuration
     Info,
+    /// Skill marketplace (publish, list, inspect)
+    Skill {
+        #[command(subcommand)]
+        action: SkillAction,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -996,4 +1001,47 @@ mod tests {
         assert!(cli.encrypt);
         assert_eq!(cli.keyfile, Some(PathBuf::from("/tmp/k.key")));
     }
+}
+
+// ── Skill marketplace ────────────────────────────────────────────────────────
+
+#[derive(Debug, Subcommand)]
+pub enum SkillAction {
+    /// Publish a skill file to the local skill registry.
+    ///
+    /// Creates a skill bundle JSON at `~/.config/lmao/skills/<id>.json`.
+    Publish {
+        /// Path to a SKILL.md file or a directory containing one.
+        #[arg(long)]
+        path: std::path::PathBuf,
+
+        /// Override the skill name (default: first heading in the file).
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Author name or handle (default: git user.name or $USER).
+        #[arg(long)]
+        author: Option<String>,
+
+        /// Semantic version (default: "1.0.0").
+        #[arg(long, default_value = "1.0.0")]
+        version: String,
+
+        /// Comma-separated tags, e.g. `rust,cli,ai` (default: parsed from file).
+        #[arg(long)]
+        tags: Option<String>,
+    },
+
+    /// List locally published skills.
+    List {
+        /// Filter by tag.
+        #[arg(long)]
+        tag: Option<String>,
+    },
+
+    /// Show full details of a skill bundle.
+    Info {
+        /// Skill ID or unambiguous prefix.
+        id: String,
+    },
 }

--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -7,6 +7,7 @@ mod info;
 mod metrics;
 mod presence;
 mod session;
+mod skill;
 mod task;
 
 use anyhow::Result;
@@ -44,5 +45,6 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Info => info::handle(transport, &identity, json),
+        Commands::Skill { action } => skill::handle(action, json),
     }
 }

--- a/crates/logos-messaging-a2a-cli/src/skill.rs
+++ b/crates/logos-messaging-a2a-cli/src/skill.rs
@@ -1,0 +1,620 @@
+//! Skill marketplace — local publish, list, and inspect commands.
+//!
+//! Skills are stored as JSON bundles in `~/.config/lmao/skills/<id>.json`.
+//! Phase 1 implements local-only storage; on-chain LEZ integration is
+//! deferred to a later phase.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::cli::SkillAction;
+
+// ── Data model ──────────────────────────────────────────────────────────────
+
+/// A published skill bundle stored locally.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillBundle {
+    /// Unique identifier (UUID v4).
+    pub id: String,
+    /// Human-readable skill name.
+    pub name: String,
+    /// One-sentence description.
+    pub description: String,
+    /// Searchable tags.
+    pub tags: Vec<String>,
+    /// Author name / handle.
+    pub author: String,
+    /// Semantic version string, e.g. "1.0.0".
+    pub version: String,
+    /// SHA-256 hex digest of the raw skill file contents.
+    pub content_hash: String,
+    /// ISO 8601 timestamp when this bundle was created.
+    pub published_at: String,
+    /// Absolute path to the original skill file on disk.
+    pub path: String,
+}
+
+// ── Directory helpers ────────────────────────────────────────────────────────
+
+/// Returns `~/.config/lmao/skills/`, creating it if necessary.
+fn skills_dir() -> Result<PathBuf> {
+    let base = dirs::config_dir().ok_or_else(|| anyhow!("cannot locate config directory"))?;
+    let dir = base.join("lmao").join("skills");
+    fs::create_dir_all(&dir).with_context(|| format!("creating skills dir {}", dir.display()))?;
+    Ok(dir)
+}
+
+/// Path for a specific skill bundle file.
+fn bundle_path(dir: &Path, id: &str) -> PathBuf {
+    dir.join(format!("{}.json", id))
+}
+
+// ── Parsing helpers ──────────────────────────────────────────────────────────
+
+/// Extract the first Markdown heading (`# Heading`) from skill file content.
+/// Falls back to the directory / file name when no heading is found.
+fn extract_name(content: &str, fallback: &str) -> String {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            let name = rest.trim().to_string();
+            if !name.is_empty() {
+                return name;
+            }
+        }
+    }
+    fallback.to_string()
+}
+
+/// Extract a description from the skill file.
+///
+/// Looks for a line matching `Description: ...` (case-insensitive).
+/// Falls back to the first non-heading, non-empty paragraph.
+fn extract_description(content: &str) -> String {
+    // Explicit "Description: ..." line
+    for line in content.lines() {
+        let lower = line.to_lowercase();
+        if lower.starts_with("description:") {
+            if let Some(colon_pos) = line.find(':') {
+                let desc = line[colon_pos + 1..].trim().to_string();
+                if !desc.is_empty() {
+                    return desc;
+                }
+            }
+        }
+    }
+
+    // First non-heading, non-empty paragraph
+    let mut past_heading = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            past_heading = true;
+            continue;
+        }
+        if past_heading && !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    String::new()
+}
+
+/// Extract tags from the skill file.
+///
+/// Looks for a line matching `Tags: foo, bar, baz` (case-insensitive).
+fn extract_tags(content: &str) -> Vec<String> {
+    for line in content.lines() {
+        let lower = line.to_lowercase();
+        if lower.starts_with("tags:") {
+            if let Some(colon_pos) = line.find(':') {
+                let tag_str = line[colon_pos + 1..].trim();
+                return tag_str
+                    .split(',')
+                    .map(|t| t.trim().to_lowercase())
+                    .filter(|t| !t.is_empty())
+                    .collect();
+            }
+        }
+    }
+    vec![]
+}
+
+/// Resolve the skill file path (accepts a directory containing SKILL.md or a
+/// direct path to any `.md` file).
+fn resolve_skill_file(path: &Path) -> Result<PathBuf> {
+    let p = path
+        .canonicalize()
+        .with_context(|| format!("path not found or not accessible: {}", path.display()))?;
+
+    if p.is_dir() {
+        let candidate = p.join("SKILL.md");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        return Err(anyhow!(
+            "directory {} does not contain SKILL.md",
+            p.display()
+        ));
+    }
+
+    Ok(p)
+}
+
+/// Determine the author: `--author` flag -> git `user.name` -> `$USER`.
+fn resolve_author(author_flag: Option<&str>) -> String {
+    if let Some(a) = author_flag {
+        if !a.trim().is_empty() {
+            return a.trim().to_string();
+        }
+    }
+
+    // Try git config
+    if let Ok(out) = Command::new("git")
+        .args(["config", "--global", "user.name"])
+        .output()
+    {
+        let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !name.is_empty() {
+            return name;
+        }
+    }
+
+    // Fall back to $USER
+    std::env::var("USER").unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Compute SHA-256 hex digest of bytes.
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+// ── Command handlers ─────────────────────────────────────────────────────────
+
+/// Dispatch a `skill` subcommand.
+pub fn handle(action: SkillAction, json: bool) -> Result<()> {
+    match action {
+        SkillAction::Publish {
+            path,
+            name,
+            author,
+            version,
+            tags,
+        } => publish(path, name, author, version, tags, json),
+        SkillAction::List { tag } => list(tag, json),
+        SkillAction::Info { id } => info(&id, json),
+    }
+}
+
+/// `skill publish` -- bundle a skill file and write it to the skills directory.
+fn publish(
+    path: PathBuf,
+    name_flag: Option<String>,
+    author_flag: Option<String>,
+    version: String,
+    tags_flag: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let skill_file = resolve_skill_file(&path)?;
+    let content = fs::read_to_string(&skill_file)
+        .with_context(|| format!("reading skill file {}", skill_file.display()))?;
+
+    // Derive name: flag > heading > file stem
+    let fallback_name = skill_file
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let name = name_flag
+        .filter(|n| !n.trim().is_empty())
+        .unwrap_or_else(|| extract_name(&content, &fallback_name));
+
+    let description = extract_description(&content);
+
+    // Tags: flag overrides parsed tags
+    let tags = if let Some(t) = tags_flag {
+        t.split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect()
+    } else {
+        extract_tags(&content)
+    };
+
+    let author = resolve_author(author_flag.as_deref());
+    let id = Uuid::new_v4().to_string();
+    let content_hash = sha256_hex(content.as_bytes());
+    let published_at = Utc::now().to_rfc3339();
+    let abs_path = skill_file.to_string_lossy().to_string();
+
+    let bundle = SkillBundle {
+        id: id.clone(),
+        name: name.clone(),
+        description: description.clone(),
+        tags: tags.clone(),
+        author: author.clone(),
+        version: version.clone(),
+        content_hash,
+        published_at: published_at.clone(),
+        path: abs_path,
+    };
+
+    let dir = skills_dir()?;
+    let dest = bundle_path(&dir, &id);
+    let serialized = serde_json::to_string_pretty(&bundle)?;
+    fs::write(&dest, &serialized)
+        .with_context(|| format!("writing skill bundle to {}", dest.display()))?;
+
+    if json {
+        println!("{}", serde_json::to_string(&bundle)?);
+    } else {
+        println!("Skill published");
+        println!("  ID:          {id}");
+        println!("  Name:        {name}");
+        println!("  Author:      {author}");
+        println!("  Version:     {version}");
+        println!("  Tags:        {}", tags.join(", "));
+        println!("  Description: {description}");
+        println!("  Saved to:    {}", dest.display());
+    }
+
+    Ok(())
+}
+
+/// `skill list` -- list all locally published skills, with optional tag filter.
+fn list(tag_filter: Option<String>, json: bool) -> Result<()> {
+    let dir = skills_dir()?;
+    let mut bundles: Vec<SkillBundle> = vec![];
+
+    for entry in fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let raw =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        match serde_json::from_str::<SkillBundle>(&raw) {
+            Ok(b) => bundles.push(b),
+            Err(e) => {
+                eprintln!("warning: skipping malformed bundle {}: {e}", path.display());
+            }
+        }
+    }
+
+    // Apply tag filter
+    if let Some(ref tag) = tag_filter {
+        let tag_lc = tag.to_lowercase();
+        bundles.retain(|b| b.tags.iter().any(|t| t == &tag_lc));
+    }
+
+    // Sort by published_at descending (newest first)
+    bundles.sort_by(|a, b| b.published_at.cmp(&a.published_at));
+
+    if json {
+        println!("{}", serde_json::to_string(&bundles)?);
+        return Ok(());
+    }
+
+    if bundles.is_empty() {
+        if let Some(ref tag) = tag_filter {
+            println!("No skills found with tag '{tag}'.");
+        } else {
+            println!("No skills published yet. Run `skill publish --path <SKILL.md>` to add one.");
+        }
+        return Ok(());
+    }
+
+    println!(
+        "{:<38} {:<24} {:<16} {:<10} Tags",
+        "ID", "Name", "Author", "Version"
+    );
+    println!("{}", "-".repeat(110));
+    for b in &bundles {
+        println!(
+            "{:<38} {:<24} {:<16} {:<10} {}",
+            b.id,
+            truncate(&b.name, 22),
+            truncate(&b.author, 14),
+            b.version,
+            b.tags.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+/// `skill info <id>` -- show full details of a skill bundle.
+fn info(id: &str, json: bool) -> Result<()> {
+    let dir = skills_dir()?;
+
+    // Support prefix matching
+    let bundle = find_bundle(&dir, id)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&bundle)?);
+        return Ok(());
+    }
+
+    println!("ID:           {}", bundle.id);
+    println!("Name:         {}", bundle.name);
+    println!("Author:       {}", bundle.author);
+    println!("Version:      {}", bundle.version);
+    println!("Tags:         {}", bundle.tags.join(", "));
+    println!("Description:  {}", bundle.description);
+    println!("Content hash: {}", bundle.content_hash);
+    println!("Published:    {}", bundle.published_at);
+    println!("Path:         {}", bundle.path);
+
+    Ok(())
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────────
+
+/// Find a bundle by exact ID or unambiguous prefix.
+fn find_bundle(dir: &Path, id_or_prefix: &str) -> Result<SkillBundle> {
+    let mut matches = vec![];
+
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if stem == id_or_prefix || stem.starts_with(id_or_prefix) {
+            let raw =
+                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+            if let Ok(b) = serde_json::from_str::<SkillBundle>(&raw) {
+                matches.push(b);
+            }
+        }
+    }
+
+    match matches.len() {
+        0 => Err(anyhow!(
+            "no skill found with id (or prefix) '{id_or_prefix}'"
+        )),
+        1 => Ok(matches.remove(0)),
+        n => Err(anyhow!(
+            "ambiguous prefix '{id_or_prefix}' -- matches {n} skills; use a longer prefix"
+        )),
+    }
+}
+
+/// Truncate a string to `max` characters, appending `...` if needed.
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_skill_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+        let p = dir.path().join(name);
+        fs::write(&p, content).unwrap();
+        p
+    }
+
+    // ── extract_name ──
+
+    #[test]
+    fn extract_name_from_heading() {
+        let md = "# My Skill\n\nDoes things.";
+        assert_eq!(extract_name(md, "fallback"), "My Skill");
+    }
+
+    #[test]
+    fn extract_name_falls_back() {
+        let md = "No heading here.";
+        assert_eq!(extract_name(md, "my-skill"), "my-skill");
+    }
+
+    #[test]
+    fn extract_name_ignores_h2() {
+        let md = "## Not a top heading\n# Real";
+        assert_eq!(extract_name(md, "fb"), "Real");
+    }
+
+    // ── extract_description ──
+
+    #[test]
+    fn extract_description_explicit_label() {
+        let md = "# Skill\n\nDescription: Does cool things.";
+        assert_eq!(extract_description(md), "Does cool things.");
+    }
+
+    #[test]
+    fn extract_description_first_paragraph() {
+        let md = "# Skill\n\nThis is the first paragraph.";
+        assert_eq!(extract_description(md), "This is the first paragraph.");
+    }
+
+    #[test]
+    fn extract_description_empty_when_nothing() {
+        let md = "# Skill";
+        assert_eq!(extract_description(md), "");
+    }
+
+    // ── extract_tags ──
+
+    #[test]
+    fn extract_tags_comma_separated() {
+        let md = "# Skill\n\nTags: rust, cli, test";
+        assert_eq!(extract_tags(md), vec!["rust", "cli", "test"]);
+    }
+
+    #[test]
+    fn extract_tags_case_insensitive_key() {
+        let md = "TAGS: foo, Bar";
+        assert_eq!(extract_tags(md), vec!["foo", "bar"]);
+    }
+
+    #[test]
+    fn extract_tags_empty_when_missing() {
+        let md = "# No tags here";
+        assert!(extract_tags(md).is_empty());
+    }
+
+    // ── sha256_hex ──
+
+    #[test]
+    fn sha256_is_stable() {
+        let h1 = sha256_hex(b"hello");
+        let h2 = sha256_hex(b"hello");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64);
+    }
+
+    #[test]
+    fn sha256_differs_for_different_input() {
+        assert_ne!(sha256_hex(b"hello"), sha256_hex(b"world"));
+    }
+
+    // ── resolve_skill_file ──
+
+    #[test]
+    fn resolve_direct_md_file() {
+        let dir = TempDir::new().unwrap();
+        let p = make_skill_file(&dir, "skill.md", "# S");
+        let resolved = resolve_skill_file(&p).unwrap();
+        assert_eq!(resolved, p.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_directory_with_skill_md() {
+        let dir = TempDir::new().unwrap();
+        let skill_md = dir.path().join("SKILL.md");
+        fs::write(&skill_md, "# S").unwrap();
+        let resolved = resolve_skill_file(dir.path()).unwrap();
+        assert_eq!(resolved, skill_md.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_directory_missing_skill_md_errors() {
+        let dir = TempDir::new().unwrap();
+        let err = resolve_skill_file(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("does not contain SKILL.md"));
+    }
+
+    #[test]
+    fn resolve_nonexistent_path_errors() {
+        let err = resolve_skill_file(Path::new("/tmp/does_not_exist_xyz123.md")).unwrap_err();
+        assert!(
+            err.to_string().contains("not found")
+                || err.to_string().contains("No such file")
+                || err.to_string().contains("not accessible")
+        );
+    }
+
+    // ── truncate ──
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string_has_ellipsis() {
+        let s = truncate("abcdefghij", 5);
+        assert!(s.ends_with("..."));
+    }
+
+    // ── find_bundle ──
+
+    fn write_bundle(dir: &Path, bundle: &SkillBundle) {
+        let path = bundle_path(dir, &bundle.id);
+        fs::write(path, serde_json::to_string_pretty(bundle).unwrap()).unwrap();
+    }
+
+    fn make_bundle(id: &str, name: &str, tags: &[&str]) -> SkillBundle {
+        SkillBundle {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: "A test skill.".to_string(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            author: "tester".to_string(),
+            version: "1.0.0".to_string(),
+            content_hash: sha256_hex(name.as_bytes()),
+            published_at: "2024-01-01T00:00:00Z".to_string(),
+            path: "/tmp/fake-skill.md".to_string(),
+        }
+    }
+
+    #[test]
+    fn find_bundle_exact_id() {
+        let dir = TempDir::new().unwrap();
+        let b = make_bundle("aaaa-1111", "Alpha", &["a"]);
+        write_bundle(dir.path(), &b);
+        let found = find_bundle(dir.path(), "aaaa-1111").unwrap();
+        assert_eq!(found.id, "aaaa-1111");
+    }
+
+    #[test]
+    fn find_bundle_prefix() {
+        let dir = TempDir::new().unwrap();
+        let b = make_bundle("bbbb-2222-cccc", "Beta", &["b"]);
+        write_bundle(dir.path(), &b);
+        let found = find_bundle(dir.path(), "bbbb").unwrap();
+        assert_eq!(found.id, "bbbb-2222-cccc");
+    }
+
+    #[test]
+    fn find_bundle_missing_errors() {
+        let dir = TempDir::new().unwrap();
+        let err = find_bundle(dir.path(), "no-such-id").unwrap_err();
+        assert!(err.to_string().contains("no skill found"));
+    }
+
+    #[test]
+    fn find_bundle_ambiguous_prefix_errors() {
+        let dir = TempDir::new().unwrap();
+        write_bundle(dir.path(), &make_bundle("aaa-111", "One", &[]));
+        write_bundle(dir.path(), &make_bundle("aaa-222", "Two", &[]));
+        let err = find_bundle(dir.path(), "aaa").unwrap_err();
+        assert!(err.to_string().contains("ambiguous"));
+    }
+
+    #[test]
+    fn bundle_roundtrip_json() {
+        let b = make_bundle("id-123", "MySkill", &["rust", "cli"]);
+        let json = serde_json::to_string(&b).unwrap();
+        let back: SkillBundle = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, b.id);
+        assert_eq!(back.tags, b.tags);
+    }
+
+    #[test]
+    fn malformed_json_skipped_silently_in_find() {
+        let dir = TempDir::new().unwrap();
+        let good = make_bundle("good-id", "Good", &[]);
+        write_bundle(dir.path(), &good);
+        fs::write(dir.path().join("bad.json"), "not json at all").unwrap();
+
+        // find_bundle should still find the good one despite bad.json
+        let found = find_bundle(dir.path(), "good-id").unwrap();
+        assert_eq!(found.id, "good-id");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #140 (Phase 1)

Adds a `skill` subcommand group to the CLI with three commands for local skill registry management.

## Commands

### `skill publish --path <SKILL.md>`
Bundles a skill file and writes it to `~/.config/lmao/skills/<uuid>.json`:
- `id` — UUID v4
- `name` — parsed from first Markdown heading (`# ...`) or overridden with `--name`
- `description` — from `Description:` line or first paragraph
- `tags` — from `Tags: foo, bar` line or overridden with `--tags`
- `author` — from `--author` flag, then `git config user.name`, then `$USER`
- `version` — from `--version` flag (default: `1.0.0`)
- `content_hash` — SHA-256 of the skill file contents
- `published_at` — ISO 8601 timestamp
- `path` — absolute path to the original skill file

### `skill list [--tag <tag>]`
Lists all published skills in a table (ID, Name, Author, Version, Tags), sorted newest-first. Accepts an optional `--tag` filter.

### `skill info <id-or-prefix>`
Shows full bundle details. Supports unambiguous prefix matching (e.g. first 8 chars of ID).

All three commands support the global `--json` flag for machine-readable output.

## Implementation

- New `skill.rs` module following existing `info.rs`/`presence.rs` style
- `SkillBundle` struct with full Serde JSON serialisation  
- New deps: `uuid`, `sha2`, `dirs`, `chrono` (all from workspace or new crate-level)
- `SkillAction` enum added to `cli.rs`; `Commands::Skill` variant wired up in `main.rs`
- **18 new unit tests** covering all parsing helpers and bundle CRUD

## Tests

```
test result: ok. 105 passed; 0 failed; 0 ignored
```

## Out of scope (Phase 2)

- On-chain LEZ program integration
- Peer-to-peer skill discovery / ranking / auto-adopt