### PR TITLE
feat(transport): add LogosCoreMixTransport for direct agent-to-agent communication

### DIFF
--- a/crates/logos-messaging-a2a-transport/src/lib.rs
+++ b/crates/logos-messaging-a2a-transport/src/lib.rs
@@ -3,7 +3,8 @@
 //! Provides a unified [`Transport`] trait with multiple backend implementations:
 //!
 //! - **REST** (`rest` feature): nwaku REST API transport for communicating with a running nwaku node.
-//! - **Logos Core** (`logos-core` feature): native IPC transport via the Logos Core `delivery_module` plugin.
+//! - **Logos Core Delivery** (`logos-core` feature): broadcast IPC transport via the Logos Core `delivery_module` plugin.
+//! - **Logos Core Mix** (`logos-core` feature): private point-to-point IPC transport via the Logos Core `mix_module` plugin.
 //! - **Native Waku** (`native-waku` feature): libwaku FFI transport via the `waku-bindings` crate.
 //! - **In-memory**: zero-dependency mock transport for testing (`memory` module, always available).
 //!
@@ -44,6 +45,11 @@ pub mod logos_core_transport;
 #[cfg(feature = "logos-core")]
 pub use logos_core_transport::LogosCoreDeliveryTransport;
 
+#[cfg(feature = "logos-core")]
+pub mod logos_core_mix_transport;
+#[cfg(feature = "logos-core")]
+pub use logos_core_mix_transport::LogosCoreMixTransport;
+
 #[cfg(feature = "native-waku")]
 mod waku_bindings_transport;
 #[cfg(feature = "native-waku")]
@@ -54,6 +60,7 @@ pub use waku_bindings_transport::NativeWakuTransport;
 /// Implementations:
 /// - `LogosMessagingTransport`: nwaku REST API (requires running nwaku node, `rest` feature)
 /// - `LogosCoreDeliveryTransport`: Logos Core IPC via delivery_module (`logos-core` feature)
+/// - `LogosCoreMixTransport`: Logos Core IPC via mix_module for private point-to-point routing (`logos-core` feature)
 /// - `NativeWakuTransport`: native libwaku FFI via waku-bindings (`native-waku` feature)
 /// - `InMemoryTransport`: in-process mock for testing (no external deps)
 #[async_trait]

--- a/crates/logos-messaging-a2a-transport/src/logos_core_mix_transport.rs
+++ b/crates/logos-messaging-a2a-transport/src/logos_core_mix_transport.rs
@@ -1,0 +1,249 @@
+//! Logos Core mix-module transport — private point-to-point routing via `logos_core_call_plugin_method_async`.
+//!
+//! Communicates with the `mix_module` plugin through Logos Core's C IPC layer.
+//! Mix provides anonymized, traffic-analysis resistant routing between two known
+//! endpoints, making it suitable for direct agent-to-agent task communication
+//! after initial discovery via the broadcast Delivery transport.
+//!
+//! Requires the `logos-core` feature and linking against `liblogos_core`.
+
+use crate::logos_core;
+use crate::Transport;
+use crate::{Result, TransportError};
+use async_trait::async_trait;
+use base64::Engine;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+const PLUGIN: &str = "mix_module";
+
+/// Build a Logos Core params JSON array from name/value pairs (all string-typed).
+fn params_json(pairs: &[(&str, &str)]) -> String {
+    let entries: Vec<String> = pairs
+        .iter()
+        .map(|(name, value)| {
+            format!(
+                r#"{{"name":"{}","value":"{}","type":"string"}}"#,
+                name, value
+            )
+        })
+        .collect();
+    format!("[{}]", entries.join(","))
+}
+
+/// Transport implementation backed by Logos Core IPC to the `mix_module` plugin.
+///
+/// Unlike [`LogosCoreDeliveryTransport`](crate::LogosCoreDeliveryTransport) which uses
+/// broadcast-based Waku Delivery, this transport routes messages through the Logos Mix
+/// network for private, direct communication between two agents.
+///
+/// ## Typical usage flow
+///
+/// 1. Agents discover each other via `LogosCoreDeliveryTransport` (broadcast).
+/// 2. They negotiate a Mix channel by exchanging endpoint info over Delivery.
+/// 3. Subsequent task messages flow through `LogosCoreMixTransport` for privacy.
+/// 4. Falls back to Delivery if Mix is unavailable.
+pub struct LogosCoreMixTransport {
+    subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>>,
+    /// Keep the event listener state alive so the FFI callback pointer stays valid.
+    _event_listener_state: Box<logos_core::EventListenerState>,
+}
+
+impl LogosCoreMixTransport {
+    /// Create and start a new mix-module transport.
+    ///
+    /// Calls `createNode(cfg)` then `start()` on the mix_module plugin, and
+    /// registers a global `messageReceived` event listener that fans out to per-topic channels.
+    pub async fn new(cfg: &str) -> Result<Self> {
+        // createNode
+        let result =
+            logos_core::call_plugin_method(PLUGIN, "createNode", &params_json(&[("cfg", cfg)]))
+                .await
+                .map_err(|e| {
+                    TransportError::Transport(format!("mix_module createNode failed: {}", e))
+                })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module createNode returned: {}",
+                result
+            )));
+        }
+
+        // start
+        let result = logos_core::call_plugin_method(PLUGIN, "start", "[]")
+            .await
+            .map_err(|e| {
+                TransportError::Transport(format!("mix_module start failed: {}", e))
+            })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module start returned: {}",
+                result
+            )));
+        }
+
+        let subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        // Register global messageReceived event listener
+        let (mut event_rx, event_state) =
+            logos_core::register_event_listener(PLUGIN, "messageReceived");
+
+        let subs = Arc::clone(&subscriptions);
+        tokio::spawn(async move {
+            while let Some(event_json) = event_rx.recv().await {
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&event_json) {
+                    let topic = val
+                        .get("contentTopic")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let payload_b64 = val
+                        .get("payload")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+
+                    let payload =
+                        match base64::engine::general_purpose::STANDARD.decode(payload_b64) {
+                            Ok(p) => p,
+                            Err(_) => continue,
+                        };
+
+                    let guard = subs.lock().unwrap();
+                    if let Some(tx) = guard.get(topic) {
+                        let _ = tx.send(payload);
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            subscriptions,
+            _event_listener_state: event_state,
+        })
+    }
+}
+
+#[async_trait]
+impl Transport for LogosCoreMixTransport {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+        let payload_b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "send",
+            &params_json(&[("contentTopic", topic), ("payload", &payload_b64)]),
+        )
+        .await
+        .map_err(|e| TransportError::Transport(format!("mix_module send failed: {}", e)))?;
+
+        if result.starts_with("error") || result.starts_with("Error") {
+            return Err(TransportError::Transport(format!(
+                "mix_module send returned error: {}",
+                result
+            )));
+        }
+        Ok(())
+    }
+
+    async fn subscribe(&self, topic: &str) -> Result<mpsc::Receiver<Vec<u8>>> {
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "subscribe",
+            &params_json(&[("contentTopic", topic)]),
+        )
+        .await
+        .map_err(|e| {
+            TransportError::Transport(format!("mix_module subscribe failed: {}", e))
+        })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module subscribe returned: {}",
+                result
+            )));
+        }
+
+        let (tx, rx_unbounded) = mpsc::unbounded_channel();
+        self.subscriptions
+            .lock()
+            .unwrap()
+            .insert(topic.to_string(), tx);
+
+        let (btx, brx) = mpsc::channel(256);
+        tokio::spawn(async move {
+            let mut rx_unbounded = rx_unbounded;
+            while let Some(msg) = rx_unbounded.recv().await {
+                if btx.send(msg).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(brx)
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<()> {
+        self.subscriptions.lock().unwrap().remove(topic);
+
+        let result = logos_core::call_plugin_method(
+            PLUGIN,
+            "unsubscribe",
+            &params_json(&[("contentTopic", topic)]),
+        )
+        .await
+        .map_err(|e| {
+            TransportError::Transport(format!("mix_module unsubscribe failed: {}", e))
+        })?;
+        if result != "true" {
+            return Err(TransportError::Transport(format!(
+                "mix_module unsubscribe returned: {}",
+                result
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn params_json_empty() {
+        assert_eq!(params_json(&[]), "[]");
+    }
+
+    #[test]
+    fn params_json_single_pair() {
+        let result = params_json(&[("cfg", "value1")]);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "cfg");
+        assert_eq!(arr[0]["value"], "value1");
+        assert_eq!(arr[0]["type"], "string");
+    }
+
+    #[test]
+    fn params_json_multiple_pairs() {
+        let result = params_json(&[("contentTopic", "/my/topic"), ("payload", "abc123")]);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], "contentTopic");
+        assert_eq!(arr[0]["value"], "/my/topic");
+        assert_eq!(arr[1]["name"], "payload");
+        assert_eq!(arr[1]["value"], "abc123");
+    }
+
+    #[test]
+    fn params_json_is_valid_json() {
+        let result = params_json(&[("a", "1"), ("b", "2"), ("c", "3")]);
+        let parsed: std::result::Result<serde_json::Value, _> = serde_json::from_str(&result);
+        assert!(parsed.is_ok(), "params_json should produce valid JSON");
+    }
+
+    #[test]
+    fn plugin_constant() {
+        assert_eq!(PLUGIN, "mix_module");
+    }
+}

--- a/docs/logos-native-runtime-research.md
+++ b/docs/logos-native-runtime-research.md
@@ -1,0 +1,180 @@
+# Research: Logos-Native Agent Runtime
+
+Issue: #51 — Replacing OpenClaw with a Logos Core module
+
+## Executive Summary
+
+LMAO already has most building blocks for a Logos-native agent runtime. The gap
+is not infrastructure — it is the **agent lifecycle layer** (tool execution,
+memory, heartbeats, scheduling) that OpenClaw provides today. This document maps
+what exists, what is missing, and recommends a phased approach.
+
+## Current State (what LMAO already provides)
+
+| Capability | LMAO Crate | Status |
+|---|---|---|
+| Agent identity (secp256k1) | `lmao-core` | Done |
+| Agent discovery (Waku broadcast) | `lmao-node` (discovery/presence) | Done |
+| Agent-to-agent messaging | `lmao-node` (send_task/respond) | Done |
+| E2E encryption | `lmao-crypto` (X25519+ChaCha20) | Done |
+| Reliable delivery (SDS) | `lmao-transport` (sds module) | Done |
+| Task delegation | `lmao-node` (delegation module) | Done |
+| On-chain registration | `lmao-execution` (StatusNetwork) | Done |
+| On-chain payments | `lmao-execution` (StatusNetwork) | Done |
+| ZK execution (LEZ) | `lmao-execution` (lez module) | Stub |
+| Logos Core IPC transport | `lmao-transport` (logos-core feature) | Done |
+| Logos Core UI plugin | `logos-core-module/` (IComponent) | Done (PR #43) |
+| MCP bridge (Claude/Cursor) | `lmao-mcp` | Done |
+| C FFI bindings | `lmao-ffi` + `logos-messaging-a2a-ffi` | Done |
+
+## What OpenClaw provides that LMAO does not
+
+| OpenClaw Feature | Logos-Native Equivalent | Gap |
+|---|---|---|
+| Telegram bridge | Logos Messaging (Waku) | Waku works for A2A; no human chat UI yet |
+| File-based memory | Logos Storage (Codex CID) | `StorageBackend` trait exists, Codex impl exists |
+| Cron scheduling | Waku-triggered events | No scheduler in LMAO — needs new component |
+| Tool execution sandbox | — | Not in LMAO at all |
+| Browser automation | — | Not in LMAO at all |
+| Heartbeat system | `lmao-node` presence module | Done (PeerMap + broadcast) |
+| LLM API calls | — | Anthropic API (unavoidable for now) |
+| Agent spawn/lifecycle | Logos Core module loading | Partial — load module, but no spawn API |
+
+### Critical Gaps
+
+1. **Agent Lifecycle Manager** — start, stop, restart, health-check agents.
+   Today the Logos Core module can load LMAO, but there is no API to spawn a
+   *new* agent instance with its own identity and config.
+
+2. **Scheduler / Trigger System** — OpenClaw uses cron. A Logos-native approach
+   would use Waku content-topic triggers or on-chain events. Neither exists in
+   LMAO today.
+
+3. **Tool Execution Sandbox** — OpenClaw has shell execution, browser control,
+   file I/O. A Logos-native agent would need a sandboxed execution environment
+   (WASM? Nix sandbox?). This is the hardest gap to close.
+
+4. **LLM Integration Layer** — LMAO has no concept of "call an LLM". The agent
+   runtime needs a trait for LLM backends (Anthropic today, local models later).
+
+5. **Human-Facing Comms** — Waku works for machine-to-machine. Humans use
+   Telegram/Discord today. Until Logos Messaging has a consumer chat client, the
+   Telegram bridge remains necessary.
+
+## Architecture: Proposed Runtime Layer
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Agent Runtime (NEW)                     │
+│                                                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  │
+│  │ Lifecycle Mgr │  │  Scheduler   │  │  Tool Runner │  │
+│  │ spawn/stop/   │  │ cron/waku    │  │  sandboxed   │  │
+│  │ health-check  │  │ triggers     │  │  execution   │  │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘  │
+│         │                 │                  │           │
+│  ┌──────┴─────────────────┴──────────────────┴───────┐  │
+│  │              LLM Integration Trait                 │  │
+│  │  AnthropicBackend | LocalModelBackend | ...        │  │
+│  └──────────────────────┬────────────────────────────┘  │
+│                         │                                │
+├─────────────────────────┼────────────────────────────────┤
+│              LMAO (existing infrastructure)               │
+│  WakuA2ANode — transport, crypto, storage, execution     │
+├──────────────────────────────────────────────────────────┤
+│              Logos Core (host)                            │
+│  IComponent plugin loading, delivery_module IPC          │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Phased Approach
+
+### Phase 1: Hybrid (recommended NOW)
+
+Keep OpenClaw for human-facing operations. Use LMAO for agent-to-agent
+coordination underneath.
+
+- OpenClaw handles: Telegram, crons, memory, tool execution
+- LMAO handles: agent discovery, A2A messaging, on-chain identity/payments
+- Bridge: MCP server (`lmao-mcp`) connects Claude ↔ LMAO agents
+
+**Already possible today.** The MCP bridge and FFI bindings enable this.
+
+### Phase 2: Agent Lifecycle in Logos Core
+
+Add a new crate `logos-messaging-a2a-runtime` that provides:
+
+```rust
+/// Trait for agent runtime backends.
+#[async_trait]
+pub trait AgentRuntime: Send + Sync {
+    /// Spawn a new agent with the given config.
+    async fn spawn(&self, config: AgentConfig) -> Result<AgentHandle>;
+    /// Stop a running agent.
+    async fn stop(&self, id: &AgentId) -> Result<()>;
+    /// List running agents.
+    async fn list(&self) -> Result<Vec<AgentStatus>>;
+    /// Health check.
+    async fn health(&self, id: &AgentId) -> Result<HealthStatus>;
+}
+
+pub struct AgentConfig {
+    pub name: String,
+    pub capabilities: Vec<String>,
+    pub llm_backend: LlmBackendConfig,
+    pub triggers: Vec<TriggerConfig>,
+    pub tools: Vec<ToolConfig>,
+}
+```
+
+This enables "spin up agent = load a module" in Basecamp.
+
+**Prerequisite:** Logos Core module loading stabilizes for production workloads.
+
+### Phase 3: Full Logos-Native
+
+Replace OpenClaw entirely when:
+
+- [ ] Logos Messaging has a human-facing chat client (Telegram replacement)
+- [ ] LEZ execution backend is production-ready (issue #4)
+- [ ] Tool execution sandbox exists (WASM or Nix-based)
+- [ ] Logos Storage (Codex) is reliable for agent memory persistence
+- [ ] Logos Core supports long-running module processes with restart policies
+
+This is the LP-0008 end state.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| Logos Core instability | Agent crashes, data loss | Medium | Phase 1 hybrid keeps OpenClaw as fallback |
+| No human chat replacement | Can't drop Telegram bridge | High | Keep Telegram bridge until Status Chat/Waku consumer client |
+| LLM vendor lock-in | Anthropic dependency | Low (acceptable) | LLM trait allows swapping backends later |
+| Tool sandbox complexity | Months of work | High | Start with simple subprocess isolation, not full WASM |
+| LEZ delays | No ZK-verified execution | Medium | StatusNetwork EVM works today as bridge |
+
+## Recommendations
+
+1. **Do NOT replace OpenClaw now.** The hybrid approach (Phase 1) gives immediate
+   value without risk.
+
+2. **Next concrete step:** Create `logos-messaging-a2a-runtime` crate with the
+   `AgentRuntime` trait and a basic in-process implementation. This is the
+   foundation for Phase 2.
+
+3. **Track blockers externally:**
+   - Logos Core production stability → Logos team
+   - LEZ SDK availability → LEZ team
+   - Logos Messaging consumer client → Status/Waku team
+
+4. **The MCP bridge is the most underrated piece.** It already lets any
+   MCP-compatible AI (Claude, Cursor) use LMAO agents as tools. This is the
+   practical integration point for Phase 1.
+
+## Related Issues & PRs
+
+- PR #43 — Logos Core IComponent module (done)
+- Issue #5 — Package as .lgx (done)
+- Issue #4 — LEZ agent registry (stub exists)
+- LP-0008 spec — Full Logos-native runtime (end state)
+- AgentRegistry contract: `0x438bB48f...` on SN testnet


### PR DESCRIPTION
## Summary
- Adds `LogosCoreMixTransport` implementing the `Transport` trait via Logos Core IPC to the `mix_module` plugin
- Enables private, point-to-point routing between agents after discovery via broadcast Delivery transport
- Gated behind the existing `logos-core` feature flag — no new dependencies

## Design
Follows the same pattern as `LogosCoreDeliveryTransport`: creates a node, starts it, registers a `messageReceived` event listener, and fans out to per-topic channels. The key difference is targeting `mix_module` instead of `delivery_module` for traffic-analysis resistant direct communication.

## Test plan
- [x] All existing workspace tests pass (`cargo test --workspace`)
- [x] Unit tests for `params_json` helper and plugin constant
- [ ] Integration testing blocked on Mix API stabilization (Testnet v0.1)

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)