### PR TITLE
feat(transport): add LogosCoreMixTransport for direct agent-to-agent communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,11 +1291,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1306,7 +1327,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2417,8 +2438,10 @@ name = "logos-messaging-a2a-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "clap_complete",
+ "dirs 5.0.1",
  "hex",
  "k256 0.13.4",
  "logos-messaging-a2a-core",
@@ -2428,9 +2451,11 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -3371,6 +3396,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4206,7 +4242,7 @@ dependencies = [
  "bindgen 0.72.1",
  "bytesize",
  "cc",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures",
  "hex",
@@ -5127,6 +5163,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5150,6 +5195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5187,6 +5247,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5199,6 +5265,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5208,6 +5280,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5235,6 +5313,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5244,6 +5328,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5259,6 +5349,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5268,6 +5364,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/lmao-ffi/Cargo.toml
+++ b/crates/lmao-ffi/Cargo.toml
@@ -7,6 +7,10 @@ description = "C FFI wrapper for LMAO (A2A over Waku)"
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
+[features]
+default = []
+logos-delivery = ["logos-messaging-a2a-transport/logos-delivery"]
+
 [dependencies]
 logos-messaging-a2a-node = { path = "../logos-messaging-a2a-node" }
 logos-messaging-a2a-core = { path = "../logos-messaging-a2a-core" }

--- a/crates/lmao-ffi/include/lmao_ffi.h
+++ b/crates/lmao-ffi/include/lmao_ffi.h
@@ -45,4 +45,24 @@ void lmao_free_string(char *s);
  */
 char *lmao_version(void);
 
+/* ── QtRO Delivery Transport Bridge ─────────────────────────────────────── */
+
+typedef int (*LmaoPublishFn)(const char *topic, const char *payload_b64, void *user_data);
+typedef int (*LmaoSubscribeFn)(const char *topic, void *user_data);
+typedef int (*LmaoUnsubscribeFn)(const char *topic, void *user_data);
+
+/**
+ * Register QtRO delivery callbacks. Called once during module init.
+ * Returns 1 on success, 0 if already registered.
+ */
+int lmao_qtro_set_callbacks(LmaoPublishFn publish_fn,
+                            LmaoSubscribeFn subscribe_fn,
+                            LmaoUnsubscribeFn unsubscribe_fn,
+                            void *user_data);
+
+/**
+ * Called from C++ when delivery_module emits a message on a subscribed topic.
+ */
+void lmao_qtro_on_message(const char *topic, const char *payload_b64);
+
 #endif  /* LMAO_FFI_H */

--- a/crates/lmao-ffi/include/lmao_ffi.h
+++ b/crates/lmao-ffi/include/lmao_ffi.h
@@ -45,24 +45,22 @@ void lmao_free_string(char *s);
  */
 char *lmao_version(void);
 
-/* ── QtRO Delivery Transport Bridge ─────────────────────────────────────── */
-
-typedef int (*LmaoPublishFn)(const char *topic, const char *payload_b64, void *user_data);
-typedef int (*LmaoSubscribeFn)(const char *topic, void *user_data);
-typedef int (*LmaoUnsubscribeFn)(const char *topic, void *user_data);
-
 /**
- * Register QtRO delivery callbacks. Called once during module init.
- * Returns 1 on success, 0 if already registered.
+ * Register QtRO delivery callbacks from the C++ module host.
+ *
+ * Must be called once during module initialization, before any transport
+ * operations. The C++ side obtains a delivery_module QtRO replica via
+ * `logosAPI->getClient("delivery_module")` and provides function pointers
+ * that forward publish/subscribe/unsubscribe calls to the replica.
+ *
+ * Returns 1 on success, 0 if callbacks were already registered.
+ *
+ * # Safety
+ * All function pointers and `user_data` must remain valid for the process lifetime.
  */
-int lmao_qtro_set_callbacks(LmaoPublishFn publish_fn,
-                            LmaoSubscribeFn subscribe_fn,
-                            LmaoUnsubscribeFn unsubscribe_fn,
+int lmao_qtro_set_callbacks(lmaoPublishFn publish_fn,
+                            lmaoSubscribeFn subscribe_fn,
+                            lmaoUnsubscribeFn unsubscribe_fn,
                             void *user_data);
-
-/**
- * Called from C++ when delivery_module emits a message on a subscribed topic.
- */
-void lmao_qtro_on_message(const char *topic, const char *payload_b64);
 
 #endif  /* LMAO_FFI_H */

--- a/crates/lmao-ffi/src/lib.rs
+++ b/crates/lmao-ffi/src/lib.rs
@@ -214,6 +214,45 @@ pub extern "C" fn lmao_version() -> *mut c_char {
     to_cstring(env!("CARGO_PKG_VERSION").to_string())
 }
 
+// ── QtRO Delivery Transport Bridge ────────────────────────────────────────
+//
+// These functions allow the C++ module host to inject QtRO-based delivery
+// transport callbacks at runtime, replacing the need for liblogos_core linkage.
+// The C++ side calls logosAPI->getClient("delivery_module") to get a QtRO
+// replica and wires the callbacks through lmao_qtro_set_callbacks().
+
+/// Register QtRO delivery callbacks from the C++ module host.
+///
+/// Must be called once during module initialization, before any transport
+/// operations. The C++ side obtains a delivery_module QtRO replica via
+/// `logosAPI->getClient("delivery_module")` and provides function pointers
+/// that forward publish/subscribe/unsubscribe calls to the replica.
+///
+/// Returns 1 on success, 0 if callbacks were already registered.
+///
+/// # Safety
+/// All function pointers and `user_data` must remain valid for the process lifetime.
+#[cfg(feature = "logos-delivery")]
+#[no_mangle]
+pub unsafe extern "C" fn lmao_qtro_set_callbacks(
+    publish_fn: logos_messaging_a2a_transport::logos_delivery_qtro::PublishFn,
+    subscribe_fn: logos_messaging_a2a_transport::logos_delivery_qtro::SubscribeFn,
+    unsubscribe_fn: logos_messaging_a2a_transport::logos_delivery_qtro::UnsubscribeFn,
+    user_data: *mut std::ffi::c_void,
+) -> std::os::raw::c_int {
+    let cbs = logos_messaging_a2a_transport::logos_delivery_qtro::QtROCallbacks {
+        publish: publish_fn,
+        subscribe: subscribe_fn,
+        unsubscribe: unsubscribe_fn,
+        user_data,
+    };
+    if logos_messaging_a2a_transport::logos_delivery_qtro::set_qtro_callbacks(cbs) {
+        1
+    } else {
+        0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/logos-messaging-a2a-cli/Cargo.toml
+++ b/crates/logos-messaging-a2a-cli/Cargo.toml
@@ -22,6 +22,10 @@ hex = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
+sha2 = { workspace = true }
+dirs = "5"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/logos-messaging-a2a-cli/src/cli.rs
+++ b/crates/logos-messaging-a2a-cli/src/cli.rs
@@ -64,6 +64,11 @@ pub enum Commands {
     },
     /// Display agent identity and topic configuration
     Info,
+    /// Skill marketplace (publish, list, inspect)
+    Skill {
+        #[command(subcommand)]
+        action: SkillAction,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -996,4 +1001,47 @@ mod tests {
         assert!(cli.encrypt);
         assert_eq!(cli.keyfile, Some(PathBuf::from("/tmp/k.key")));
     }
+}
+
+// ── Skill marketplace ────────────────────────────────────────────────────────
+
+#[derive(Debug, Subcommand)]
+pub enum SkillAction {
+    /// Publish a skill file to the local skill registry.
+    ///
+    /// Creates a skill bundle JSON at `~/.config/lmao/skills/<id>.json`.
+    Publish {
+        /// Path to a SKILL.md file or a directory containing one.
+        #[arg(long)]
+        path: std::path::PathBuf,
+
+        /// Override the skill name (default: first heading in the file).
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Author name or handle (default: git user.name or $USER).
+        #[arg(long)]
+        author: Option<String>,
+
+        /// Semantic version (default: "1.0.0").
+        #[arg(long, default_value = "1.0.0")]
+        version: String,
+
+        /// Comma-separated tags, e.g. `rust,cli,ai` (default: parsed from file).
+        #[arg(long)]
+        tags: Option<String>,
+    },
+
+    /// List locally published skills.
+    List {
+        /// Filter by tag.
+        #[arg(long)]
+        tag: Option<String>,
+    },
+
+    /// Show full details of a skill bundle.
+    Info {
+        /// Skill ID or unambiguous prefix.
+        id: String,
+    },
 }

--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -7,6 +7,7 @@ mod info;
 mod metrics;
 mod presence;
 mod session;
+mod skill;
 mod task;
 
 use anyhow::Result;
@@ -44,5 +45,6 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Info => info::handle(transport, &identity, json),
+        Commands::Skill { action } => skill::handle(action, json),
     }
 }

--- a/crates/logos-messaging-a2a-cli/src/skill.rs
+++ b/crates/logos-messaging-a2a-cli/src/skill.rs
@@ -1,0 +1,620 @@
+//! Skill marketplace — local publish, list, and inspect commands.
+//!
+//! Skills are stored as JSON bundles in `~/.config/lmao/skills/<id>.json`.
+//! Phase 1 implements local-only storage; on-chain LEZ integration is
+//! deferred to a later phase.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::cli::SkillAction;
+
+// ── Data model ──────────────────────────────────────────────────────────────
+
+/// A published skill bundle stored locally.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillBundle {
+    /// Unique identifier (UUID v4).
+    pub id: String,
+    /// Human-readable skill name.
+    pub name: String,
+    /// One-sentence description.
+    pub description: String,
+    /// Searchable tags.
+    pub tags: Vec<String>,
+    /// Author name / handle.
+    pub author: String,
+    /// Semantic version string, e.g. "1.0.0".
+    pub version: String,
+    /// SHA-256 hex digest of the raw skill file contents.
+    pub content_hash: String,
+    /// ISO 8601 timestamp when this bundle was created.
+    pub published_at: String,
+    /// Absolute path to the original skill file on disk.
+    pub path: String,
+}
+
+// ── Directory helpers ────────────────────────────────────────────────────────
+
+/// Returns `~/.config/lmao/skills/`, creating it if necessary.
+fn skills_dir() -> Result<PathBuf> {
+    let base = dirs::config_dir().ok_or_else(|| anyhow!("cannot locate config directory"))?;
+    let dir = base.join("lmao").join("skills");
+    fs::create_dir_all(&dir).with_context(|| format!("creating skills dir {}", dir.display()))?;
+    Ok(dir)
+}
+
+/// Path for a specific skill bundle file.
+fn bundle_path(dir: &Path, id: &str) -> PathBuf {
+    dir.join(format!("{}.json", id))
+}
+
+// ── Parsing helpers ──────────────────────────────────────────────────────────
+
+/// Extract the first Markdown heading (`# Heading`) from skill file content.
+/// Falls back to the directory / file name when no heading is found.
+fn extract_name(content: &str, fallback: &str) -> String {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            let name = rest.trim().to_string();
+            if !name.is_empty() {
+                return name;
+            }
+        }
+    }
+    fallback.to_string()
+}
+
+/// Extract a description from the skill file.
+///
+/// Looks for a line matching `Description: ...` (case-insensitive).
+/// Falls back to the first non-heading, non-empty paragraph.
+fn extract_description(content: &str) -> String {
+    // Explicit "Description: ..." line
+    for line in content.lines() {
+        let lower = line.to_lowercase();
+        if lower.starts_with("description:") {
+            if let Some(colon_pos) = line.find(':') {
+                let desc = line[colon_pos + 1..].trim().to_string();
+                if !desc.is_empty() {
+                    return desc;
+                }
+            }
+        }
+    }
+
+    // First non-heading, non-empty paragraph
+    let mut past_heading = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            past_heading = true;
+            continue;
+        }
+        if past_heading && !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    String::new()
+}
+
+/// Extract tags from the skill file.
+///
+/// Looks for a line matching `Tags: foo, bar, baz` (case-insensitive).
+fn extract_tags(content: &str) -> Vec<String> {
+    for line in content.lines() {
+        let lower = line.to_lowercase();
+        if lower.starts_with("tags:") {
+            if let Some(colon_pos) = line.find(':') {
+                let tag_str = line[colon_pos + 1..].trim();
+                return tag_str
+                    .split(',')
+                    .map(|t| t.trim().to_lowercase())
+                    .filter(|t| !t.is_empty())
+                    .collect();
+            }
+        }
+    }
+    vec![]
+}
+
+/// Resolve the skill file path (accepts a directory containing SKILL.md or a
+/// direct path to any `.md` file).
+fn resolve_skill_file(path: &Path) -> Result<PathBuf> {
+    let p = path
+        .canonicalize()
+        .with_context(|| format!("path not found or not accessible: {}", path.display()))?;
+
+    if p.is_dir() {
+        let candidate = p.join("SKILL.md");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        return Err(anyhow!(
+            "directory {} does not contain SKILL.md",
+            p.display()
+        ));
+    }
+
+    Ok(p)
+}
+
+/// Determine the author: `--author` flag -> git `user.name` -> `$USER`.
+fn resolve_author(author_flag: Option<&str>) -> String {
+    if let Some(a) = author_flag {
+        if !a.trim().is_empty() {
+            return a.trim().to_string();
+        }
+    }
+
+    // Try git config
+    if let Ok(out) = Command::new("git")
+        .args(["config", "--global", "user.name"])
+        .output()
+    {
+        let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !name.is_empty() {
+            return name;
+        }
+    }
+
+    // Fall back to $USER
+    std::env::var("USER").unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Compute SHA-256 hex digest of bytes.
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+// ── Command handlers ─────────────────────────────────────────────────────────
+
+/// Dispatch a `skill` subcommand.
+pub fn handle(action: SkillAction, json: bool) -> Result<()> {
+    match action {
+        SkillAction::Publish {
+            path,
+            name,
+            author,
+            version,
+            tags,
+        } => publish(path, name, author, version, tags, json),
+        SkillAction::List { tag } => list(tag, json),
+        SkillAction::Info { id } => info(&id, json),
+    }
+}
+
+/// `skill publish` -- bundle a skill file and write it to the skills directory.
+fn publish(
+    path: PathBuf,
+    name_flag: Option<String>,
+    author_flag: Option<String>,
+    version: String,
+    tags_flag: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let skill_file = resolve_skill_file(&path)?;
+    let content = fs::read_to_string(&skill_file)
+        .with_context(|| format!("reading skill file {}", skill_file.display()))?;
+
+    // Derive name: flag > heading > file stem
+    let fallback_name = skill_file
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let name = name_flag
+        .filter(|n| !n.trim().is_empty())
+        .unwrap_or_else(|| extract_name(&content, &fallback_name));
+
+    let description = extract_description(&content);
+
+    // Tags: flag overrides parsed tags
+    let tags = if let Some(t) = tags_flag {
+        t.split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect()
+    } else {
+        extract_tags(&content)
+    };
+
+    let author = resolve_author(author_flag.as_deref());
+    let id = Uuid::new_v4().to_string();
+    let content_hash = sha256_hex(content.as_bytes());
+    let published_at = Utc::now().to_rfc3339();
+    let abs_path = skill_file.to_string_lossy().to_string();
+
+    let bundle = SkillBundle {
+        id: id.clone(),
+        name: name.clone(),
+        description: description.clone(),
+        tags: tags.clone(),
+        author: author.clone(),
+        version: version.clone(),
+        content_hash,
+        published_at: published_at.clone(),
+        path: abs_path,
+    };
+
+    let dir = skills_dir()?;
+    let dest = bundle_path(&dir, &id);
+    let serialized = serde_json::to_string_pretty(&bundle)?;
+    fs::write(&dest, &serialized)
+        .with_context(|| format!("writing skill bundle to {}", dest.display()))?;
+
+    if json {
+        println!("{}", serde_json::to_string(&bundle)?);
+    } else {
+        println!("Skill published");
+        println!("  ID:          {id}");
+        println!("  Name:        {name}");
+        println!("  Author:      {author}");
+        println!("  Version:     {version}");
+        println!("  Tags:        {}", tags.join(", "));
+        println!("  Description: {description}");
+        println!("  Saved to:    {}", dest.display());
+    }
+
+    Ok(())
+}
+
+/// `skill list` -- list all locally published skills, with optional tag filter.
+fn list(tag_filter: Option<String>, json: bool) -> Result<()> {
+    let dir = skills_dir()?;
+    let mut bundles: Vec<SkillBundle> = vec![];
+
+    for entry in fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let raw =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        match serde_json::from_str::<SkillBundle>(&raw) {
+            Ok(b) => bundles.push(b),
+            Err(e) => {
+                eprintln!("warning: skipping malformed bundle {}: {e}", path.display());
+            }
+        }
+    }
+
+    // Apply tag filter
+    if let Some(ref tag) = tag_filter {
+        let tag_lc = tag.to_lowercase();
+        bundles.retain(|b| b.tags.iter().any(|t| t == &tag_lc));
+    }
+
+    // Sort by published_at descending (newest first)
+    bundles.sort_by(|a, b| b.published_at.cmp(&a.published_at));
+
+    if json {
+        println!("{}", serde_json::to_string(&bundles)?);
+        return Ok(());
+    }
+
+    if bundles.is_empty() {
+        if let Some(ref tag) = tag_filter {
+            println!("No skills found with tag '{tag}'.");
+        } else {
+            println!("No skills published yet. Run `skill publish --path <SKILL.md>` to add one.");
+        }
+        return Ok(());
+    }
+
+    println!(
+        "{:<38} {:<24} {:<16} {:<10} Tags",
+        "ID", "Name", "Author", "Version"
+    );
+    println!("{}", "-".repeat(110));
+    for b in &bundles {
+        println!(
+            "{:<38} {:<24} {:<16} {:<10} {}",
+            b.id,
+            truncate(&b.name, 22),
+            truncate(&b.author, 14),
+            b.version,
+            b.tags.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+/// `skill info <id>` -- show full details of a skill bundle.
+fn info(id: &str, json: bool) -> Result<()> {
+    let dir = skills_dir()?;
+
+    // Support prefix matching
+    let bundle = find_bundle(&dir, id)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&bundle)?);
+        return Ok(());
+    }
+
+    println!("ID:           {}", bundle.id);
+    println!("Name:         {}", bundle.name);
+    println!("Author:       {}", bundle.author);
+    println!("Version:      {}", bundle.version);
+    println!("Tags:         {}", bundle.tags.join(", "));
+    println!("Description:  {}", bundle.description);
+    println!("Content hash: {}", bundle.content_hash);
+    println!("Published:    {}", bundle.published_at);
+    println!("Path:         {}", bundle.path);
+
+    Ok(())
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────────
+
+/// Find a bundle by exact ID or unambiguous prefix.
+fn find_bundle(dir: &Path, id_or_prefix: &str) -> Result<SkillBundle> {
+    let mut matches = vec![];
+
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if stem == id_or_prefix || stem.starts_with(id_or_prefix) {
+            let raw =
+                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+            if let Ok(b) = serde_json::from_str::<SkillBundle>(&raw) {
+                matches.push(b);
+            }
+        }
+    }
+
+    match matches.len() {
+        0 => Err(anyhow!(
+            "no skill found with id (or prefix) '{id_or_prefix}'"
+        )),
+        1 => Ok(matches.remove(0)),
+        n => Err(anyhow!(
+            "ambiguous prefix '{id_or_prefix}' -- matches {n} skills; use a longer prefix"
+        )),
+    }
+}
+
+/// Truncate a string to `max` characters, appending `...` if needed.
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_skill_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+        let p = dir.path().join(name);
+        fs::write(&p, content).unwrap();
+        p
+    }
+
+    // ── extract_name ──
+
+    #[test]
+    fn extract_name_from_heading() {
+        let md = "# My Skill\n\nDoes things.";
+        assert_eq!(extract_name(md, "fallback"), "My Skill");
+    }
+
+    #[test]
+    fn extract_name_falls_back() {
+        let md = "No heading here.";
+        assert_eq!(extract_name(md, "my-skill"), "my-skill");
+    }
+
+    #[test]
+    fn extract_name_ignores_h2() {
+        let md = "## Not a top heading\n# Real";
+        assert_eq!(extract_name(md, "fb"), "Real");
+    }
+
+    // ── extract_description ──
+
+    #[test]
+    fn extract_description_explicit_label() {
+        let md = "# Skill\n\nDescription: Does cool things.";
+        assert_eq!(extract_description(md), "Does cool things.");
+    }
+
+    #[test]
+    fn extract_description_first_paragraph() {
+        let md = "# Skill\n\nThis is the first paragraph.";
+        assert_eq!(extract_description(md), "This is the first paragraph.");
+    }
+
+    #[test]
+    fn extract_description_empty_when_nothing() {
+        let md = "# Skill";
+        assert_eq!(extract_description(md), "");
+    }
+
+    // ── extract_tags ──
+
+    #[test]
+    fn extract_tags_comma_separated() {
+        let md = "# Skill\n\nTags: rust, cli, test";
+        assert_eq!(extract_tags(md), vec!["rust", "cli", "test"]);
+    }
+
+    #[test]
+    fn extract_tags_case_insensitive_key() {
+        let md = "TAGS: foo, Bar";
+        assert_eq!(extract_tags(md), vec!["foo", "bar"]);
+    }
+
+    #[test]
+    fn extract_tags_empty_when_missing() {
+        let md = "# No tags here";
+        assert!(extract_tags(md).is_empty());
+    }
+
+    // ── sha256_hex ──
+
+    #[test]
+    fn sha256_is_stable() {
+        let h1 = sha256_hex(b"hello");
+        let h2 = sha256_hex(b"hello");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64);
+    }
+
+    #[test]
+    fn sha256_differs_for_different_input() {
+        assert_ne!(sha256_hex(b"hello"), sha256_hex(b"world"));
+    }
+
+    // ── resolve_skill_file ──
+
+    #[test]
+    fn resolve_direct_md_file() {
+        let dir = TempDir::new().unwrap();
+        let p = make_skill_file(&dir, "skill.md", "# S");
+        let resolved = resolve_skill_file(&p).unwrap();
+        assert_eq!(resolved, p.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_directory_with_skill_md() {
+        let dir = TempDir::new().unwrap();
+        let skill_md = dir.path().join("SKILL.md");
+        fs::write(&skill_md, "# S").unwrap();
+        let resolved = resolve_skill_file(dir.path()).unwrap();
+        assert_eq!(resolved, skill_md.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_directory_missing_skill_md_errors() {
+        let dir = TempDir::new().unwrap();
+        let err = resolve_skill_file(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("does not contain SKILL.md"));
+    }
+
+    #[test]
+    fn resolve_nonexistent_path_errors() {
+        let err = resolve_skill_file(Path::new("/tmp/does_not_exist_xyz123.md")).unwrap_err();
+        assert!(
+            err.to_string().contains("not found")
+                || err.to_string().contains("No such file")
+                || err.to_string().contains("not accessible")
+        );
+    }
+
+    // ── truncate ──
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string_has_ellipsis() {
+        let s = truncate("abcdefghij", 5);
+        assert!(s.ends_with("..."));
+    }
+
+    // ── find_bundle ──
+
+    fn write_bundle(dir: &Path, bundle: &SkillBundle) {
+        let path = bundle_path(dir, &bundle.id);
+        fs::write(path, serde_json::to_string_pretty(bundle).unwrap()).unwrap();
+    }
+
+    fn make_bundle(id: &str, name: &str, tags: &[&str]) -> SkillBundle {
+        SkillBundle {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: "A test skill.".to_string(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            author: "tester".to_string(),
+            version: "1.0.0".to_string(),
+            content_hash: sha256_hex(name.as_bytes()),
+            published_at: "2024-01-01T00:00:00Z".to_string(),
+            path: "/tmp/fake-skill.md".to_string(),
+        }
+    }
+
+    #[test]
+    fn find_bundle_exact_id() {
+        let dir = TempDir::new().unwrap();
+        let b = make_bundle("aaaa-1111", "Alpha", &["a"]);
+        write_bundle(dir.path(), &b);
+        let found = find_bundle(dir.path(), "aaaa-1111").unwrap();
+        assert_eq!(found.id, "aaaa-1111");
+    }
+
+    #[test]
+    fn find_bundle_prefix() {
+        let dir = TempDir::new().unwrap();
+        let b = make_bundle("bbbb-2222-cccc", "Beta", &["b"]);
+        write_bundle(dir.path(), &b);
+        let found = find_bundle(dir.path(), "bbbb").unwrap();
+        assert_eq!(found.id, "bbbb-2222-cccc");
+    }
+
+    #[test]
+    fn find_bundle_missing_errors() {
+        let dir = TempDir::new().unwrap();
+        let err = find_bundle(dir.path(), "no-such-id").unwrap_err();
+        assert!(err.to_string().contains("no skill found"));
+    }
+
+    #[test]
+    fn find_bundle_ambiguous_prefix_errors() {
+        let dir = TempDir::new().unwrap();
+        write_bundle(dir.path(), &make_bundle("aaa-111", "One", &[]));
+        write_bundle(dir.path(), &make_bundle("aaa-222", "Two", &[]));
+        let err = find_bundle(dir.path(), "aaa").unwrap_err();
+        assert!(err.to_string().contains("ambiguous"));
+    }
+
+    #[test]
+    fn bundle_roundtrip_json() {
+        let b = make_bundle("id-123", "MySkill", &["rust", "cli"]);
+        let json = serde_json::to_string(&b).unwrap();
+        let back: SkillBundle = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, b.id);
+        assert_eq!(back.tags, b.tags);
+    }
+
+    #[test]
+    fn malformed_json_skipped_silently_in_find() {
+        let dir = TempDir::new().unwrap();
+        let good = make_bundle("good-id", "Good", &[]);
+        write_bundle(dir.path(), &good);
+        fs::write(dir.path().join("bad.json"), "not json at all").unwrap();
+
+        // find_bundle should still find the good one despite bad.json
+        let found = find_bundle(dir.path(), "good-id").unwrap();
+        assert_eq!(found.id, "good-id");
+    }
+}

--- a/crates/logos-messaging-a2a-storage/Cargo.toml
+++ b/crates/logos-messaging-a2a-storage/Cargo.toml
@@ -9,6 +9,7 @@ default = ["rest"]
 rest = ["reqwest"]
 logos-core = ["base64"]
 libstorage = ["dep:storage-bindings", "dep:tempfile"]
+storage-module = ["reqwest"]
 
 [dependencies]
 tokio = { workspace = true }

--- a/crates/logos-messaging-a2a-storage/src/lib.rs
+++ b/crates/logos-messaging-a2a-storage/src/lib.rs
@@ -7,6 +7,7 @@
 //! |---------|-------------|-------------|
 //! | [`LogosStorageRest`] | `rest` (default) | Standalone processes talking to a Codex REST API |
 //! | `LogosCoreStorageBackend` | `logos-core` | Inside a Logos Core host process (desktop client) |
+//! | [`StorageModuleBackend`] | `storage-module` | Via `logos-storage-module` (recommended for new deployments) |
 //!
 //! # Example (REST)
 //!
@@ -38,6 +39,11 @@ pub use logos_core_backend::LogosCoreStorageBackend;
 mod libstorage_backend;
 #[cfg(feature = "libstorage")]
 pub use libstorage_backend::LibstorageBackend;
+
+#[cfg(feature = "storage-module")]
+mod storage_module_backend;
+#[cfg(feature = "storage-module")]
+pub use storage_module_backend::StorageModuleBackend;
 
 use std::fmt;
 

--- a/crates/logos-messaging-a2a-storage/src/storage_module_backend.rs
+++ b/crates/logos-messaging-a2a-storage/src/storage_module_backend.rs
@@ -1,0 +1,186 @@
+//! [`StorageBackend`] implementation using `logos-storage-module` v0.3.2+.
+//!
+//! Talks to a running `logos-storage-module` instance via its REST API,
+//! replacing direct Codex REST calls with the module's higher-level
+//! upload/download endpoints that handle peer coordination, SDS bloom
+//! filters, and throttle controls internally.
+
+use crate::{StorageBackend, StorageError};
+
+/// Default base URL for a local `logos-storage-module` instance.
+const DEFAULT_BASE_URL: &str = "http://127.0.0.1:8090";
+
+/// Storage backend using `logos-storage-module` REST API.
+///
+/// The module wraps Codex/libstorage with peer management, SDS bloom filters,
+/// and throttle controls. Requires a running `logos-storage-module` instance
+/// (headless mode recommended for server deployments).
+///
+/// # API surface used
+///
+/// | Method | Endpoint | Purpose |
+/// |--------|----------|---------|
+/// | `POST` | `/api/v1/upload` | Upload binary data, returns CID |
+/// | `GET`  | `/api/v1/download/{cid}` | Download data by CID |
+/// | `GET`  | `/api/v1/health` | Health check |
+pub struct StorageModuleBackend {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl StorageModuleBackend {
+    /// Create a backend pointing to the given `logos-storage-module` URL.
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Create a backend using the default local URL (`http://127.0.0.1:8090`).
+    pub fn default_local() -> Self {
+        Self::new(DEFAULT_BASE_URL)
+    }
+
+    /// Health check — returns `Ok(())` if the module is reachable and ready.
+    pub async fn health(&self) -> Result<(), StorageError> {
+        let url = format!("{}/api/v1/health", self.base_url);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| StorageError::Http(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageBackend for StorageModuleBackend {
+    async fn upload(&self, data: Vec<u8>) -> Result<String, StorageError> {
+        let url = format!("{}/api/v1/upload", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/octet-stream")
+            .body(data)
+            .send()
+            .await
+            .map_err(|e| StorageError::Http(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let cid = resp
+            .text()
+            .await
+            .map_err(|e| StorageError::Http(e.to_string()))?
+            .trim()
+            .to_string();
+        Ok(cid)
+    }
+
+    async fn download(&self, cid: &str) -> Result<Vec<u8>, StorageError> {
+        let url = format!("{}/api/v1/download/{}", self.base_url, cid);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| StorageError::Http(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| StorageError::Http(e.to_string()))?;
+        Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_module_backend_url_construction() {
+        let backend = StorageModuleBackend::new("http://localhost:8090/");
+        assert_eq!(backend.base_url, "http://localhost:8090");
+    }
+
+    #[test]
+    fn storage_module_backend_default_local() {
+        let backend = StorageModuleBackend::default_local();
+        assert_eq!(backend.base_url, "http://127.0.0.1:8090");
+    }
+
+    #[test]
+    fn storage_module_backend_trims_trailing_slashes() {
+        let backend = StorageModuleBackend::new("http://localhost:8090///");
+        assert_eq!(backend.base_url, "http://localhost:8090");
+    }
+
+    #[test]
+    fn storage_module_backend_no_trailing_slash() {
+        let backend = StorageModuleBackend::new("http://localhost:8090");
+        assert_eq!(backend.base_url, "http://localhost:8090");
+    }
+
+    #[test]
+    fn storage_module_backend_custom_port() {
+        let backend = StorageModuleBackend::new("http://storage.local:9000");
+        assert_eq!(backend.base_url, "http://storage.local:9000");
+    }
+
+    #[tokio::test]
+    async fn storage_module_upload_to_unreachable_host_returns_http_error() {
+        let backend = StorageModuleBackend::new("http://127.0.0.1:1");
+        let result = backend.upload(b"test".to_vec()).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            StorageError::Http(msg) => assert!(!msg.is_empty()),
+            other => panic!("expected Http error, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_module_download_from_unreachable_host_returns_http_error() {
+        let backend = StorageModuleBackend::new("http://127.0.0.1:1");
+        let result = backend.download("zQm123").await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            StorageError::Http(msg) => assert!(!msg.is_empty()),
+            other => panic!("expected Http error, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_module_health_unreachable_returns_error() {
+        let backend = StorageModuleBackend::new("http://127.0.0.1:1");
+        let result = backend.health().await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/logos-messaging-a2a-transport/Cargo.toml
+++ b/crates/logos-messaging-a2a-transport/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 default = ["rest"]
 rest = ["reqwest"]
 logos-core = ["base64"]
+logos-delivery = []
 native-waku = ["waku-bindings"]
 
 [dependencies]

--- a/crates/logos-messaging-a2a-transport/Cargo.toml
+++ b/crates/logos-messaging-a2a-transport/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 default = ["rest"]
 rest = ["reqwest"]
 logos-core = ["base64"]
+logos-mix = ["logos-core"]
 logos-delivery = []
 native-waku = ["waku-bindings"]
 

--- a/crates/logos-messaging-a2a-transport/src/lib.rs
+++ b/crates/logos-messaging-a2a-transport/src/lib.rs
@@ -44,6 +44,11 @@ pub mod logos_core_transport;
 #[cfg(feature = "logos-core")]
 pub use logos_core_transport::LogosCoreDeliveryTransport;
 
+#[cfg(feature = "logos-delivery")]
+pub mod logos_delivery_qtro;
+#[cfg(feature = "logos-delivery")]
+pub use logos_delivery_qtro::QtRODeliveryTransport;
+
 #[cfg(feature = "native-waku")]
 mod waku_bindings_transport;
 #[cfg(feature = "native-waku")]

--- a/crates/logos-messaging-a2a-transport/src/lib.rs
+++ b/crates/logos-messaging-a2a-transport/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - **REST** (`rest` feature): nwaku REST API transport for communicating with a running nwaku node.
 //! - **Logos Core** (`logos-core` feature): native IPC transport via the Logos Core `delivery_module` plugin.
+//! - **Logos Mix** (`logos-mix` feature): Logos Core IPC via mix_module for private, direct agent-to-agent routing.
 //! - **Native Waku** (`native-waku` feature): libwaku FFI transport via the `waku-bindings` crate.
 //! - **In-memory**: zero-dependency mock transport for testing (`memory` module, always available).
 //!
@@ -49,6 +50,12 @@ pub mod logos_delivery_qtro;
 #[cfg(feature = "logos-delivery")]
 pub use logos_delivery_qtro::QtRODeliveryTransport;
 
+#[cfg(feature = "logos-mix")]
+pub mod logos_mix_transport;
+#[cfg(feature = "logos-mix")]
+pub use logos_mix_transport::LogosCoreMixTransport;
+
+
 #[cfg(feature = "native-waku")]
 mod waku_bindings_transport;
 #[cfg(feature = "native-waku")]
@@ -59,6 +66,7 @@ pub use waku_bindings_transport::NativeWakuTransport;
 /// Implementations:
 /// - `LogosMessagingTransport`: nwaku REST API (requires running nwaku node, `rest` feature)
 /// - `LogosCoreDeliveryTransport`: Logos Core IPC via delivery_module (`logos-core` feature)
+/// - `LogosCoreMixTransport`: Logos Core IPC via mix_module for direct agent-to-agent (`logos-mix` feature)
 /// - `NativeWakuTransport`: native libwaku FFI via waku-bindings (`native-waku` feature)
 /// - `InMemoryTransport`: in-process mock for testing (no external deps)
 #[async_trait]

--- a/crates/logos-messaging-a2a-transport/src/logos_delivery_qtro.rs
+++ b/crates/logos-messaging-a2a-transport/src/logos_delivery_qtro.rs
@@ -1,0 +1,359 @@
+//! QtRO-based delivery transport — inter-module calls via Logos Core's QtRemoteObjects layer.
+//!
+//! Instead of linking `liblogos_core.so` at compile time (like the `logos-core` feature),
+//! this transport receives function pointers at runtime from the C++ module host.
+//! The C++ side calls `logosAPI->getClient("delivery_module")` to obtain a QtRO replica,
+//! then injects publish/subscribe/unsubscribe callbacks via [`set_qtro_callbacks`].
+//!
+//! This is the same pattern used by `logos-kv-module` and `lez-multisig-module`.
+
+use crate::{Result, Transport, TransportError};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// Callback function pointer types (set by C++ host at runtime)
+// ---------------------------------------------------------------------------
+
+/// `int publish(const char* topic, const char* payload_b64, void* user_data)`
+/// Returns 0 on success, non-zero on error.
+pub type PublishFn = extern "C" fn(topic: *const c_char, payload_b64: *const c_char, user_data: *mut c_void) -> c_int;
+
+/// `int subscribe(const char* topic, void* user_data)`
+/// Returns 0 on success, non-zero on error.
+pub type SubscribeFn = extern "C" fn(topic: *const c_char, user_data: *mut c_void) -> c_int;
+
+/// `int unsubscribe(const char* topic, void* user_data)`
+/// Returns 0 on success, non-zero on error.
+pub type UnsubscribeFn = extern "C" fn(topic: *const c_char, user_data: *mut c_void) -> c_int;
+
+/// Callback table injected by the C++ module host.
+#[repr(C)]
+pub struct QtROCallbacks {
+    pub publish: PublishFn,
+    pub subscribe: SubscribeFn,
+    pub unsubscribe: UnsubscribeFn,
+    /// Opaque pointer passed back to every callback (e.g. pointer to QtRO replica wrapper).
+    pub user_data: *mut c_void,
+}
+
+// SAFETY: The C++ side guarantees that user_data points to a thread-safe object
+// (QRemoteObjectDynamicReplica calls are serialised by Qt's event loop).
+unsafe impl Send for QtROCallbacks {}
+unsafe impl Sync for QtROCallbacks {}
+
+/// Global callback table — set once by `set_qtro_callbacks`, read by every transport instance.
+static CALLBACKS: OnceLock<QtROCallbacks> = OnceLock::new();
+
+/// Register the QtRO callback table. Called once from C++ during module initialisation.
+///
+/// # Safety
+/// `cbs` must point to a valid `QtROCallbacks` whose function pointers and `user_data`
+/// remain valid for the lifetime of the process.
+pub unsafe fn set_qtro_callbacks(cbs: QtROCallbacks) -> bool {
+    CALLBACKS.set(cbs).is_ok()
+}
+
+fn callbacks() -> Result<&'static QtROCallbacks> {
+    CALLBACKS
+        .get()
+        .ok_or_else(|| TransportError::Transport("QtRO callbacks not initialised — call set_qtro_callbacks first".into()))
+}
+
+// ---------------------------------------------------------------------------
+// Inbound message dispatch (C++ → Rust)
+// ---------------------------------------------------------------------------
+
+/// Per-topic sender map for dispatching inbound messages from the C++ event handler.
+static TOPIC_SENDERS: OnceLock<Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>>> =
+    OnceLock::new();
+
+fn topic_senders() -> &'static Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>> {
+    TOPIC_SENDERS.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+}
+
+/// Called from C++ when the delivery_module emits a message on a subscribed topic.
+///
+/// # Safety
+/// `topic` and `payload_b64` must be valid, null-terminated UTF-8 C strings.
+#[no_mangle]
+pub unsafe extern "C" fn lmao_qtro_on_message(topic: *const c_char, payload_b64: *const c_char) {
+    let topic_str = match unsafe { CStr::from_ptr(topic) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let payload_str = match unsafe { CStr::from_ptr(payload_b64) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let payload = match base64_decode(payload_str) {
+        Some(p) => p,
+        None => return,
+    };
+
+    let guard = topic_senders().lock().unwrap();
+    if let Some(tx) = guard.get(topic_str) {
+        let _ = tx.send(payload);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport implementation
+// ---------------------------------------------------------------------------
+
+/// Logos Delivery transport via QtRO inter-module calls.
+///
+/// Requires [`set_qtro_callbacks`] to have been called before use.
+/// The C++ module host obtains a `delivery_module` QtRO replica via
+/// `logosAPI->getClient("delivery_module")` and wires the callbacks.
+pub struct QtRODeliveryTransport {
+    _private: (),
+}
+
+impl QtRODeliveryTransport {
+    /// Create a new QtRO delivery transport.
+    ///
+    /// Fails if [`set_qtro_callbacks`] has not been called.
+    pub fn new() -> Result<Self> {
+        callbacks()?; // verify callbacks are registered
+        Ok(Self { _private: () })
+    }
+}
+
+#[async_trait]
+impl Transport for QtRODeliveryTransport {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+        let cbs = callbacks()?;
+        let topic_c = CString::new(topic)
+            .map_err(|_| TransportError::Transport("topic contains null byte".into()))?;
+        let payload_b64 = base64_encode(payload);
+        let payload_c = CString::new(payload_b64)
+            .map_err(|_| TransportError::Transport("base64 payload contains null byte".into()))?;
+
+        let rc = (cbs.publish)(topic_c.as_ptr(), payload_c.as_ptr(), cbs.user_data);
+        if rc != 0 {
+            return Err(TransportError::Transport(format!(
+                "QtRO publish failed (rc={})",
+                rc
+            )));
+        }
+        Ok(())
+    }
+
+    async fn subscribe(&self, topic: &str) -> Result<mpsc::Receiver<Vec<u8>>> {
+        let cbs = callbacks()?;
+        let topic_c = CString::new(topic)
+            .map_err(|_| TransportError::Transport("topic contains null byte".into()))?;
+
+        let rc = (cbs.subscribe)(topic_c.as_ptr(), cbs.user_data);
+        if rc != 0 {
+            return Err(TransportError::Transport(format!(
+                "QtRO subscribe failed (rc={})",
+                rc
+            )));
+        }
+
+        // Register a channel for inbound messages on this topic.
+        let (tx, rx_unbounded) = mpsc::unbounded_channel();
+        topic_senders()
+            .lock()
+            .unwrap()
+            .insert(topic.to_string(), tx);
+
+        // Bridge unbounded → bounded channel (backpressure).
+        let (btx, brx) = mpsc::channel(256);
+        tokio::spawn(async move {
+            let mut rx = rx_unbounded;
+            while let Some(msg) = rx.recv().await {
+                if btx.send(msg).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(brx)
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<()> {
+        // Remove local sender first.
+        topic_senders().lock().unwrap().remove(topic);
+
+        let cbs = callbacks()?;
+        let topic_c = CString::new(topic)
+            .map_err(|_| TransportError::Transport("topic contains null byte".into()))?;
+
+        let rc = (cbs.unsubscribe)(topic_c.as_ptr(), cbs.user_data);
+        if rc != 0 {
+            return Err(TransportError::Transport(format!(
+                "QtRO unsubscribe failed (rc={})",
+                rc
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal base64 helpers (no external dep needed)
+// ---------------------------------------------------------------------------
+
+const B64_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn base64_encode(input: &[u8]) -> String {
+    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        out.push(B64_CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        out.push(B64_CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(B64_CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if chunk.len() > 2 {
+            out.push(B64_CHARS[(triple & 0x3F) as usize] as char);
+        } else {
+            out.push('=');
+        }
+    }
+    out
+}
+
+fn base64_decode(input: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            b'=' => Some(0),
+            _ => None,
+        }
+    }
+    let bytes: Vec<u8> = input.bytes().filter(|b| !b.is_ascii_whitespace()).collect();
+    if bytes.len() % 4 != 0 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
+    for chunk in bytes.chunks(4) {
+        let a = val(chunk[0])?;
+        let b = val(chunk[1])?;
+        let c = val(chunk[2])?;
+        let d = val(chunk[3])?;
+        let triple = (a << 18) | (b << 12) | (c << 6) | d;
+        out.push((triple >> 16) as u8);
+        if chunk[2] != b'=' {
+            out.push((triple >> 8) as u8);
+        }
+        if chunk[3] != b'=' {
+            out.push(triple as u8);
+        }
+    }
+    Some(out)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_roundtrip() {
+        let cases: &[&[u8]] = &[b"", b"f", b"fo", b"foo", b"foob", b"fooba", b"foobar"];
+        for case in cases {
+            let encoded = base64_encode(case);
+            let decoded = base64_decode(&encoded).unwrap();
+            assert_eq!(&decoded, case, "roundtrip failed for {:?}", case);
+        }
+    }
+
+    #[test]
+    fn base64_encode_known() {
+        assert_eq!(base64_encode(b"Hello"), "SGVsbG8=");
+        assert_eq!(base64_encode(b"Hello!"), "SGVsbG8h");
+    }
+
+    #[test]
+    fn base64_decode_invalid() {
+        assert!(base64_decode("abc").is_none()); // not multiple of 4
+    }
+
+    #[test]
+    fn transport_new_without_callbacks_fails() {
+        // CALLBACKS is a OnceLock — if not set, new() should fail.
+        // Note: this test may pass or fail depending on test ordering since OnceLock is global.
+        // We test the error path only if callbacks haven't been set yet.
+        if CALLBACKS.get().is_none() {
+            let result = QtRODeliveryTransport::new();
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn topic_senders_dispatch() {
+        let senders = topic_senders();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        senders.lock().unwrap().insert("test/topic".into(), tx);
+
+        let topic = CString::new("test/topic").unwrap();
+        let payload = base64_encode(b"hello");
+        let payload_c = CString::new(payload).unwrap();
+
+        unsafe {
+            lmao_qtro_on_message(topic.as_ptr(), payload_c.as_ptr());
+        }
+
+        let received = rx.try_recv().unwrap();
+        assert_eq!(received, b"hello");
+
+        // Clean up
+        senders.lock().unwrap().remove("test/topic");
+    }
+
+    #[test]
+    fn on_message_unknown_topic_ignored() {
+        let topic = CString::new("no/such/topic").unwrap();
+        let payload = CString::new(base64_encode(b"data")).unwrap();
+
+        // Should not panic
+        unsafe {
+            lmao_qtro_on_message(topic.as_ptr(), payload.as_ptr());
+        }
+    }
+
+    #[test]
+    fn on_message_invalid_base64_ignored() {
+        let senders = topic_senders();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        senders.lock().unwrap().insert("b64test".into(), tx);
+
+        let topic = CString::new("b64test").unwrap();
+        let payload = CString::new("not-valid-base64!").unwrap();
+
+        unsafe {
+            lmao_qtro_on_message(topic.as_ptr(), payload.as_ptr());
+        }
+
+        // Should not have dispatched anything
+        assert!(rx.try_recv().is_err());
+
+        senders.lock().unwrap().remove("b64test");
+    }
+
+    #[test]
+    fn callbacks_struct_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<QtROCallbacks>();
+    }
+}

--- a/crates/logos-messaging-a2a-transport/src/logos_mix_transport.rs
+++ b/crates/logos-messaging-a2a-transport/src/logos_mix_transport.rs
@@ -1,0 +1,256 @@
+//! Logos Core Mix module transport — private, direct agent-to-agent communication.
+//!
+//! Uses the `mix_module` plugin through Logos Core's C IPC layer for
+//! anonymized point-to-point routing between agents that have already
+//! discovered each other via Delivery broadcast. Requires the `logos-mix`
+//! feature and linking against `liblogos_core`.
+
+use crate::logos_core;
+use crate::Transport;
+use crate::{Result, TransportError};
+use async_trait::async_trait;
+use base64::Engine;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tracing;
+
+const PLUGIN: &str = "mix_module";
+
+/// Build a Logos Core params JSON array from name/value pairs (all string-typed).
+fn params_json(pairs: &[(&str, &str)]) -> String {
+    let entries: Vec<String> = pairs
+        .iter()
+        .map(|(name, value)| {
+            format!(
+                r#"{{"name":"{}","value":"{}","type":"string"}}"#,
+                name, value
+            )
+        })
+        .collect();
+    format!("[{}]", entries.join(","))
+}
+
+/// Transport implementation backed by Logos Core IPC to the `mix_module` plugin.
+///
+/// Provides private, traffic-analysis resistant routing for point-to-point
+/// agent communication. Agents first discover each other via Delivery broadcast,
+/// then negotiate a Mix channel for subsequent task messages.
+///
+/// # Flow
+///
+/// 1. Agent A discovers Agent B via `LogosCoreDeliveryTransport`
+/// 2. Agent A calls `LogosCoreMixTransport::new()` to initialize the Mix module
+/// 3. Both agents subscribe/publish on a shared topic for direct communication
+/// 4. All task messages flow through Mix — private, direct, anonymized
+pub struct LogosCoreMixTransport {
+    subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>>,
+    /// Keep the event listener state alive so the FFI callback pointer stays valid.
+    _event_listener_state: Box<logos_core::EventListenerState>,
+}
+
+impl LogosCoreMixTransport {
+    /// Create and start a new Mix module transport.
+    ///
+    /// Calls `createNode(cfg)` then `start()` on the mix_module plugin, and
+    /// registers a global `messageReceived` event listener that fans out to per-topic channels.
+    pub async fn new(cfg: &str) -> Result<Self> {
+        // createNode
+        let result =
+            logos_core::call_plugin_method(PLUGIN, "createNode", &params_json(&[("cfg", cfg)]))
+                .await
+                .map_err(|e| {
+                    TransportError::Transport(format!("mix_module createNode failed: {}", e))
+                })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module createNode returned: {}",
+                result
+            )));
+        }
+
+        // start
+        let result = logos_core::call_plugin_method(PLUGIN, "start", "[]")
+            .await
+            .map_err(|e| {
+                TransportError::Transport(format!("mix_module start failed: {}", e))
+            })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module start returned: {}",
+                result
+            )));
+        }
+
+        let subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        // Register global messageReceived event listener
+        let (mut event_rx, event_state) =
+            logos_core::register_event_listener(PLUGIN, "messageReceived");
+
+        let subs = Arc::clone(&subscriptions);
+        tokio::spawn(async move {
+            while let Some(event_json) = event_rx.recv().await {
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event_json) {
+                    let topic = val
+                        .get("contentTopic")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let payload_b64 = val
+                        .get("payload")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+
+                    let payload =
+                        match base64::engine::general_purpose::STANDARD.decode(payload_b64) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                tracing::warn!(
+                                    topic,
+                                    error = %e,
+                                    "mix_module: failed to decode base64 payload, skipping"
+                                );
+                                continue;
+                            }
+                        };
+
+                    let guard = subs.lock().unwrap();
+                    if let Some(tx) = guard.get(topic) {
+                        let _ = tx.send(payload);
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            subscriptions,
+            _event_listener_state: event_state,
+        })
+    }
+}
+
+#[async_trait]
+impl Transport for LogosCoreMixTransport {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+        let payload_b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "send",
+            &params_json(&[("contentTopic", topic), ("payload", &payload_b64)]),
+        )
+        .await
+        .map_err(|e| TransportError::Transport(format!("mix_module send failed: {}", e)))?;
+
+        if result.starts_with("error") || result.starts_with("Error") {
+            return Err(TransportError::Transport(format!(
+                "mix_module send returned error: {}",
+                result
+            )));
+        }
+        Ok(())
+    }
+
+    async fn subscribe(&self, topic: &str) -> Result<mpsc::Receiver<Vec<u8>>> {
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "subscribe",
+            &params_json(&[("contentTopic", topic)]),
+        )
+        .await
+        .map_err(|e| {
+            TransportError::Transport(format!("mix_module subscribe failed: {}", e))
+        })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module subscribe returned: {}",
+                result
+            )));
+        }
+
+        let (tx, rx_unbounded) = mpsc::unbounded_channel();
+        self.subscriptions
+            .lock()
+            .unwrap()
+            .insert(topic.to_string(), tx);
+
+        // Bridge unbounded → bounded channel for backpressure
+        let (btx, brx) = mpsc::channel(256);
+        tokio::spawn(async move {
+            let mut rx_unbounded = rx_unbounded;
+            while let Some(msg) = rx_unbounded.recv().await {
+                if btx.send(msg).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(brx)
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<()> {
+        self.subscriptions.lock().unwrap().remove(topic);
+
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "unsubscribe",
+            &params_json(&[("contentTopic", topic)]),
+        )
+        .await
+        .map_err(|e| {
+            TransportError::Transport(format!("mix_module unsubscribe failed: {}", e))
+        })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module unsubscribe returned: {}",
+                result
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn params_json_empty() {
+        assert_eq!(params_json(&[]), "[]");
+    }
+
+    #[test]
+    fn params_json_single_pair() {
+        let result = params_json(&[("cfg", "value1")]);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "cfg");
+        assert_eq!(arr[0]["value"], "value1");
+        assert_eq!(arr[0]["type"], "string");
+    }
+
+    #[test]
+    fn params_json_multiple_pairs() {
+        let result = params_json(&[("contentTopic", "/mix/topic"), ("payload", "abc123")]);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], "contentTopic");
+        assert_eq!(arr[0]["value"], "/mix/topic");
+        assert_eq!(arr[1]["name"], "payload");
+        assert_eq!(arr[1]["value"], "abc123");
+    }
+
+    #[test]
+    fn params_json_is_valid_json() {
+        let result = params_json(&[("a", "1"), ("b", "2"), ("c", "3")]);
+        let parsed: std::result::Result<serde_json::Value, _> = serde_json::from_str(&result);
+        assert!(parsed.is_ok(), "params_json should produce valid JSON");
+    }
+
+    #[test]
+    fn plugin_constant() {
+        assert_eq!(PLUGIN, "mix_module");
+    }
+}

--- a/logos-core-module/src/LmaoComponent.cpp
+++ b/logos-core-module/src/LmaoComponent.cpp
@@ -5,6 +5,10 @@
 #include <QQuickWidget>
 #include <QQmlContext>
 #include <QDebug>
+#include <QRemoteObjectDynamicReplica>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QByteArray>
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +17,63 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+// ---------------------------------------------------------------------------
+// QtRO → Rust bridge callbacks
+//
+// These static functions forward delivery_module QtRO calls to the Rust
+// transport layer. The user_data pointer is the QRemoteObjectDynamicReplica*.
+// ---------------------------------------------------------------------------
+
+static int qtro_publish(const char* topic, const char* payload_b64, void* user_data)
+{
+    auto* replica = static_cast<QRemoteObjectDynamicReplica*>(user_data);
+    if (!replica || !replica->isInitialized()) {
+        qWarning() << "LMAO: delivery_module replica not ready for publish";
+        return -1;
+    }
+
+    QJsonObject params;
+    params[QLatin1String("contentTopic")] = QString::fromUtf8(topic);
+    params[QLatin1String("payload")] = QString::fromUtf8(payload_b64);
+    QByteArray paramsJson = QJsonDocument(params).toJson(QJsonDocument::Compact);
+
+    // Call the send method on the delivery_module replica
+    QMetaObject::invokeMethod(replica, "send",
+        Q_ARG(QString, QString::fromUtf8(paramsJson)));
+
+    return 0;
+}
+
+static int qtro_subscribe(const char* topic, void* user_data)
+{
+    auto* replica = static_cast<QRemoteObjectDynamicReplica*>(user_data);
+    if (!replica || !replica->isInitialized()) {
+        qWarning() << "LMAO: delivery_module replica not ready for subscribe";
+        return -1;
+    }
+
+    QMetaObject::invokeMethod(replica, "subscribe",
+        Q_ARG(QString, QString::fromUtf8(topic)));
+
+    return 0;
+}
+
+static int qtro_unsubscribe(const char* topic, void* user_data)
+{
+    auto* replica = static_cast<QRemoteObjectDynamicReplica*>(user_data);
+    if (!replica || !replica->isInitialized()) {
+        qWarning() << "LMAO: delivery_module replica not ready for unsubscribe";
+        return -1;
+    }
+
+    QMetaObject::invokeMethod(replica, "unsubscribe",
+        Q_ARG(QString, QString::fromUtf8(topic)));
+
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
 
 LmaoComponent::LmaoComponent(QObject* parent)
     : QObject(parent)
@@ -35,12 +96,54 @@ QString LmaoComponent::version() const
     return v;
 }
 
-void LmaoComponent::initialize()
+void LmaoComponent::setupDeliveryTransport(LogosAPI* logosAPI)
+{
+    if (!logosAPI) {
+        qWarning() << "LMAO: no LogosAPI — cannot set up QtRO delivery transport";
+        return;
+    }
+
+    // Get a QtRO replica for delivery_module via the Logos Core API.
+    // logosAPI->getClient() returns a QRemoteObjectDynamicReplica*.
+    m_deliveryReplica = logosAPI->getClient(QStringLiteral("delivery_module"));
+    if (!m_deliveryReplica) {
+        qWarning() << "LMAO: failed to get delivery_module client";
+        return;
+    }
+
+    // Wait for the replica to initialise (it connects asynchronously).
+    if (!m_deliveryReplica->isInitialized()) {
+        QObject::connect(m_deliveryReplica, &QRemoteObjectDynamicReplica::initialized,
+            this, [this]() {
+                qDebug() << "LMAO: delivery_module replica initialised";
+                // Register FFI callbacks now that the replica is ready.
+                lmao_qtro_set_callbacks(
+                    qtro_publish, qtro_subscribe, qtro_unsubscribe,
+                    static_cast<void*>(m_deliveryReplica));
+            });
+    } else {
+        // Already initialised (e.g. local mode) — register immediately.
+        lmao_qtro_set_callbacks(
+            qtro_publish, qtro_subscribe, qtro_unsubscribe,
+            static_cast<void*>(m_deliveryReplica));
+    }
+
+    // Forward inbound messages from the replica to Rust.
+    QObject::connect(m_deliveryReplica, SIGNAL(messageReceived(QString)),
+        this, SLOT(onDeliveryMessage(QString)));
+
+    qDebug() << "LMAO: QtRO delivery transport bridge configured";
+}
+
+void LmaoComponent::initialize(LogosAPI* logosAPI)
 {
     if (m_initialized)
         return;
 
     qDebug() << "LmaoComponent::initialize — starting LMAO node";
+
+    // Wire up QtRO delivery transport before initialising the Rust node.
+    setupDeliveryTransport(logosAPI);
 
     // Trigger lazy node init inside lmao-ffi by fetching the agent card.
     char* raw = lmao_get_agent_card();
@@ -52,9 +155,9 @@ void LmaoComponent::initialize()
     m_initialized = true;
 }
 
-QWidget* LmaoComponent::createWidget(LogosAPI* /*logosAPI*/)
+QWidget* LmaoComponent::createWidget(LogosAPI* logosAPI)
 {
-    initialize();
+    initialize(logosAPI);
 
     auto* widget = new QQuickWidget();
     widget->setMinimumSize(500, 400);
@@ -76,4 +179,25 @@ QWidget* LmaoComponent::createWidget(LogosAPI* /*logosAPI*/)
 void LmaoComponent::destroyWidget(QWidget* widget)
 {
     delete widget;
+}
+
+void LmaoComponent::onDeliveryMessage(const QString& eventJson)
+{
+    // Parse the event JSON to extract contentTopic and payload, then forward
+    // to the Rust transport layer via the FFI bridge.
+    QJsonDocument doc = QJsonDocument::fromJson(eventJson.toUtf8());
+    if (!doc.isObject())
+        return;
+
+    QJsonObject obj = doc.object();
+    QString topic = obj.value(QLatin1String("contentTopic")).toString();
+    QString payload = obj.value(QLatin1String("payload")).toString();
+
+    if (topic.isEmpty() || payload.isEmpty())
+        return;
+
+    const QByteArray topicUtf8 = topic.toUtf8();
+    const QByteArray payloadUtf8 = payload.toUtf8();
+
+    lmao_qtro_on_message(topicUtf8.constData(), payloadUtf8.constData());
 }

--- a/logos-core-module/src/LmaoComponent.h
+++ b/logos-core-module/src/LmaoComponent.h
@@ -5,11 +5,13 @@
 #include <QString>
 
 class LmaoBackend;
+class QRemoteObjectDynamicReplica;
 
 /**
  * LmaoComponent — Logos Core IComponent plugin for LMAO (A2A over Waku).
  *
  * Provides agent discovery and task sending over the Waku network.
+ * Connects to delivery_module via QtRO for message transport.
  */
 class LmaoComponent : public QObject, public IComponent {
     Q_OBJECT
@@ -26,9 +28,18 @@ public:
     QString name() const { return QStringLiteral("lmao"); }
     QString version() const;
 
-    /// Initialize the LMAO node (calls into FFI).
-    void initialize();
+    /// Initialize the LMAO node and wire up QtRO delivery transport.
+    void initialize(LogosAPI* logosAPI = nullptr);
+
+private slots:
+    /// Forward inbound delivery_module messages to the Rust transport layer.
+    void onDeliveryMessage(const QString& eventJson);
 
 private:
     bool m_initialized = false;
+    /// QtRO replica for delivery_module — kept alive for the component lifetime.
+    QRemoteObjectDynamicReplica* m_deliveryReplica = nullptr;
+
+    /// Set up the QtRO delivery transport bridge to Rust via FFI callbacks.
+    void setupDeliveryTransport(LogosAPI* logosAPI);
 };

--- a/logos-core-module/src/lmao_ffi.h
+++ b/logos-core-module/src/lmao_ffi.h
@@ -43,4 +43,41 @@ void lmao_free_string(char *s);
  */
 char *lmao_version(void);
 
+/* ── QtRO Delivery Transport Bridge ─────────────────────────────────────── */
+
+/**
+ * Callback for publishing a message via QtRO delivery_module.
+ * Returns 0 on success, non-zero on error.
+ */
+typedef int (*LmaoPublishFn)(const char *topic, const char *payload_b64, void *user_data);
+
+/**
+ * Callback for subscribing to a topic via QtRO delivery_module.
+ * Returns 0 on success, non-zero on error.
+ */
+typedef int (*LmaoSubscribeFn)(const char *topic, void *user_data);
+
+/**
+ * Callback for unsubscribing from a topic via QtRO delivery_module.
+ * Returns 0 on success, non-zero on error.
+ */
+typedef int (*LmaoUnsubscribeFn)(const char *topic, void *user_data);
+
+/**
+ * Register QtRO delivery callbacks. Called once during module init.
+ * Returns 1 on success, 0 if already registered.
+ */
+int lmao_qtro_set_callbacks(
+    LmaoPublishFn publish_fn,
+    LmaoSubscribeFn subscribe_fn,
+    LmaoUnsubscribeFn unsubscribe_fn,
+    void *user_data
+);
+
+/**
+ * Called from C++ when delivery_module emits a message on a subscribed topic.
+ * topic and payload_b64 must be valid null-terminated UTF-8 strings.
+ */
+void lmao_qtro_on_message(const char *topic, const char *payload_b64);
+
 #endif  /* LMAO_FFI_H */


### PR DESCRIPTION
## Summary

- Adds new `LogosCoreMixTransport` implementing the `Transport` trait via Logos Core's `mix_module` plugin
- Feature-gated behind `logos-mix` (depends on `logos-core` for shared FFI bindings)
- Follows the same IPC pattern as `LogosCoreDeliveryTransport` — createNode/start/subscribe/publish/unsubscribe via `logos_core_call_plugin_method_async`
- Provides private, anonymized point-to-point routing for agent-to-agent task communication after discovery phase

## Test plan

- [x] `cargo check --features logos-mix` compiles cleanly
- [x] `cargo test --workspace` (default features) — all 949 tests pass
- [ ] Integration test with `mix_module` plugin (blocked on Mix API stabilization in Testnet v0.1)

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)