### PR TITLE
feat: logos-app IComponent UI plugin dashboard for LMAO agent

### DIFF
--- a/crates/lmao-ffi/include/lmao_ffi.h
+++ b/crates/lmao-ffi/include/lmao_ffi.h
@@ -41,6 +41,21 @@ char *lmao_get_agent_card(void);
 void lmao_free_string(char *s);
 
 /**
+ * Get agent info: identity, topics, and encryption status.
+ *
+ * Returns: { "success": true, "public_key": "02...", "task_topic": "...",
+ *            "discovery_topic": "...", "presence_topic": "...", "encryption": false }
+ */
+char *lmao_get_info(void);
+
+/**
+ * Get operational metrics counters.
+ *
+ * Returns: { "success": true, "tasks_sent": 0, "tasks_received": 0, ... }
+ */
+char *lmao_get_metrics(void);
+
+/**
  * Returns the version string of this FFI library.
  */
 char *lmao_version(void);

--- a/crates/lmao-ffi/src/lib.rs
+++ b/crates/lmao-ffi/src/lib.rs
@@ -1330,19 +1330,26 @@ mod tests {
         if v["success"] == true {
             // All 17 counter fields should be present
             let expected_fields = [
-                "tasks_sent", "tasks_received", "tasks_failed",
-                "messages_published", "messages_received",
-                "discoveries", "announcements_sent", "peers_discovered",
-                "encryptions", "decryptions", "sessions_created",
-                "delegations_sent", "stream_chunks_sent", "stream_chunks_received",
-                "retry_attempts", "retries_exhausted", "responses_sent",
+                "tasks_sent",
+                "tasks_received",
+                "tasks_failed",
+                "messages_published",
+                "messages_received",
+                "discoveries",
+                "announcements_sent",
+                "peers_discovered",
+                "encryptions",
+                "decryptions",
+                "sessions_created",
+                "delegations_sent",
+                "stream_chunks_sent",
+                "stream_chunks_received",
+                "retry_attempts",
+                "retries_exhausted",
+                "responses_sent",
             ];
             for field in &expected_fields {
-                assert!(
-                    v.get(*field).is_some(),
-                    "metrics missing field: {}",
-                    field
-                );
+                assert!(v.get(*field).is_some(), "metrics missing field: {}", field);
             }
         }
     }

--- a/crates/lmao-ffi/src/lib.rs
+++ b/crates/lmao-ffi/src/lib.rs
@@ -7,6 +7,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::sync::OnceLock;
 
+use logos_messaging_a2a_core::topics;
 use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 use tokio::runtime::Runtime;
@@ -205,6 +206,37 @@ pub extern "C" fn lmao_free_string(s: *mut c_char) {
         unsafe {
             let _ = CString::from_raw(s);
         }
+    }
+}
+
+/// Get agent info: identity, topics, and encryption status.
+///
+/// Returns: { "success": true, "public_key": "02...", "task_topic": "...",
+///            "discovery_topic": "...", "presence_topic": "...", "encryption": false }
+#[no_mangle]
+pub extern "C" fn lmao_get_info() -> *mut c_char {
+    let node = get_or_init_node();
+    let pubkey = node.pubkey();
+    let encrypt = node.card.intro_bundle.is_some();
+    success_json(serde_json::json!({
+        "public_key": pubkey,
+        "task_topic": topics::task_topic(pubkey),
+        "discovery_topic": topics::DISCOVERY,
+        "presence_topic": topics::PRESENCE,
+        "encryption": encrypt,
+    }))
+}
+
+/// Get operational metrics counters.
+///
+/// Returns: { "success": true, "tasks_sent": 0, "tasks_received": 0, ... }
+#[no_mangle]
+pub extern "C" fn lmao_get_metrics() -> *mut c_char {
+    let node = get_or_init_node();
+    let snapshot = node.metrics();
+    match serde_json::to_value(&snapshot) {
+        Ok(v) => success_json(v),
+        Err(e) => error_json(&format!("metrics serialization error: {}", e)),
     }
 }
 
@@ -1241,6 +1273,88 @@ mod tests {
         }
         for ptr in ptrs {
             lmao_free_string(ptr);
+        }
+    }
+
+    // ── lmao_get_info tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_get_info_returns_valid_json() {
+        // get_info triggers node init; it may fail without a running Waku
+        // node, but should still return valid JSON with a "success" key.
+        let ptr = lmao_get_info();
+        assert!(!ptr.is_null());
+        let v = unsafe { read_json_and_free(ptr) };
+        assert!(v.is_object());
+        assert!(v.get("success").is_some());
+    }
+
+    #[test]
+    fn test_get_info_non_null() {
+        let ptr = lmao_get_info();
+        assert!(!ptr.is_null());
+        lmao_free_string(ptr);
+    }
+
+    #[test]
+    fn test_get_info_idempotent() {
+        let v1 = unsafe { read_json_and_free(lmao_get_info()) };
+        let v2 = unsafe { read_json_and_free(lmao_get_info()) };
+        // Both calls should return the same public key
+        if v1["success"] == true && v2["success"] == true {
+            assert_eq!(v1["public_key"], v2["public_key"]);
+        }
+    }
+
+    // ── lmao_get_metrics tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_get_metrics_returns_valid_json() {
+        let ptr = lmao_get_metrics();
+        assert!(!ptr.is_null());
+        let v = unsafe { read_json_and_free(ptr) };
+        assert!(v.is_object());
+        assert!(v.get("success").is_some());
+    }
+
+    #[test]
+    fn test_get_metrics_non_null() {
+        let ptr = lmao_get_metrics();
+        assert!(!ptr.is_null());
+        lmao_free_string(ptr);
+    }
+
+    #[test]
+    fn test_get_metrics_has_counter_fields() {
+        let v = unsafe { read_json_and_free(lmao_get_metrics()) };
+        if v["success"] == true {
+            // All 17 counter fields should be present
+            let expected_fields = [
+                "tasks_sent", "tasks_received", "tasks_failed",
+                "messages_published", "messages_received",
+                "discoveries", "announcements_sent", "peers_discovered",
+                "encryptions", "decryptions", "sessions_created",
+                "delegations_sent", "stream_chunks_sent", "stream_chunks_received",
+                "retry_attempts", "retries_exhausted", "responses_sent",
+            ];
+            for field in &expected_fields {
+                assert!(
+                    v.get(*field).is_some(),
+                    "metrics missing field: {}",
+                    field
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_metrics_counters_start_at_zero() {
+        let v = unsafe { read_json_and_free(lmao_get_metrics()) };
+        if v["success"] == true {
+            // On a fresh node with no activity, all counters should be 0
+            assert_eq!(v["tasks_sent"], 0);
+            assert_eq!(v["tasks_received"], 0);
+            assert_eq!(v["tasks_failed"], 0);
         }
     }
 }

--- a/docs/logos-native-runtime-research.md
+++ b/docs/logos-native-runtime-research.md
@@ -1,0 +1,259 @@
+# Research: Logos-Native Agent Runtime
+
+Issue: #51 — Replacing OpenClaw with a Logos Core module
+
+## Executive Summary
+
+LMAO already has most building blocks for a Logos-native agent runtime. The gap
+is not infrastructure — it is the **agent lifecycle layer** (tool execution,
+memory, heartbeats, scheduling) that OpenClaw provides today. This document maps
+what exists, what is missing, and recommends a phased approach.
+
+## Current State (what LMAO already provides)
+
+| Capability | LMAO Crate | Status |
+|---|---|---|
+| Agent identity (secp256k1) | `lmao-core` | Done |
+| Agent discovery (Waku broadcast + presence) | `lmao-node` (discovery/presence) | Done |
+| Agent-to-agent messaging | `lmao-node` (send_task/respond) | Done |
+| E2E encryption | `lmao-crypto` (X25519+ChaCha20) | Done |
+| Reliable delivery (full SDS) | `lmao-transport` (bloom filter, causal ordering, batch ACK) | Done |
+| Task delegation (4 strategies) | `lmao-node` (FirstAvailable, CapabilityMatch, BroadcastCollect, RoundRobin) | Done |
+| Task streaming | `lmao-node` | Done |
+| On-chain registration | `lmao-execution` (StatusNetwork) | Done |
+| On-chain payments (x402) | `lmao-execution` (StatusNetwork) | Done |
+| ZK execution (LEZ) | `lmao-execution` (lez module) | Stub |
+| CID payload offloading | `lmao-storage` (Codex REST + LogosCore IPC) | Done |
+| Logos Core IPC transport | `lmao-transport` (logos-core feature) | Done |
+| Logos Core UI plugin | `logos-core-module/` (IComponent + QML UI) | Done (PR #43) |
+| MCP bridge (Claude/Cursor) | `lmao-mcp` | Done |
+| C FFI bindings | `lmao-ffi` + `logos-messaging-a2a-ffi` | Done |
+| CLI with JSON output | `lmao-cli` (info, health, sessions, completions) | Done |
+| Observability | `lmao-node` (metrics counters) | Done |
+| Message retry with backoff | `lmao-node` (RetryLayer) | Done |
+
+## What OpenClaw provides that LMAO does not
+
+| OpenClaw Feature | Logos-Native Equivalent | Gap |
+|---|---|---|
+| Telegram bridge | Logos Messaging (Waku) | Waku works for A2A; no human chat UI yet |
+| File-based memory | Logos Storage (Codex CID) | `StorageBackend` trait exists, Codex + LogosCore impl done |
+| Cron scheduling | Waku-triggered events | No scheduler in LMAO — needs new component |
+| Tool execution sandbox | — | Not in LMAO at all |
+| Browser automation | — | Not in LMAO at all |
+| Heartbeat system | `lmao-node` presence module | Done (PeerMap + signed broadcasts + TTL expiry) |
+| LLM API calls | — | Anthropic API (unavoidable for now) |
+| Agent spawn/lifecycle | Logos Core module loading | Partial — load module, but no spawn API |
+
+### Critical Gaps
+
+1. **Agent Lifecycle Manager** — start, stop, restart, health-check agents.
+   Today the Logos Core module can load LMAO, but there is no API to spawn a
+   *new* agent instance with its own identity and config.
+
+2. **Scheduler / Trigger System** — OpenClaw uses cron. A Logos-native approach
+   would use Waku content-topic triggers or on-chain events. Neither exists in
+   LMAO today.
+
+3. **Tool Execution Sandbox** — OpenClaw has shell execution, browser control,
+   file I/O. A Logos-native agent would need a sandboxed execution environment
+   (WASM? Nix sandbox?). This is the hardest gap to close.
+
+4. **LLM Integration Layer** — LMAO has no concept of "call an LLM". The agent
+   runtime needs a trait for LLM backends (Anthropic today, local models later).
+
+5. **Human-Facing Comms** — Waku works for machine-to-machine. Humans use
+   Telegram/Discord today. Until Logos Messaging has a consumer chat client, the
+   Telegram bridge remains necessary.
+
+## Architecture: Proposed Runtime Layer
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Agent Runtime (NEW)                     │
+│                                                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  │
+│  │ Lifecycle Mgr │  │  Scheduler   │  │  Tool Runner │  │
+│  │ spawn/stop/   │  │ cron/waku    │  │  sandboxed   │  │
+│  │ health-check  │  │ triggers     │  │  execution   │  │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘  │
+│         │                 │                  │           │
+│  ┌──────┴─────────────────┴──────────────────┴───────┐  │
+│  │              LLM Integration Trait                 │  │
+│  │  AnthropicBackend | LocalModelBackend | ...        │  │
+│  └──────────────────────┬────────────────────────────┘  │
+│                         │                                │
+├─────────────────────────┼────────────────────────────────┤
+│              LMAO (existing infrastructure)               │
+│                                                          │
+│  WakuA2ANode ─── transport, crypto, storage, execution   │
+│  ├── SdsTransport (bloom filter dedup, causal ordering)  │
+│  ├── PeerMap (signed presence, capability match)         │
+│  ├── Delegation (4 strategies incl. RoundRobin)          │
+│  ├── RetryLayer (exponential backoff + jitter)           │
+│  ├── Metrics (observability counters)                    │
+│  └── MCP Bridge (Claude/Cursor integration)              │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│              Logos Core (host)                            │
+│  IComponent plugin loading                               │
+│  delivery_module IPC (pub/sub)                           │
+│  storage_module IPC (CID upload/download)                │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Existing Integration Points (code audit)
+
+### Transport: Two production-ready paths
+
+1. **NwakuRestTransport** — REST API to external nwaku node (`http://localhost:8645`)
+2. **LogosCoreDeliveryTransport** — Native IPC via `delivery_module` plugin
+
+Both implement `WakuTransport { publish, subscribe, poll }`. The Logos Core
+transport is already battle-tested in the e2e demo (`demos/logos-core-e2e/`).
+
+### Storage: CID-addressed with auto-offload
+
+```
+StorageBackend { upload(data) → CID, download(CID) → data }
+├── LogosStorageRest        — Codex REST API (standalone processes)
+├── LogosCoreStorageBackend — storage_module IPC (inside Logos Core)
+└── LibstorageBackend       — Direct FFI (future)
+```
+
+Payloads > 100 KB are auto-offloaded to storage via `maybe_offload()`. This
+means agent memory/context could use CID-addressed blobs with zero new code.
+
+### Execution: On-chain agent economy
+
+```
+ExecutionBackend { register_agent, pay, balance, verify_transfer }
+├── StatusNetworkBackend — EVM/gasless (AgentRegistry at 0x438bB48f...)
+└── LezExecutionBackend  — ZK-verified (stub, tracking issue #4)
+```
+
+The x402 payment flow already enables pay-per-task agent economics.
+
+### FFI: Three layers deep
+
+```
+Logos Core Qt App
+  → LmaoComponent (IComponent C++ plugin)
+    → LmaoBackend (QObject, calls C FFI)
+      → lmao-ffi (Rust cdylib, JSON in/out)
+        → WakuA2ANode (full async Rust stack)
+```
+
+Key FFI functions: `lmao_discover_agents()`, `lmao_send_task()`,
+`lmao_get_agent_card()`. All return `{"success": bool, ...}` JSON.
+
+## Phased Approach
+
+### Phase 1: Hybrid (recommended NOW)
+
+Keep OpenClaw for human-facing operations. Use LMAO for agent-to-agent
+coordination underneath.
+
+- OpenClaw handles: Telegram, crons, memory, tool execution
+- LMAO handles: agent discovery, A2A messaging, on-chain identity/payments
+- Bridge: MCP server (`lmao-mcp`) connects Claude <-> LMAO agents
+
+**Already possible today.** The MCP bridge and FFI bindings enable this.
+
+**Concrete integration path:**
+1. OpenClaw agent registers on-chain via `lmao-execution` (StatusNetwork)
+2. OpenClaw agent announces presence via `lmao-node` (Waku broadcast)
+3. Other LMAO agents discover it and send tasks via A2A protocol
+4. OpenClaw processes tasks using its existing tool execution pipeline
+5. Results flow back through LMAO transport
+
+### Phase 2: Agent Lifecycle in Logos Core
+
+Add a new crate `logos-messaging-a2a-runtime` that provides:
+
+```rust
+/// Trait for agent runtime backends.
+#[async_trait]
+pub trait AgentRuntime: Send + Sync {
+    /// Spawn a new agent with the given config.
+    async fn spawn(&self, config: AgentConfig) -> Result<AgentHandle>;
+    /// Stop a running agent.
+    async fn stop(&self, id: &AgentId) -> Result<()>;
+    /// List running agents with status.
+    async fn list(&self) -> Result<Vec<AgentStatus>>;
+    /// Health check a specific agent.
+    async fn health(&self, id: &AgentId) -> Result<HealthStatus>;
+}
+
+pub struct AgentConfig {
+    pub name: String,
+    pub capabilities: Vec<String>,
+    pub llm_backend: LlmBackendConfig,
+    pub triggers: Vec<TriggerConfig>,
+    pub tools: Vec<ToolConfig>,
+    pub storage_backend: StorageBackendConfig,
+}
+
+/// Trait for LLM backends (Anthropic today, local models later).
+#[async_trait]
+pub trait LlmBackend: Send + Sync {
+    async fn complete(&self, messages: Vec<Message>) -> Result<Message>;
+    async fn complete_stream(&self, messages: Vec<Message>) -> Result<MessageStream>;
+}
+```
+
+This enables "spin up agent = load a module" in Basecamp.
+
+**Prerequisite:** Logos Core module loading stabilizes for production workloads.
+
+### Phase 3: Full Logos-Native
+
+Replace OpenClaw entirely when:
+
+- [ ] Logos Messaging has a human-facing chat client (Telegram replacement)
+- [ ] LEZ execution backend is production-ready (issue #4)
+- [ ] Tool execution sandbox exists (WASM or Nix-based)
+- [ ] Logos Storage (Codex) is reliable for agent memory persistence
+- [ ] Logos Core supports long-running module processes with restart policies
+
+This is the LP-0008 end state.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| Logos Core instability | Agent crashes, data loss | Medium | Phase 1 hybrid keeps OpenClaw as fallback |
+| No human chat replacement | Can't drop Telegram bridge | High | Keep Telegram bridge until Status Chat/Waku consumer client |
+| LLM vendor lock-in | Anthropic dependency | Low (acceptable) | LLM trait allows swapping backends later |
+| Tool sandbox complexity | Months of work | High | Start with simple subprocess isolation, not full WASM |
+| LEZ delays | No ZK-verified execution | Medium | StatusNetwork EVM works today as bridge |
+
+## Recommendations
+
+1. **Do NOT replace OpenClaw now.** The hybrid approach (Phase 1) gives immediate
+   value without risk.
+
+2. **Next concrete step:** Create `logos-messaging-a2a-runtime` crate with the
+   `AgentRuntime` and `LlmBackend` traits and a basic in-process implementation.
+   This is the foundation for Phase 2.
+
+3. **Leverage what exists:** The delegation system (4 strategies including
+   RoundRobin) already supports orchestrator patterns. An OpenClaw agent could
+   act as orchestrator, delegating subtasks to specialized LMAO agents.
+
+4. **Track blockers externally:**
+   - Logos Core production stability -> Logos team
+   - LEZ SDK availability -> LEZ team
+   - Logos Messaging consumer client -> Status/Waku team
+
+5. **The MCP bridge is the most underrated piece.** It already lets any
+   MCP-compatible AI (Claude, Cursor) use LMAO agents as tools. This is the
+   practical integration point for Phase 1.
+
+## Related Issues & PRs
+
+- PR #43 — Logos Core IComponent module (done)
+- Issue #5 — Package as .lgx (done)
+- Issue #4 — LEZ agent registry (stub exists)
+- LP-0008 spec — Full Logos-native runtime (end state)
+- AgentRegistry contract: `0x438bB48f...` on SN testnet

--- a/logos-core-module/CMakeLists.txt
+++ b/logos-core-module/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(${MODULE_TARGET} SHARED
     src/LmaoComponent.cpp
     src/LmaoBackend.cpp
     src/AgentListModel.cpp
+    src/DeliveryTransport.cpp
     qml/qml.qrc
 )
 

--- a/logos-core-module/module.yaml
+++ b/logos-core-module/module.yaml
@@ -4,7 +4,8 @@ type: core
 category: network
 description: "LMAO — A2A agent discovery and task communication over Waku"
 
-dependencies: []
+dependencies:
+  - delivery_module
 
 nix_packages:
   build: []
@@ -22,3 +23,4 @@ cmake:
   extra_sources:
     - src/AgentListModel.cpp
     - src/LmaoBackend.cpp
+    - src/DeliveryTransport.cpp

--- a/logos-core-module/qml/DashboardView.qml
+++ b/logos-core-module/qml/DashboardView.qml
@@ -1,0 +1,269 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+/**
+ * DashboardView — agent status, identity, topics, and encryption overview.
+ *
+ * Context properties (injected by LmaoComponent):
+ *   - lmaoModule     : LmaoBackend*
+ *   - lmaoAgentModel : AgentListModel*
+ */
+Item {
+    id: root
+
+    property var infoData: ({})
+    property bool loaded: false
+    property string errorMsg: ""
+
+    function refresh() {
+        errorMsg = ""
+        var result = lmaoModule.getInfo()
+        try {
+            var obj = JSON.parse(result)
+            if (obj.success) {
+                infoData = obj
+                loaded = true
+            } else {
+                errorMsg = obj.error || "Unknown error"
+            }
+        } catch (e) {
+            errorMsg = "Failed to parse info response"
+        }
+    }
+
+    Component.onCompleted: refresh()
+
+    Flickable {
+        anchors.fill: parent
+        contentHeight: col.implicitHeight + Theme.spacing.large * 2
+        clip: true
+
+        ColumnLayout {
+            id: col
+            anchors {
+                left: parent.left; right: parent.right
+                top: parent.top
+                margins: Theme.spacing.large
+            }
+            spacing: Theme.spacing.medium
+
+            // ── Status banner ──
+            Rectangle {
+                Layout.fillWidth: true
+                height: 56
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundSecondary
+
+                RowLayout {
+                    anchors { fill: parent; margins: Theme.spacing.medium }
+                    spacing: Theme.spacing.medium
+
+                    Rectangle {
+                        width: 10; height: 10; radius: 5
+                        color: root.loaded ? Theme.palette.success : Theme.palette.error
+                    }
+
+                    Text {
+                        text: root.loaded ? "Agent Online" : "Initializing…"
+                        color: Theme.palette.text
+                        font { pixelSize: 15; bold: true; family: "monospace" }
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    Text {
+                        visible: lmaoAgentModel.count > 0
+                        text: lmaoAgentModel.count + " peers"
+                        color: Theme.palette.textSecondary
+                        font.pixelSize: 12
+                    }
+
+                    Button {
+                        text: "↻"
+                        onClicked: root.refresh()
+                        width: 32; height: 32
+                        contentItem: Text {
+                            text: parent.text
+                            color: Theme.palette.primary
+                            font.pixelSize: 16
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        background: Rectangle {
+                            color: parent.hovered ? Theme.palette.backgroundTertiary : "transparent"
+                            radius: Theme.spacing.tiny
+                        }
+                    }
+                }
+            }
+
+            // ── Error display ──
+            Text {
+                visible: root.errorMsg.length > 0
+                text: "⚠ " + root.errorMsg
+                color: Theme.palette.error
+                font.pixelSize: 12
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+            }
+
+            // ── Identity card ──
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: identityCol.implicitHeight + Theme.spacing.large * 2
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundTertiary
+                border { color: Theme.palette.borderSecondary; width: 1 }
+
+                ColumnLayout {
+                    id: identityCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.large
+                    }
+                    spacing: Theme.spacing.small
+
+                    Text {
+                        text: "Identity"
+                        color: Theme.palette.text
+                        font { pixelSize: 14; bold: true }
+                    }
+
+                    InfoRow { label: "Public Key"; value: infoData.public_key || "—"; mono: true; copyable: true }
+                    InfoRow { label: "Encryption"; value: infoData.encryption ? "Enabled" : "Disabled"; statusColor: infoData.encryption ? Theme.palette.success : Theme.palette.textTertiary }
+                }
+            }
+
+            // ── Waku Topics card ──
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: topicsCol.implicitHeight + Theme.spacing.large * 2
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundTertiary
+                border { color: Theme.palette.borderSecondary; width: 1 }
+
+                ColumnLayout {
+                    id: topicsCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.large
+                    }
+                    spacing: Theme.spacing.small
+
+                    Text {
+                        text: "Waku Topics"
+                        color: Theme.palette.text
+                        font { pixelSize: 14; bold: true }
+                    }
+
+                    InfoRow { label: "Task"; value: infoData.task_topic || "—"; mono: true }
+                    InfoRow { label: "Discovery"; value: infoData.discovery_topic || "—"; mono: true }
+                    InfoRow { label: "Presence"; value: infoData.presence_topic || "—"; mono: true }
+                }
+            }
+
+            // ── Transport card ──
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: transportCol.implicitHeight + Theme.spacing.large * 2
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundTertiary
+                border { color: Theme.palette.borderSecondary; width: 1 }
+
+                ColumnLayout {
+                    id: transportCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.large
+                    }
+                    spacing: Theme.spacing.small
+
+                    Text {
+                        text: "Transport"
+                        color: Theme.palette.text
+                        font { pixelSize: 14; bold: true }
+                    }
+
+                    InfoRow {
+                        label: "QtRO Delivery"
+                        value: lmaoModule.hasDeliveryTransport ? "Connected" : "Unavailable"
+                        statusColor: lmaoModule.hasDeliveryTransport ? Theme.palette.success : Theme.palette.textTertiary
+                    }
+                }
+            }
+        }
+    }
+
+    // ── InfoRow helper component ──
+    component InfoRow: RowLayout {
+        property string label: ""
+        property string value: ""
+        property bool mono: false
+        property bool copyable: false
+        property color statusColor: "transparent"
+
+        Layout.fillWidth: true
+        spacing: Theme.spacing.small
+
+        Text {
+            text: label
+            color: Theme.palette.textSecondary
+            font.pixelSize: 12
+            Layout.preferredWidth: 100
+        }
+
+        Rectangle {
+            visible: statusColor != "transparent"
+            width: 8; height: 8; radius: 4
+            color: statusColor
+        }
+
+        Text {
+            text: {
+                if (!mono) return value
+                if (value.length > 48)
+                    return value.substring(0, 20) + "…" + value.slice(-12)
+                return value
+            }
+            color: Theme.palette.text
+            font { pixelSize: 12; family: mono ? "monospace" : "sans-serif" }
+            Layout.fillWidth: true
+            elide: Text.ElideRight
+
+            MouseArea {
+                anchors.fill: parent
+                visible: copyable
+                cursorShape: copyable ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: {
+                    // Copy full value to clipboard
+                    clipHelper.text = value
+                    clipHelper.selectAll()
+                    clipHelper.copy()
+                    copiedTip.visible = true
+                    copiedTimer.restart()
+                }
+            }
+        }
+
+        Text {
+            id: copiedTip
+            visible: false
+            text: "Copied!"
+            color: Theme.palette.success
+            font.pixelSize: 10
+
+            Timer {
+                id: copiedTimer
+                interval: 1500
+                onTriggered: copiedTip.visible = false
+            }
+        }
+    }
+
+    // Hidden TextInput for clipboard support
+    TextInput {
+        id: clipHelper
+        visible: false
+    }
+}

--- a/logos-core-module/qml/LmaoView.qml
+++ b/logos-core-module/qml/LmaoView.qml
@@ -3,15 +3,17 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 /**
- * LmaoView — basic fleet view for A2A agent discovery and task sending.
+ * LmaoView — main tabbed view for LMAO agent dashboard.
  *
  * Context properties (injected by LmaoComponent):
  *   - lmaoAgentModel : AgentListModel*
  *   - lmaoModule     : LmaoBackend*
+ *   - lmaoDelivery   : DeliveryTransport*
  */
 Item {
     id: root
 
+    property int currentTab: 0
     property bool discovering: false
     property string lastError: ""
     property string lastResult: ""
@@ -25,232 +27,276 @@ Item {
     Rectangle {
         id: header
         anchors { left: parent.left; right: parent.right; top: parent.top }
-        height: 56
+        height: 44
         color: Theme.palette.backgroundSecondary
 
         RowLayout {
-            anchors { fill: parent; leftMargin: Theme.spacing.large; rightMargin: Theme.spacing.large }
-            spacing: 10
+            anchors { fill: parent; leftMargin: Theme.spacing.medium; rightMargin: Theme.spacing.medium }
+            spacing: 0
 
             Text {
-                text: "LMAO Fleet"
+                text: "LMAO"
                 color: Theme.palette.primary
-                font { pixelSize: 18; bold: true; family: "monospace" }
+                font { pixelSize: 15; bold: true; family: "monospace" }
+                Layout.rightMargin: Theme.spacing.medium
             }
 
-            // ── Status indicator ──
-            Rectangle {
-                width: 8; height: 8; radius: 4
-                color: Theme.palette.success
-            }
-            Text {
-                text: "Online"
-                color: Theme.palette.success
-                font.pixelSize: 11
-            }
+            Repeater {
+                model: ["Dashboard", "Fleet", "Metrics", "History"]
+                delegate: Rectangle {
+                    Layout.preferredHeight: 44
+                    Layout.preferredWidth: tabLabel.implicitWidth + Theme.spacing.large * 2
+                    color: "transparent"
 
-            // ── Peer count ──
-            Rectangle {
-                visible: lmaoAgentModel.count > 0
-                width: countText.implicitWidth + Theme.spacing.medium
-                height: 20
-                radius: 10
-                color: Theme.palette.backgroundSecondary
+                    Rectangle {
+                        anchors { bottom: parent.bottom; left: parent.left; right: parent.right }
+                        height: 2
+                        color: Theme.palette.primary
+                        visible: root.currentTab === index
+                    }
 
-                Text {
-                    id: countText
-                    anchors.centerIn: parent
-                    text: lmaoAgentModel.count + " peers"
-                    color: Theme.palette.textSecondary
-                    font.pixelSize: 11
+                    Text {
+                        id: tabLabel
+                        anchors.centerIn: parent
+                        text: modelData
+                        color: root.currentTab === index ? Theme.palette.primary : Theme.palette.textSecondary
+                        font { pixelSize: 12; bold: root.currentTab === index }
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.currentTab = index
+                    }
                 }
             }
 
             Item { Layout.fillWidth: true }
 
-            BusyIndicator {
-                running: root.discovering
-                width: 20; height: 20
-                visible: root.discovering
-            }
-
-            Button {
-                text: "Discover"
-                enabled: !root.discovering
-                onClicked: {
-                    root.discovering = true
-                    root.lastError = ""
-                    var result = lmaoModule.discoverAgents("5000")
-                    lmaoAgentModel.loadFromJson(result)
-                    root.discovering = false
-                }
-                contentItem: Text {
-                    text: parent.text
-                    color: Theme.palette.primary
-                    font.pixelSize: 13
-                    horizontalAlignment: Text.AlignHCenter
-                }
-                background: Rectangle {
-                    color: parent.hovered ? Theme.palette.backgroundSecondary : "transparent"
-                    radius: Theme.spacing.tiny
-                    border { color: Theme.palette.primary; width: 1 }
-                }
-                height: 30
+            // Online indicator
+            Rectangle {
+                width: 6; height: 6; radius: 3
+                color: Theme.palette.success
             }
         }
     }
 
-    // ── Body ────────────────────────────────────────────────────────────
-    ColumnLayout {
+    // ── Tab Content ────────────────────────────────────────────────────
+    StackLayout {
         anchors {
             left: parent.left; right: parent.right
             top: header.bottom; bottom: parent.bottom
-            margins: Theme.spacing.medium
         }
-        spacing: Theme.spacing.medium
+        currentIndex: root.currentTab
 
-        // ── Agent List ──────────────────────────────────────────────────
-        ListView {
-            id: agentList
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            spacing: Theme.spacing.small
-            clip: true
-            model: lmaoAgentModel
+        // Tab 0: Dashboard
+        DashboardView {}
 
-            ScrollBar.vertical: ScrollBar {}
-
-            delegate: AgentCard {
-                width: agentList.width
-                agentName:    model.name       || ""
-                agentDesc:    model.description || ""
-                agentPubkey:  model.pubkey      || ""
-                agentVersion: model.version     || ""
-
-                onSendTaskRequested: function(pubkey) {
-                    taskPubkeyField.text = pubkey
-                }
-            }
-
-            // Empty state
-            Column {
-                anchors.centerIn: parent
-                spacing: Theme.spacing.medium
-                visible: lmaoAgentModel.count === 0 && !root.discovering
-
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: "No agents discovered"
-                    color: Theme.palette.textTertiary
-                    font.pixelSize: 15
-                }
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: "Click Discover to search the Waku network"
-                    color: Theme.palette.textTertiary
-                    font.pixelSize: 12
-                }
-            }
-        }
-
-        // ── Send Task Form ──────────────────────────────────────────────
-        Rectangle {
-            Layout.fillWidth: true
-            height: sendColumn.implicitHeight + Theme.spacing.large * 2
-            radius: Theme.spacing.radiusLarge
-            color: Theme.palette.backgroundTertiary
-            border { color: Theme.palette.borderSecondary; width: 1 }
-
+        // Tab 1: Fleet (discovery + task sending)
+        Item {
             ColumnLayout {
-                id: sendColumn
                 anchors {
-                    left: parent.left; right: parent.right
-                    top: parent.top
-                    margins: Theme.spacing.large
+                    fill: parent
+                    margins: Theme.spacing.medium
                 }
-                spacing: Theme.spacing.small
+                spacing: Theme.spacing.medium
 
-                Text {
-                    text: "Send Test Task"
-                    color: Theme.palette.text
-                    font { pixelSize: 14; bold: true }
-                }
-
-                TextField {
-                    id: taskPubkeyField
-                    Layout.fillWidth: true
-                    placeholderText: "Agent public key"
-                    color: Theme.palette.text
-                    font.pixelSize: 12
-                    background: Rectangle {
-                        color: Theme.palette.background
-                        border { color: Theme.palette.borderSecondary; width: 1 }
-                        radius: Theme.spacing.tiny
-                    }
-                }
-
-                TextField {
-                    id: taskTextField
-                    Layout.fillWidth: true
-                    placeholderText: "Task text"
-                    color: Theme.palette.text
-                    font.pixelSize: 12
-                    background: Rectangle {
-                        color: Theme.palette.background
-                        border { color: Theme.palette.borderSecondary; width: 1 }
-                        radius: Theme.spacing.tiny
-                    }
-                }
-
+                // ── Fleet header ──
                 RowLayout {
+                    Layout.fillWidth: true
                     spacing: Theme.spacing.small
 
+                    Text {
+                        text: "Fleet Discovery"
+                        color: Theme.palette.text
+                        font { pixelSize: 16; bold: true }
+                    }
+
+                    Text {
+                        visible: lmaoAgentModel.count > 0
+                        text: lmaoAgentModel.count + " peers"
+                        color: Theme.palette.textSecondary
+                        font.pixelSize: 12
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    BusyIndicator {
+                        running: root.discovering
+                        width: 20; height: 20
+                        visible: root.discovering
+                    }
+
                     Button {
-                        text: "Send"
-                        enabled: taskPubkeyField.text.length > 0 && taskTextField.text.length > 0
+                        text: "Discover"
+                        enabled: !root.discovering
                         onClicked: {
-                            var result = lmaoModule.sendTask(taskPubkeyField.text, taskTextField.text)
-                            root.lastResult = result
-                            taskTextField.text = ""
+                            root.discovering = true
+                            root.lastError = ""
+                            var result = lmaoModule.discoverAgents("5000")
+                            lmaoAgentModel.loadFromJson(result)
+                            root.discovering = false
                         }
                         contentItem: Text {
                             text: parent.text
-                            color: parent.enabled ? "#FFFFFF" : Theme.palette.textTertiary
+                            color: Theme.palette.primary
                             font.pixelSize: 13
                             horizontalAlignment: Text.AlignHCenter
                         }
                         background: Rectangle {
-                            color: parent.enabled ? Theme.palette.primary : Theme.palette.backgroundSecondary
+                            color: parent.hovered ? Theme.palette.backgroundSecondary : "transparent"
                             radius: Theme.spacing.tiny
+                            border { color: Theme.palette.primary; width: 1 }
                         }
-                        height: 32
-                        width: 80
+                        height: 30
+                    }
+                }
+
+                // ── Agent List ──
+                ListView {
+                    id: agentList
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    spacing: Theme.spacing.small
+                    clip: true
+                    model: lmaoAgentModel
+
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: AgentCard {
+                        width: agentList.width
+                        agentName:    model.name       || ""
+                        agentDesc:    model.description || ""
+                        agentPubkey:  model.pubkey      || ""
+                        agentVersion: model.version     || ""
+
+                        onSendTaskRequested: function(pubkey) {
+                            taskPubkeyField.text = pubkey
+                        }
                     }
 
-                    Text {
-                        visible: root.lastResult.length > 0
-                        text: {
-                            if (root.lastResult.length > 60)
-                                return root.lastResult.substring(0, 60) + "\u2026"
-                            return root.lastResult
+                    // Empty state
+                    Column {
+                        anchors.centerIn: parent
+                        spacing: Theme.spacing.medium
+                        visible: lmaoAgentModel.count === 0 && !root.discovering
+
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: "No agents discovered"
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 15
                         }
-                        color: Theme.palette.textSecondary
-                        font.pixelSize: 11
-                        Layout.fillWidth: true
-                        elide: Text.ElideRight
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: "Click Discover to search the Waku network"
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 12
+                        }
+                    }
+                }
+
+                // ── Send Task Form ──
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: sendColumn.implicitHeight + Theme.spacing.large * 2
+                    radius: Theme.spacing.radiusLarge
+                    color: Theme.palette.backgroundTertiary
+                    border { color: Theme.palette.borderSecondary; width: 1 }
+
+                    ColumnLayout {
+                        id: sendColumn
+                        anchors {
+                            left: parent.left; right: parent.right
+                            top: parent.top
+                            margins: Theme.spacing.large
+                        }
+                        spacing: Theme.spacing.small
+
+                        Text {
+                            text: "Send Task"
+                            color: Theme.palette.text
+                            font { pixelSize: 14; bold: true }
+                        }
+
+                        TextField {
+                            id: taskPubkeyField
+                            Layout.fillWidth: true
+                            placeholderText: "Agent public key"
+                            color: Theme.palette.text
+                            font.pixelSize: 12
+                            background: Rectangle {
+                                color: Theme.palette.background
+                                border { color: Theme.palette.borderSecondary; width: 1 }
+                                radius: Theme.spacing.tiny
+                            }
+                        }
+
+                        TextField {
+                            id: taskTextField
+                            Layout.fillWidth: true
+                            placeholderText: "Task text"
+                            color: Theme.palette.text
+                            font.pixelSize: 12
+                            background: Rectangle {
+                                color: Theme.palette.background
+                                border { color: Theme.palette.borderSecondary; width: 1 }
+                                radius: Theme.spacing.tiny
+                            }
+                        }
+
+                        RowLayout {
+                            spacing: Theme.spacing.small
+
+                            Button {
+                                text: "Send"
+                                enabled: taskPubkeyField.text.length > 0 && taskTextField.text.length > 0
+                                onClicked: {
+                                    var result = lmaoModule.sendTask(taskPubkeyField.text, taskTextField.text)
+                                    root.lastResult = result
+                                    // Record in task history
+                                    if (historyView.item)
+                                        historyView.item.addTask(taskPubkeyField.text, taskTextField.text, "sent", result)
+                                    taskTextField.text = ""
+                                }
+                                contentItem: Text {
+                                    text: parent.text
+                                    color: parent.enabled ? "#FFFFFF" : Theme.palette.textTertiary
+                                    font.pixelSize: 13
+                                    horizontalAlignment: Text.AlignHCenter
+                                }
+                                background: Rectangle {
+                                    color: parent.enabled ? Theme.palette.primary : Theme.palette.backgroundSecondary
+                                    radius: Theme.spacing.tiny
+                                }
+                                height: 32
+                                width: 80
+                            }
+
+                            Text {
+                                visible: root.lastResult.length > 0
+                                text: {
+                                    if (root.lastResult.length > 60)
+                                        return root.lastResult.substring(0, 60) + "\u2026"
+                                    return root.lastResult
+                                }
+                                color: Theme.palette.textSecondary
+                                font.pixelSize: 11
+                                Layout.fillWidth: true
+                                elide: Text.ElideRight
+                            }
+                        }
                     }
                 }
             }
         }
 
-        // ── Last task info ──
-        Text {
-            visible: root.lastResult.length > 0
-            text: "Last result: " + root.lastResult
-            color: Theme.palette.textTertiary
-            font.pixelSize: 10
-            Layout.fillWidth: true
-            elide: Text.ElideRight
+        // Tab 2: Metrics
+        MetricsView {}
+
+        // Tab 3: Task History
+        TaskHistoryView {
+            id: historyView
         }
     }
 }

--- a/logos-core-module/qml/MetricsView.qml
+++ b/logos-core-module/qml/MetricsView.qml
@@ -1,0 +1,230 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+/**
+ * MetricsView — operational metrics counters from the LMAO node.
+ *
+ * Context properties (injected by LmaoComponent):
+ *   - lmaoModule : LmaoBackend*
+ */
+Item {
+    id: root
+
+    property var metricsData: ({})
+    property bool loaded: false
+    property string errorMsg: ""
+
+    function refresh() {
+        errorMsg = ""
+        var result = lmaoModule.getMetrics()
+        try {
+            var obj = JSON.parse(result)
+            if (obj.success) {
+                metricsData = obj
+                loaded = true
+            } else {
+                errorMsg = obj.error || "Unknown error"
+            }
+        } catch (e) {
+            errorMsg = "Failed to parse metrics response"
+        }
+    }
+
+    // Auto-refresh every 5 seconds
+    Timer {
+        id: autoRefresh
+        interval: 5000
+        running: true
+        repeat: true
+        onTriggered: root.refresh()
+    }
+
+    Component.onCompleted: refresh()
+
+    Flickable {
+        anchors.fill: parent
+        contentHeight: col.implicitHeight + Theme.spacing.large * 2
+        clip: true
+
+        ColumnLayout {
+            id: col
+            anchors {
+                left: parent.left; right: parent.right
+                top: parent.top
+                margins: Theme.spacing.large
+            }
+            spacing: Theme.spacing.medium
+
+            // ── Header ──
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacing.small
+
+                Text {
+                    text: "Metrics"
+                    color: Theme.palette.text
+                    font { pixelSize: 16; bold: true }
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Text {
+                    visible: root.loaded
+                    text: "Auto-refresh: 5s"
+                    color: Theme.palette.textTertiary
+                    font.pixelSize: 10
+                }
+
+                Button {
+                    text: "↻"
+                    onClicked: root.refresh()
+                    width: 32; height: 32
+                    contentItem: Text {
+                        text: parent.text
+                        color: Theme.palette.primary
+                        font.pixelSize: 16
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? Theme.palette.backgroundTertiary : "transparent"
+                        radius: Theme.spacing.tiny
+                    }
+                }
+            }
+
+            // ── Error display ──
+            Text {
+                visible: root.errorMsg.length > 0
+                text: "⚠ " + root.errorMsg
+                color: Theme.palette.error
+                font.pixelSize: 12
+                Layout.fillWidth: true
+            }
+
+            // ── Tasks section ──
+            MetricSection {
+                title: "Tasks"
+                metrics: [
+                    { label: "Sent",     value: metricsData.tasks_sent || 0 },
+                    { label: "Received", value: metricsData.tasks_received || 0 },
+                    { label: "Failed",   value: metricsData.tasks_failed || 0,
+                      highlight: (metricsData.tasks_failed || 0) > 0 }
+                ]
+            }
+
+            // ── Messages section ──
+            MetricSection {
+                title: "Messages"
+                metrics: [
+                    { label: "Published", value: metricsData.messages_published || 0 },
+                    { label: "Received",  value: metricsData.messages_received || 0 },
+                    { label: "Responses",  value: metricsData.responses_sent || 0 }
+                ]
+            }
+
+            // ── Discovery section ──
+            MetricSection {
+                title: "Discovery"
+                metrics: [
+                    { label: "Discoveries",   value: metricsData.discoveries || 0 },
+                    { label: "Announcements",  value: metricsData.announcements_sent || 0 },
+                    { label: "Peers Found",    value: metricsData.peers_discovered || 0 }
+                ]
+            }
+
+            // ── Sessions & Encryption section ──
+            MetricSection {
+                title: "Sessions & Encryption"
+                metrics: [
+                    { label: "Sessions",    value: metricsData.sessions_created || 0 },
+                    { label: "Encryptions", value: metricsData.encryptions || 0 },
+                    { label: "Decryptions", value: metricsData.decryptions || 0 }
+                ]
+            }
+
+            // ── Streaming section ──
+            MetricSection {
+                title: "Streaming & Delegation"
+                metrics: [
+                    { label: "Chunks Sent",     value: metricsData.stream_chunks_sent || 0 },
+                    { label: "Chunks Received", value: metricsData.stream_chunks_received || 0 },
+                    { label: "Delegations",     value: metricsData.delegations_sent || 0 }
+                ]
+            }
+
+            // ── Retries section ──
+            MetricSection {
+                title: "Retries"
+                metrics: [
+                    { label: "Attempts",  value: metricsData.retry_attempts || 0 },
+                    { label: "Exhausted", value: metricsData.retries_exhausted || 0,
+                      highlight: (metricsData.retries_exhausted || 0) > 0 }
+                ]
+            }
+        }
+    }
+
+    // ── MetricSection helper component ──
+    component MetricSection: Rectangle {
+        property string title: ""
+        property var metrics: []
+
+        Layout.fillWidth: true
+        implicitHeight: sectionCol.implicitHeight + Theme.spacing.medium * 2
+        radius: Theme.spacing.radiusLarge
+        color: Theme.palette.backgroundTertiary
+        border { color: Theme.palette.borderSecondary; width: 1 }
+
+        ColumnLayout {
+            id: sectionCol
+            anchors {
+                left: parent.left; right: parent.right; top: parent.top
+                margins: Theme.spacing.medium
+            }
+            spacing: Theme.spacing.tiny
+
+            Text {
+                text: title
+                color: Theme.palette.textSecondary
+                font { pixelSize: 11; bold: true; letterSpacing: 1 }
+            }
+
+            // Counter tiles row
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacing.small
+
+                Repeater {
+                    model: metrics
+                    delegate: Rectangle {
+                        Layout.fillWidth: true
+                        height: 56
+                        radius: Theme.spacing.tiny
+                        color: Theme.palette.backgroundSecondary
+
+                        ColumnLayout {
+                            anchors.centerIn: parent
+                            spacing: 2
+
+                            Text {
+                                text: modelData.value !== undefined ? modelData.value.toString() : "0"
+                                color: (modelData.highlight) ? Theme.palette.error : Theme.palette.primary
+                                font { pixelSize: 20; bold: true; family: "monospace" }
+                                Layout.alignment: Qt.AlignHCenter
+                            }
+
+                            Text {
+                                text: modelData.label || ""
+                                color: Theme.palette.textTertiary
+                                font.pixelSize: 10
+                                Layout.alignment: Qt.AlignHCenter
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/logos-core-module/qml/TaskHistoryView.qml
+++ b/logos-core-module/qml/TaskHistoryView.qml
@@ -1,0 +1,248 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+/**
+ * TaskHistoryView — list of recent tasks sent/received.
+ *
+ * Context properties (injected by LmaoComponent):
+ *   - lmaoModule     : LmaoBackend*
+ *   - lmaoAgentModel : AgentListModel*
+ */
+Item {
+    id: root
+
+    // In-memory task history (most recent first)
+    property var taskHistory: []
+    property int selectedIndex: -1
+
+    function addTask(peer, text, direction, resultJson) {
+        var entry = {
+            timestamp: new Date().toISOString(),
+            peer: peer,
+            text: text,
+            direction: direction,  // "sent" or "received"
+            status: "unknown",
+            taskId: "",
+            duration: 0
+        }
+
+        try {
+            var obj = JSON.parse(resultJson)
+            entry.status = obj.success ? "ok" : "failed"
+            entry.taskId = obj.task_id || ""
+            if (obj.error) entry.text = obj.error
+        } catch (e) {
+            entry.status = "error"
+        }
+
+        var updated = [entry].concat(taskHistory)
+        // Keep max 50 entries
+        if (updated.length > 50) updated = updated.slice(0, 50)
+        taskHistory = updated
+    }
+
+    ColumnLayout {
+        anchors {
+            fill: parent
+            margins: Theme.spacing.large
+        }
+        spacing: Theme.spacing.medium
+
+        // ── Header ──
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing.small
+
+            Text {
+                text: "Task History"
+                color: Theme.palette.text
+                font { pixelSize: 16; bold: true }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            Text {
+                text: taskHistory.length + " tasks"
+                color: Theme.palette.textTertiary
+                font.pixelSize: 12
+            }
+
+            Button {
+                text: "Clear"
+                visible: taskHistory.length > 0
+                onClicked: {
+                    taskHistory = []
+                    selectedIndex = -1
+                }
+                contentItem: Text {
+                    text: parent.text
+                    color: Theme.palette.error
+                    font.pixelSize: 11
+                    horizontalAlignment: Text.AlignHCenter
+                }
+                background: Rectangle {
+                    color: parent.hovered ? Theme.palette.backgroundSecondary : "transparent"
+                    radius: Theme.spacing.tiny
+                    border { color: Theme.palette.error; width: 1 }
+                }
+                height: 26
+            }
+        }
+
+        // ── Task List ──
+        ListView {
+            id: historyList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: Theme.spacing.tiny
+            clip: true
+            model: taskHistory.length
+
+            ScrollBar.vertical: ScrollBar {}
+
+            delegate: Rectangle {
+                width: historyList.width
+                height: taskCol.implicitHeight + Theme.spacing.medium * 2
+                radius: Theme.spacing.radiusLarge
+                color: index === root.selectedIndex
+                       ? Theme.palette.backgroundSecondary
+                       : Theme.palette.backgroundTertiary
+                border {
+                    color: index === root.selectedIndex
+                           ? Theme.palette.primary
+                           : Theme.palette.borderSecondary
+                    width: 1
+                }
+
+                property var task: taskHistory[index] || ({})
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        root.selectedIndex = (root.selectedIndex === index) ? -1 : index
+                    }
+                }
+
+                ColumnLayout {
+                    id: taskCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.medium
+                    }
+                    spacing: Theme.spacing.tiny
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.spacing.small
+
+                        // Direction indicator
+                        Rectangle {
+                            width: 6; height: 6; radius: 3
+                            color: task.direction === "sent" ? Theme.palette.primary : Theme.palette.success
+                        }
+
+                        Text {
+                            text: task.direction === "sent" ? "→" : "←"
+                            color: Theme.palette.textSecondary
+                            font { pixelSize: 12; family: "monospace" }
+                        }
+
+                        Text {
+                            text: {
+                                var p = task.peer || ""
+                                if (p.length > 16)
+                                    return p.substring(0, 8) + "…" + p.slice(-6)
+                                return p || "(unknown)"
+                            }
+                            color: Theme.palette.text
+                            font { pixelSize: 13; family: "monospace" }
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                        }
+
+                        // Status badge
+                        Rectangle {
+                            width: statusText.implicitWidth + 12
+                            height: 18
+                            radius: 9
+                            color: task.status === "ok" ? "#1B5E20"
+                                 : task.status === "failed" ? "#B71C1C"
+                                 : Theme.palette.backgroundSecondary
+
+                            Text {
+                                id: statusText
+                                anchors.centerIn: parent
+                                text: task.status || "?"
+                                color: "#FFFFFF"
+                                font.pixelSize: 10
+                            }
+                        }
+
+                        Text {
+                            text: {
+                                if (!task.timestamp) return ""
+                                var d = new Date(task.timestamp)
+                                return Qt.formatTime(d, "HH:mm:ss")
+                            }
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 11
+                        }
+                    }
+
+                    // ── Expanded details ──
+                    ColumnLayout {
+                        visible: index === root.selectedIndex
+                        Layout.fillWidth: true
+                        spacing: 2
+
+                        Text {
+                            visible: (task.text || "").length > 0
+                            text: "Text: " + task.text
+                            color: Theme.palette.textSecondary
+                            font.pixelSize: 11
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+
+                        Text {
+                            visible: (task.taskId || "").length > 0
+                            text: "Task ID: " + task.taskId
+                            color: Theme.palette.textTertiary
+                            font { pixelSize: 11; family: "monospace" }
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                        }
+
+                        Text {
+                            text: "Timestamp: " + (task.timestamp || "—")
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 11
+                        }
+                    }
+                }
+            }
+
+            // ── Empty state ──
+            Column {
+                anchors.centerIn: parent
+                spacing: Theme.spacing.medium
+                visible: taskHistory.length === 0
+
+                Text {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: "No tasks yet"
+                    color: Theme.palette.textTertiary
+                    font.pixelSize: 15
+                }
+                Text {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: "Tasks will appear here as you send and receive them"
+                    color: Theme.palette.textTertiary
+                    font.pixelSize: 12
+                }
+            }
+        }
+    }
+}

--- a/logos-core-module/qml/qml.qrc
+++ b/logos-core-module/qml/qml.qrc
@@ -5,5 +5,8 @@
     <file>Theme.qml</file>
     <file>LmaoView.qml</file>
     <file>AgentCard.qml</file>
+    <file>DashboardView.qml</file>
+    <file>MetricsView.qml</file>
+    <file>TaskHistoryView.qml</file>
   </qresource>
 </RCC>

--- a/logos-core-module/src/DeliveryTransport.cpp
+++ b/logos-core-module/src/DeliveryTransport.cpp
@@ -1,0 +1,164 @@
+#include "DeliveryTransport.h"
+
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QMetaObject>
+#include <QVariant>
+
+DeliveryTransport::DeliveryTransport(QObject* parent)
+    : QObject(parent)
+{
+}
+
+bool DeliveryTransport::init(LogosAPI* logosAPI)
+{
+    if (!logosAPI) {
+        qWarning() << "DeliveryTransport::init — logosAPI is null";
+        return false;
+    }
+
+    // logosAPI is a QObject-derived class from the Logos SDK.
+    // Use QMetaObject::invokeMethod to call getClient("delivery_module")
+    // without needing the full LogosAPI header at compile time.
+    auto* apiObj = reinterpret_cast<QObject*>(logosAPI);
+
+    QObject* client = nullptr;
+    bool ok = QMetaObject::invokeMethod(
+        apiObj,
+        "getClient",
+        Qt::DirectConnection,
+        Q_RETURN_ARG(QObject*, client),
+        Q_ARG(QString, QStringLiteral("delivery_module")));
+
+    if (!ok || !client) {
+        qWarning() << "DeliveryTransport::init — failed to get delivery_module client"
+                    << "(invokeMethod returned" << ok << ")";
+        return false;
+    }
+
+    m_client = client;
+    qDebug() << "DeliveryTransport::init — connected to delivery_module";
+
+    // Connect the messageReceived event from the delivery_module replica.
+    // The delivery_module emits: void eventReceived(const QString& name, const QString& data)
+    connect(m_client, SIGNAL(eventReceived(QString, QString)),
+            this, SLOT(onDeliveryEvent(QString, QString)));
+
+    emit connectedChanged();
+    return true;
+}
+
+void DeliveryTransport::onDeliveryEvent(const QString& eventName, const QString& eventData)
+{
+    if (eventName != QLatin1String("messageReceived"))
+        return;
+
+    QJsonDocument doc = QJsonDocument::fromJson(eventData.toUtf8());
+    if (!doc.isObject())
+        return;
+
+    QJsonObject obj = doc.object();
+    QString topic = obj.value(QLatin1String("contentTopic")).toString();
+    QString payloadB64 = obj.value(QLatin1String("payload")).toString();
+    QByteArray payload = QByteArray::fromBase64(payloadB64.toUtf8());
+
+    emit messageReceived(topic, payload);
+}
+
+QString DeliveryTransport::callMethod(const QString& method, const QVariantList& args)
+{
+    if (!m_client) {
+        qWarning() << "DeliveryTransport::callMethod — not connected";
+        return {};
+    }
+
+    // Build the Logos Core params JSON array:
+    // [{"name":"key","value":"val","type":"string"}, ...]
+    QJsonArray params;
+    for (int i = 0; i + 1 < args.size(); i += 2) {
+        QJsonObject param;
+        param[QLatin1String("name")] = args[i].toString();
+        param[QLatin1String("value")] = args[i + 1].toString();
+        param[QLatin1String("type")] = QStringLiteral("string");
+        params.append(param);
+    }
+
+    QString paramsJson = QString::fromUtf8(
+        QJsonDocument(params).toJson(QJsonDocument::Compact));
+
+    QString result;
+    bool ok = QMetaObject::invokeMethod(
+        m_client,
+        "callMethod",
+        Qt::DirectConnection,
+        Q_RETURN_ARG(QString, result),
+        Q_ARG(QString, method),
+        Q_ARG(QString, paramsJson));
+
+    if (!ok) {
+        qWarning() << "DeliveryTransport::callMethod — invokeMethod failed for" << method;
+        return {};
+    }
+
+    return result;
+}
+
+bool DeliveryTransport::createNode(const QString& configJson)
+{
+    QString result = callMethod(QStringLiteral("createNode"),
+                                {QStringLiteral("cfg"), configJson});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::createNode failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::start()
+{
+    // start takes no params — pass empty list
+    QString result = callMethod(QStringLiteral("start"), {});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::start failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::send(const QString& contentTopic, const QByteArray& payload)
+{
+    QString payloadB64 = QString::fromLatin1(payload.toBase64());
+    QString result = callMethod(QStringLiteral("send"),
+                                {QStringLiteral("contentTopic"), contentTopic,
+                                 QStringLiteral("payload"), payloadB64});
+
+    if (result.startsWith(QLatin1String("error"), Qt::CaseInsensitive)) {
+        qWarning() << "DeliveryTransport::send failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::subscribe(const QString& contentTopic)
+{
+    QString result = callMethod(QStringLiteral("subscribe"),
+                                {QStringLiteral("contentTopic"), contentTopic});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::subscribe failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::unsubscribe(const QString& contentTopic)
+{
+    QString result = callMethod(QStringLiteral("unsubscribe"),
+                                {QStringLiteral("contentTopic"), contentTopic});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::unsubscribe failed:" << result;
+        return false;
+    }
+    return true;
+}

--- a/logos-core-module/src/DeliveryTransport.h
+++ b/logos-core-module/src/DeliveryTransport.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QByteArray>
+
+class LogosAPI;
+
+/**
+ * DeliveryTransport — QtRO bridge to the delivery_module Logos Core module.
+ *
+ * Obtains a QtRO replica of delivery_module via logosAPI->getClient() and
+ * exposes send/subscribe/unsubscribe as Q_INVOKABLE methods.
+ *
+ * This follows the same pattern used by logos-kv-module and lez-multisig-module.
+ */
+class DeliveryTransport : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool connected READ isConnected NOTIFY connectedChanged)
+
+public:
+    explicit DeliveryTransport(QObject* parent = nullptr);
+    ~DeliveryTransport() override = default;
+
+    /// Acquire the delivery_module replica from logosAPI.
+    /// Returns true if the client was obtained successfully.
+    bool init(LogosAPI* logosAPI);
+
+    bool isConnected() const { return m_client != nullptr; }
+
+    /// Send a payload to a content topic via delivery_module.
+    Q_INVOKABLE bool send(const QString& contentTopic, const QByteArray& payload);
+
+    /// Subscribe to a content topic.
+    Q_INVOKABLE bool subscribe(const QString& contentTopic);
+
+    /// Unsubscribe from a content topic.
+    Q_INVOKABLE bool unsubscribe(const QString& contentTopic);
+
+    /// Initialize the delivery node with a configuration JSON string.
+    Q_INVOKABLE bool createNode(const QString& configJson);
+
+    /// Start the delivery node.
+    Q_INVOKABLE bool start();
+
+signals:
+    void connectedChanged();
+    void messageReceived(const QString& contentTopic, const QByteArray& payload);
+
+private slots:
+    void onDeliveryEvent(const QString& eventName, const QString& eventData);
+
+private:
+    /// Call a method on the delivery_module replica via QMetaObject::invokeMethod.
+    /// Returns the result string, or an empty string on failure.
+    QString callMethod(const QString& method, const QVariantList& args);
+
+    QObject* m_client = nullptr;
+};

--- a/logos-core-module/src/LmaoBackend.cpp
+++ b/logos-core-module/src/LmaoBackend.cpp
@@ -70,6 +70,18 @@ QString LmaoBackend::getAgentCard()
     return callFfiStr(lmao_get_agent_card());
 }
 
+QString LmaoBackend::getInfo()
+{
+    qDebug() << "LmaoBackend::getInfo";
+    return callFfiStr(lmao_get_info());
+}
+
+QString LmaoBackend::getMetrics()
+{
+    qDebug() << "LmaoBackend::getMetrics";
+    return callFfiStr(lmao_get_metrics());
+}
+
 bool LmaoBackend::deliverySend(const QString& contentTopic, const QByteArray& payload)
 {
     if (!m_delivery) {

--- a/logos-core-module/src/LmaoBackend.cpp
+++ b/logos-core-module/src/LmaoBackend.cpp
@@ -1,4 +1,5 @@
 #include "LmaoBackend.h"
+#include "DeliveryTransport.h"
 
 #include <QDebug>
 #include <QJsonDocument>
@@ -13,9 +14,15 @@ extern "C" {
 }
 #endif
 
-LmaoBackend::LmaoBackend(QObject* parent)
+LmaoBackend::LmaoBackend(DeliveryTransport* delivery, QObject* parent)
     : QObject(parent)
+    , m_delivery(delivery)
 {
+    if (m_delivery) {
+        qDebug() << "LmaoBackend: using QtRO delivery transport";
+    } else {
+        qDebug() << "LmaoBackend: no QtRO transport — using FFI only";
+    }
 }
 
 /*static*/
@@ -61,4 +68,18 @@ QString LmaoBackend::getAgentCard()
 {
     qDebug() << "LmaoBackend::getAgentCard";
     return callFfiStr(lmao_get_agent_card());
+}
+
+bool LmaoBackend::deliverySend(const QString& contentTopic, const QByteArray& payload)
+{
+    if (!m_delivery) {
+        qDebug() << "LmaoBackend::deliverySend — no QtRO transport available";
+        return false;
+    }
+
+    bool ok = m_delivery->send(contentTopic, payload);
+    if (!ok) {
+        emit errorOccurred(QStringLiteral("delivery_module send failed via QtRO"));
+    }
+    return ok;
 }

--- a/logos-core-module/src/LmaoBackend.h
+++ b/logos-core-module/src/LmaoBackend.h
@@ -3,22 +3,36 @@
 #include <QObject>
 #include <QString>
 
+class DeliveryTransport;
+
 /**
  * LmaoBackend — QObject wrapper around lmao-ffi for QML integration.
  *
  * Exposes agent discovery, task sending, and agent card retrieval
  * as Q_INVOKABLE methods callable from QML.
+ *
+ * When a DeliveryTransport (QtRO) is available, message sending uses
+ * the delivery_module via QtRO inter-module calls (issue #77).
+ * Falls back to Rust FFI transport when QtRO is unavailable.
  */
 class LmaoBackend : public QObject {
     Q_OBJECT
+    Q_PROPERTY(bool hasDeliveryTransport READ hasDeliveryTransport CONSTANT)
 
 public:
-    explicit LmaoBackend(QObject* parent = nullptr);
+    explicit LmaoBackend(DeliveryTransport* delivery = nullptr,
+                         QObject* parent = nullptr);
     ~LmaoBackend() override = default;
+
+    bool hasDeliveryTransport() const { return m_delivery != nullptr; }
 
     Q_INVOKABLE QString discoverAgents(const QString& timeoutMs);
     Q_INVOKABLE QString sendTask(const QString& agentPubkey, const QString& taskText);
     Q_INVOKABLE QString getAgentCard();
+
+    /// Send raw bytes to a content topic via QtRO delivery transport.
+    /// Returns true if sent via QtRO, false if QtRO unavailable (caller should fall back).
+    Q_INVOKABLE bool deliverySend(const QString& contentTopic, const QByteArray& payload);
 
 signals:
     void agentsDiscovered(const QString& json);
@@ -27,4 +41,5 @@ signals:
 
 private:
     static QString callFfiStr(char* raw);
+    DeliveryTransport* m_delivery = nullptr;
 };

--- a/logos-core-module/src/LmaoBackend.h
+++ b/logos-core-module/src/LmaoBackend.h
@@ -29,6 +29,8 @@ public:
     Q_INVOKABLE QString discoverAgents(const QString& timeoutMs);
     Q_INVOKABLE QString sendTask(const QString& agentPubkey, const QString& taskText);
     Q_INVOKABLE QString getAgentCard();
+    Q_INVOKABLE QString getInfo();
+    Q_INVOKABLE QString getMetrics();
 
     /// Send raw bytes to a content topic via QtRO delivery transport.
     /// Returns true if sent via QtRO, false if QtRO unavailable (caller should fall back).

--- a/logos-core-module/src/LmaoComponent.cpp
+++ b/logos-core-module/src/LmaoComponent.cpp
@@ -1,6 +1,7 @@
 #include "LmaoComponent.h"
 #include "LmaoBackend.h"
 #include "AgentListModel.h"
+#include "DeliveryTransport.h"
 
 #include <QQuickWidget>
 #include <QQmlContext>
@@ -52,15 +53,27 @@ void LmaoComponent::initialize()
     m_initialized = true;
 }
 
-QWidget* LmaoComponent::createWidget(LogosAPI* /*logosAPI*/)
+QWidget* LmaoComponent::createWidget(LogosAPI* logosAPI)
 {
     initialize();
+
+    // Store logosAPI and set up QtRO delivery transport (issue #77).
+    m_logosAPI = logosAPI;
+    if (logosAPI && !m_delivery) {
+        m_delivery = new DeliveryTransport(this);
+        if (m_delivery->init(logosAPI)) {
+            qDebug() << "LmaoComponent: delivery transport connected via QtRO";
+        } else {
+            qWarning() << "LmaoComponent: delivery transport init failed — "
+                           "falling back to FFI transport";
+        }
+    }
 
     auto* widget = new QQuickWidget();
     widget->setMinimumSize(500, 400);
     widget->setResizeMode(QQuickWidget::SizeRootObjectToView);
 
-    auto* backend = new LmaoBackend();
+    auto* backend = new LmaoBackend(m_delivery);
     backend->setParent(widget);
 
     auto* model = new AgentListModel();
@@ -68,6 +81,7 @@ QWidget* LmaoComponent::createWidget(LogosAPI* /*logosAPI*/)
 
     widget->rootContext()->setContextProperty("lmaoModule", backend);
     widget->rootContext()->setContextProperty("lmaoAgentModel", model);
+    widget->rootContext()->setContextProperty("lmaoDelivery", m_delivery);
     widget->setSource(QUrl("qrc:/lmao/LmaoView.qml"));
 
     return widget;

--- a/logos-core-module/src/LmaoComponent.h
+++ b/logos-core-module/src/LmaoComponent.h
@@ -5,11 +5,13 @@
 #include <QString>
 
 class LmaoBackend;
+class DeliveryTransport;
 
 /**
  * LmaoComponent — Logos Core IComponent plugin for LMAO (A2A over Waku).
  *
  * Provides agent discovery and task sending over the Waku network.
+ * Uses QtRO to call delivery_module for message transport (issue #77).
  */
 class LmaoComponent : public QObject, public IComponent {
     Q_OBJECT
@@ -31,4 +33,6 @@ public:
 
 private:
     bool m_initialized = false;
+    LogosAPI* m_logosAPI = nullptr;
+    DeliveryTransport* m_delivery = nullptr;
 };

--- a/logos-core-module/src/lmao_ffi.h
+++ b/logos-core-module/src/lmao_ffi.h
@@ -34,6 +34,21 @@ char *lmao_send_task(const char *args_json);
 char *lmao_get_agent_card(void);
 
 /**
+ * Get agent info: identity, topics, and encryption status.
+ *
+ * Returns: { "success": true, "public_key": "02...", "task_topic": "...",
+ *            "discovery_topic": "...", "presence_topic": "...", "encryption": false }
+ */
+char *lmao_get_info(void);
+
+/**
+ * Get operational metrics counters.
+ *
+ * Returns: { "success": true, "tasks_sent": 0, "tasks_received": 0, ... }
+ */
+char *lmao_get_metrics(void);
+
+/**
  * Free a string returned by any lmao_* function.
  */
 void lmao_free_string(char *s);


### PR DESCRIPTION
## Summary

- Add **Dashboard view** with agent identity, public key (click-to-copy), Waku topics, encryption status, and QtRO transport status
- Add **Metrics view** with grouped counter tiles (tasks, messages, discovery, sessions, streaming, retries) and 5-second auto-refresh
- Add **Task History view** with in-memory task log, expandable details, status badges, and timestamps
- Refactor **LmaoView** from single fleet view to tabbed navigation (Dashboard / Fleet / Metrics / History)
- Add `lmao_get_info()` and `lmao_get_metrics()` FFI functions in Rust with full test coverage
- Add `getInfo()` and `getMetrics()` Q_INVOKABLE methods to C++ LmaoBackend

## Test plan

- [x] `cargo test --workspace` — all 98 FFI tests + workspace tests pass
- [ ] Build with `nix build .#lgx` and verify UI plugin loads in logos-app
- [ ] Verify Dashboard tab shows agent identity and topics
- [ ] Verify Metrics tab shows counters and auto-refreshes
- [ ] Verify Fleet tab retains discovery + task sending functionality
- [ ] Verify Task History records sent tasks with correct status

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)