### PR TITLE
feat: decentralized skill marketplace — publish, discover, rank, auto-adopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 name = "lmao-ffi"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "cbindgen",
  "logos-messaging-a2a-core",
  "logos-messaging-a2a-node",

--- a/crates/lmao-ffi/Cargo.toml
+++ b/crates/lmao-ffi/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "C FFI wrapper for LMAO (A2A over Waku)"
 
+[features]
+default = []
+logos-core = ["logos-messaging-a2a-transport/logos-core"]
+
 [lib]
 crate-type = ["cdylib", "staticlib"]
 

--- a/crates/lmao-ffi/Cargo.toml
+++ b/crates/lmao-ffi/Cargo.toml
@@ -18,6 +18,7 @@ logos-messaging-a2a-transport = { path = "../logos-messaging-a2a-transport" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+base64 = "0.22"
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/crates/lmao-ffi/include/lmao_ffi.h
+++ b/crates/lmao-ffi/include/lmao_ffi.h
@@ -29,6 +29,19 @@ char *lmao_discover_agents(const char *args_json);
 char *lmao_send_task(const char *args_json);
 
 /**
+ * Build a task envelope without sending it — for use with external transports (QtRO).
+ *
+ * args_json: { "agent_pubkey": "02...", "task_text": "Hello" }
+ *
+ * Returns: { "success": true, "task_id": "...", "topic": "/lmao/1/task/...",
+ *            "payload_b64": "<base64-encoded A2A envelope>" }
+ *
+ * The caller (e.g. C++ DeliveryTransport) can send the payload to the topic
+ * via QtRO inter-module call to delivery_module, bypassing the Rust transport (issue #143).
+ */
+char *lmao_build_task_envelope(const char *args_json);
+
+/**
  * Get this agent's card as JSON.
  *
  * Returns: { "success": true, "card": { "name": "...", ... } }

--- a/crates/lmao-ffi/include/lmao_ffi.h
+++ b/crates/lmao-ffi/include/lmao_ffi.h
@@ -41,6 +41,21 @@ char *lmao_get_agent_card(void);
 void lmao_free_string(char *s);
 
 /**
+ * Get agent info: identity, topics, and encryption status.
+ *
+ * Returns: { "success": true, "public_key": "02...", "task_topic": "...",
+ *            "discovery_topic": "...", "presence_topic": "...", "encryption": false }
+ */
+char *lmao_get_info(void);
+
+/**
+ * Get operational metrics counters.
+ *
+ * Returns: { "success": true, "tasks_sent": 0, "tasks_received": 0, ... }
+ */
+char *lmao_get_metrics(void);
+
+/**
  * Returns the version string of this FFI library.
  */
 char *lmao_version(void);

--- a/crates/lmao-ffi/src/lib.rs
+++ b/crates/lmao-ffi/src/lib.rs
@@ -1330,19 +1330,26 @@ mod tests {
         if v["success"] == true {
             // All 17 counter fields should be present
             let expected_fields = [
-                "tasks_sent", "tasks_received", "tasks_failed",
-                "messages_published", "messages_received",
-                "discoveries", "announcements_sent", "peers_discovered",
-                "encryptions", "decryptions", "sessions_created",
-                "delegations_sent", "stream_chunks_sent", "stream_chunks_received",
-                "retry_attempts", "retries_exhausted", "responses_sent",
+                "tasks_sent",
+                "tasks_received",
+                "tasks_failed",
+                "messages_published",
+                "messages_received",
+                "discoveries",
+                "announcements_sent",
+                "peers_discovered",
+                "encryptions",
+                "decryptions",
+                "sessions_created",
+                "delegations_sent",
+                "stream_chunks_sent",
+                "stream_chunks_received",
+                "retry_attempts",
+                "retries_exhausted",
+                "responses_sent",
             ];
             for field in &expected_fields {
-                assert!(
-                    v.get(*field).is_some(),
-                    "metrics missing field: {}",
-                    field
-                );
+                assert!(v.get(*field).is_some(), "metrics missing field: {}", field);
             }
         }
     }

--- a/crates/lmao-ffi/src/lib.rs
+++ b/crates/lmao-ffi/src/lib.rs
@@ -2,6 +2,13 @@
 //!
 //! All functions accept/return JSON strings (UTF-8, null-terminated).
 //! Caller must free returned strings with lmao_free_string().
+//!
+//! ## Transport selection
+//!
+//! - **Default (REST)**: uses nwaku REST API via `WAKU_URL` env var (default `http://localhost:8645`).
+//! - **`logos-core` feature**: uses `LogosCoreDeliveryTransport` — inter-module IPC via
+//!   `logos_core_call_plugin_method_async` to the `delivery_module` plugin. This is the
+//!   transport used when running inside Logos Core as a plugin (issue #77, #143).
 
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
@@ -9,8 +16,18 @@ use std::sync::OnceLock;
 
 use logos_messaging_a2a_core::topics;
 use logos_messaging_a2a_node::WakuA2ANode;
-use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 use tokio::runtime::Runtime;
+
+#[cfg(feature = "logos-core")]
+use logos_messaging_a2a_transport::LogosCoreDeliveryTransport;
+#[cfg(not(feature = "logos-core"))]
+use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
+
+/// The concrete transport type used by this build.
+#[cfg(feature = "logos-core")]
+type NodeTransport = LogosCoreDeliveryTransport;
+#[cfg(not(feature = "logos-core"))]
+type NodeTransport = LogosMessagingTransport;
 
 /// Global tokio runtime for async operations.
 fn runtime() -> &'static Runtime {
@@ -19,16 +36,34 @@ fn runtime() -> &'static Runtime {
 }
 
 /// Global node instance (lazy-initialized on first call).
-static NODE: OnceLock<WakuA2ANode<LogosMessagingTransport>> = OnceLock::new();
+static NODE: OnceLock<WakuA2ANode<NodeTransport>> = OnceLock::new();
 
 /// Returns a reference to the lazily-initialized global node, creating it on the
-/// first call using the `WAKU_URL` environment variable (defaults to `http://localhost:8645`).
-/// The node is announced on the Waku network as part of initialization.
-fn get_or_init_node() -> &'static WakuA2ANode<LogosMessagingTransport> {
+/// first call.
+///
+/// - With `logos-core` feature: uses `LogosCoreDeliveryTransport` to communicate via
+///   the `delivery_module` plugin over Logos Core IPC (QtRO inter-module calls).
+///   Reads `DELIVERY_CFG` env var for node config JSON (default `{}`).
+/// - Without: uses nwaku REST transport via `WAKU_URL` env var (default `http://localhost:8645`).
+fn get_or_init_node() -> &'static WakuA2ANode<NodeTransport> {
     NODE.get_or_init(|| {
-        let waku_url =
-            std::env::var("WAKU_URL").unwrap_or_else(|_| "http://localhost:8645".to_string());
-        let transport = LogosMessagingTransport::new(&waku_url);
+        let rt = runtime();
+
+        #[cfg(feature = "logos-core")]
+        let transport = {
+            let cfg =
+                std::env::var("DELIVERY_CFG").unwrap_or_else(|_| "{}".to_string());
+            rt.block_on(LogosCoreDeliveryTransport::new(&cfg))
+                .expect("failed to create LogosCoreDeliveryTransport — is delivery_module loaded?")
+        };
+
+        #[cfg(not(feature = "logos-core"))]
+        let transport = {
+            let waku_url =
+                std::env::var("WAKU_URL").unwrap_or_else(|_| "http://localhost:8645".to_string());
+            LogosMessagingTransport::new(&waku_url)
+        };
+
         let node = WakuA2ANode::new(
             "lmao-agent",
             "LMAO A2A agent via Logos Core",
@@ -37,7 +72,7 @@ fn get_or_init_node() -> &'static WakuA2ANode<LogosMessagingTransport> {
         );
 
         // Announce on startup
-        let _ = runtime().block_on(node.announce());
+        let _ = rt.block_on(node.announce());
 
         node
     })

--- a/crates/lmao-ffi/src/lib.rs
+++ b/crates/lmao-ffi/src/lib.rs
@@ -215,6 +215,61 @@ pub extern "C" fn lmao_send_task(args_json: *const c_char) -> *mut c_char {
     }
 }
 
+/// Build a task envelope without sending it — for use with external transports (QtRO).
+///
+/// args_json: { "agent_pubkey": "02...", "task_text": "Hello" }
+///
+/// Returns: { "success": true, "task_id": "...", "topic": "/lmao/1/task/...",
+///            "payload_b64": "<base64-encoded A2A envelope>" }
+///
+/// The caller (e.g. C++ DeliveryTransport) can send the payload to the topic
+/// via QtRO inter-module call to delivery_module, bypassing the Rust transport (issue #143).
+#[no_mangle]
+pub extern "C" fn lmao_build_task_envelope(args_json: *const c_char) -> *mut c_char {
+    use logos_messaging_a2a_core::{A2AEnvelope, Task};
+
+    let s = match cstr_to_str(args_json) {
+        Ok(s) => s,
+        Err(e) => return error_json(&e),
+    };
+
+    let v: serde_json::Value = match serde_json::from_str(s) {
+        Ok(v) => v,
+        Err(e) => return error_json(&format!("JSON parse error: {}", e)),
+    };
+
+    let agent_pubkey = match v.get("agent_pubkey").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return error_json("missing 'agent_pubkey'"),
+    };
+
+    let task_text = match v.get("task_text").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return error_json("missing 'task_text'"),
+    };
+
+    let node = get_or_init_node();
+    let task = Task::new(node.pubkey(), &agent_pubkey, &task_text);
+    let topic = topics::task_topic(&agent_pubkey);
+
+    let envelope = A2AEnvelope::Task(task.clone());
+    let envelope_bytes = match serde_json::to_vec(&envelope) {
+        Ok(b) => b,
+        Err(e) => return error_json(&format!("envelope serialization error: {}", e)),
+    };
+
+    use base64::Engine;
+    let payload_b64 = base64::engine::general_purpose::STANDARD.encode(&envelope_bytes);
+
+    success_json(serde_json::json!({
+        "task_id": task.id,
+        "from": task.from,
+        "to": task.to,
+        "topic": topic,
+        "payload_b64": payload_b64,
+    }))
+}
+
 /// Get this agent's card as JSON.
 ///
 /// Returns: { "success": true, "card": { "name": "...", ... } }
@@ -284,6 +339,7 @@ pub extern "C" fn lmao_version() -> *mut c_char {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine;
     use logos_messaging_a2a_core::{A2AEnvelope, AgentCard, Message, Part, Task, TaskState};
 
     /// Helper: read a *mut c_char back into a String, then free it.
@@ -1397,6 +1453,68 @@ mod tests {
             assert_eq!(v["tasks_sent"], 0);
             assert_eq!(v["tasks_received"], 0);
             assert_eq!(v["tasks_failed"], 0);
+        }
+    }
+
+    // ── lmao_build_task_envelope tests ────────────────────────────────────
+
+    #[test]
+    fn test_build_task_envelope_null_pointer() {
+        let v = unsafe { read_json_and_free(lmao_build_task_envelope(std::ptr::null())) };
+        assert_eq!(v["success"], false);
+        assert_eq!(v["error"], "null pointer");
+    }
+
+    #[test]
+    fn test_build_task_envelope_invalid_json() {
+        let input = CString::new("not json").unwrap();
+        let v = unsafe { read_json_and_free(lmao_build_task_envelope(input.as_ptr())) };
+        assert_eq!(v["success"], false);
+        assert!(v["error"].as_str().unwrap().contains("JSON parse error"));
+    }
+
+    #[test]
+    fn test_build_task_envelope_missing_agent_pubkey() {
+        let input = CString::new(r#"{"task_text": "hello"}"#).unwrap();
+        let v = unsafe { read_json_and_free(lmao_build_task_envelope(input.as_ptr())) };
+        assert_eq!(v["success"], false);
+        assert_eq!(v["error"], "missing 'agent_pubkey'");
+    }
+
+    #[test]
+    fn test_build_task_envelope_missing_task_text() {
+        let input = CString::new(r#"{"agent_pubkey": "02aabb"}"#).unwrap();
+        let v = unsafe { read_json_and_free(lmao_build_task_envelope(input.as_ptr())) };
+        assert_eq!(v["success"], false);
+        assert_eq!(v["error"], "missing 'task_text'");
+    }
+
+    #[test]
+    fn test_build_task_envelope_returns_envelope_fields() {
+        let input =
+            CString::new(r#"{"agent_pubkey": "02aabb", "task_text": "hello"}"#).unwrap();
+        let v = unsafe { read_json_and_free(lmao_build_task_envelope(input.as_ptr())) };
+        // This triggers node init — if it succeeds, check envelope fields
+        if v["success"] == true {
+            assert!(v["task_id"].is_string());
+            assert!(v["topic"].as_str().unwrap().contains("/waku-a2a/"));
+            assert!(v["payload_b64"].is_string());
+            assert_eq!(v["to"], "02aabb");
+
+            // Verify payload_b64 is valid base64 that decodes to a valid A2A envelope
+            let b64 = v["payload_b64"].as_str().unwrap();
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(b64)
+                .expect("payload_b64 should be valid base64");
+            let envelope: A2AEnvelope =
+                serde_json::from_slice(&decoded).expect("decoded payload should be valid A2AEnvelope");
+            match envelope {
+                A2AEnvelope::Task(t) => {
+                    assert_eq!(t.to, "02aabb");
+                    assert_eq!(t.text(), Some("hello"));
+                }
+                _ => panic!("expected A2AEnvelope::Task"),
+            }
         }
     }
 }

--- a/crates/lmao-ffi/src/lib.rs
+++ b/crates/lmao-ffi/src/lib.rs
@@ -7,6 +7,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::sync::OnceLock;
 
+use logos_messaging_a2a_core::topics;
 use logos_messaging_a2a_node::WakuA2ANode;
 use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
 use tokio::runtime::Runtime;
@@ -205,6 +206,37 @@ pub extern "C" fn lmao_free_string(s: *mut c_char) {
         unsafe {
             let _ = CString::from_raw(s);
         }
+    }
+}
+
+/// Get agent info: identity, topics, and encryption status.
+///
+/// Returns: { "success": true, "public_key": "02...", "task_topic": "...",
+///            "discovery_topic": "...", "presence_topic": "...", "encryption": false }
+#[no_mangle]
+pub extern "C" fn lmao_get_info() -> *mut c_char {
+    let node = get_or_init_node();
+    let pubkey = node.pubkey();
+    let encrypt = node.card.intro_bundle.is_some();
+    success_json(serde_json::json!({
+        "public_key": pubkey,
+        "task_topic": topics::task_topic(pubkey),
+        "discovery_topic": topics::DISCOVERY,
+        "presence_topic": topics::PRESENCE,
+        "encryption": encrypt,
+    }))
+}
+
+/// Get operational metrics counters.
+///
+/// Returns: { "success": true, "tasks_sent": 0, "tasks_received": 0, ... }
+#[no_mangle]
+pub extern "C" fn lmao_get_metrics() -> *mut c_char {
+    let node = get_or_init_node();
+    let snapshot = node.metrics();
+    match serde_json::to_value(&snapshot) {
+        Ok(v) => success_json(v),
+        Err(e) => error_json(&format!("metrics serialization error: {}", e)),
     }
 }
 
@@ -1241,6 +1273,88 @@ mod tests {
         }
         for ptr in ptrs {
             lmao_free_string(ptr);
+        }
+    }
+
+    // ── lmao_get_info tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_get_info_returns_valid_json() {
+        // get_info triggers node init; it may fail without a running Waku
+        // node, but should still return valid JSON with a "success" key.
+        let ptr = lmao_get_info();
+        assert!(!ptr.is_null());
+        let v = unsafe { read_json_and_free(ptr) };
+        assert!(v.is_object());
+        assert!(v.get("success").is_some());
+    }
+
+    #[test]
+    fn test_get_info_non_null() {
+        let ptr = lmao_get_info();
+        assert!(!ptr.is_null());
+        lmao_free_string(ptr);
+    }
+
+    #[test]
+    fn test_get_info_idempotent() {
+        let v1 = unsafe { read_json_and_free(lmao_get_info()) };
+        let v2 = unsafe { read_json_and_free(lmao_get_info()) };
+        // Both calls should return the same public key
+        if v1["success"] == true && v2["success"] == true {
+            assert_eq!(v1["public_key"], v2["public_key"]);
+        }
+    }
+
+    // ── lmao_get_metrics tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_get_metrics_returns_valid_json() {
+        let ptr = lmao_get_metrics();
+        assert!(!ptr.is_null());
+        let v = unsafe { read_json_and_free(ptr) };
+        assert!(v.is_object());
+        assert!(v.get("success").is_some());
+    }
+
+    #[test]
+    fn test_get_metrics_non_null() {
+        let ptr = lmao_get_metrics();
+        assert!(!ptr.is_null());
+        lmao_free_string(ptr);
+    }
+
+    #[test]
+    fn test_get_metrics_has_counter_fields() {
+        let v = unsafe { read_json_and_free(lmao_get_metrics()) };
+        if v["success"] == true {
+            // All 17 counter fields should be present
+            let expected_fields = [
+                "tasks_sent", "tasks_received", "tasks_failed",
+                "messages_published", "messages_received",
+                "discoveries", "announcements_sent", "peers_discovered",
+                "encryptions", "decryptions", "sessions_created",
+                "delegations_sent", "stream_chunks_sent", "stream_chunks_received",
+                "retry_attempts", "retries_exhausted", "responses_sent",
+            ];
+            for field in &expected_fields {
+                assert!(
+                    v.get(*field).is_some(),
+                    "metrics missing field: {}",
+                    field
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_metrics_counters_start_at_zero() {
+        let v = unsafe { read_json_and_free(lmao_get_metrics()) };
+        if v["success"] == true {
+            // On a fresh node with no activity, all counters should be 0
+            assert_eq!(v["tasks_sent"], 0);
+            assert_eq!(v["tasks_received"], 0);
+            assert_eq!(v["tasks_failed"], 0);
         }
     }
 }

--- a/crates/logos-messaging-a2a-core/src/envelope.rs
+++ b/crates/logos-messaging-a2a-core/src/envelope.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent::AgentCard;
 use crate::presence::PresenceAnnouncement;
+use crate::skill::SkillAnnouncement;
 use crate::task::{Task, TaskStreamChunk};
 
 /// Wire envelope for all messages on Waku topics.
@@ -32,6 +33,8 @@ pub enum A2AEnvelope {
     Presence(PresenceAnnouncement),
     /// A streaming chunk carrying incremental task output (e.g. LLM tokens).
     StreamChunk(TaskStreamChunk),
+    /// A skill announcement for the decentralized skill marketplace.
+    SkillAnnouncement(SkillAnnouncement),
 }
 
 #[cfg(test)]
@@ -296,6 +299,18 @@ mod tests {
                 chunk_index: 0,
                 text: "x".into(),
                 is_final: false,
+            }),
+            A2AEnvelope::SkillAnnouncement(SkillAnnouncement {
+                skill: crate::skill::SkillDescriptor {
+                    skill_id: "s".into(),
+                    content_hash: "h".into(),
+                    author_pubkey: "a".into(),
+                    version: "1.0.0".into(),
+                    description: "d".into(),
+                    tags: vec![],
+                    timestamp: 0,
+                },
+                is_update: false,
             }),
         ];
         let mut type_tags: Vec<String> = Vec::new();

--- a/crates/logos-messaging-a2a-core/src/lib.rs
+++ b/crates/logos-messaging-a2a-core/src/lib.rs
@@ -27,6 +27,10 @@ pub mod presence;
 pub mod registry;
 /// Exponential-backoff retry configuration.
 pub mod retry;
+/// Skill marketplace types for decentralized skill sharing.
+pub mod skill;
+/// Skill registry trait for on-chain skill registration and rating.
+pub mod skill_registry;
 /// Task lifecycle types and message parts.
 pub mod task;
 pub mod topics;

--- a/crates/logos-messaging-a2a-core/src/skill.rs
+++ b/crates/logos-messaging-a2a-core/src/skill.rs
@@ -1,0 +1,155 @@
+//! Skill marketplace types for the decentralized skill sharing system.
+//!
+//! Agents publish skill bundles to Logos Storage, register them in a LEZ
+//! program, discover them via Messaging, rate them on-chain, and
+//! automatically adopt highly-ranked skills from trusted peers.
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata describing a published skill bundle.
+///
+/// A skill is identified by its `skill_id` (unique name) and pinned to a
+/// specific `content_hash` (Logos Storage / Codex CID) for immutable,
+/// verifiable retrieval.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillDescriptor {
+    /// Unique identifier for this skill (e.g. `"summarize-long-docs"`).
+    pub skill_id: String,
+    /// Content hash (CID) of the skill bundle in Logos Storage.
+    pub content_hash: String,
+    /// secp256k1 compressed public key of the skill author.
+    pub author_pubkey: String,
+    /// Semantic version of this skill (e.g. `"1.0.0"`).
+    pub version: String,
+    /// Human-readable description of what this skill does.
+    pub description: String,
+    /// Searchable tags (e.g. `["nlp", "summarization"]`).
+    pub tags: Vec<String>,
+    /// Unix timestamp (seconds) when this version was published.
+    pub timestamp: u64,
+}
+
+/// A rating submitted by an agent for a skill.
+///
+/// Ratings are public and on-chain. Each agent can rate a skill once
+/// (latest rating wins). A small stake prevents spam.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillRating {
+    /// The skill being rated.
+    pub skill_id: String,
+    /// Public key of the agent submitting this rating.
+    pub rater_pubkey: String,
+    /// Rating score from 1 (poor) to 5 (excellent).
+    pub score: u8,
+    /// Optional freeform comment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    /// Unix timestamp (seconds) of this rating.
+    pub timestamp: u64,
+}
+
+/// Announcement broadcast on the skill discovery topic when a skill is
+/// published or updated.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillAnnouncement {
+    /// The skill descriptor being announced.
+    pub skill: SkillDescriptor,
+    /// Whether this is a new skill or an update to an existing one.
+    pub is_update: bool,
+}
+
+impl SkillRating {
+    /// Validate that the score is in the allowed range (1..=5).
+    pub fn is_valid(&self) -> bool {
+        (1..=5).contains(&self.score)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_descriptor() -> SkillDescriptor {
+        SkillDescriptor {
+            skill_id: "summarize-docs".into(),
+            content_hash: "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi".into(),
+            author_pubkey: "02abcdef1234567890".into(),
+            version: "1.0.0".into(),
+            description: "Summarizes long documents".into(),
+            tags: vec!["nlp".into(), "summarization".into()],
+            timestamp: 1713360000,
+        }
+    }
+
+    #[test]
+    fn skill_descriptor_serialization_roundtrip() {
+        let desc = sample_descriptor();
+        let json = serde_json::to_string(&desc).unwrap();
+        let deserialized: SkillDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(desc, deserialized);
+    }
+
+    #[test]
+    fn skill_rating_valid_scores() {
+        for score in 1..=5 {
+            let rating = SkillRating {
+                skill_id: "test".into(),
+                rater_pubkey: "02ab".into(),
+                score,
+                comment: None,
+                timestamp: 0,
+            };
+            assert!(rating.is_valid());
+        }
+    }
+
+    #[test]
+    fn skill_rating_invalid_scores() {
+        for score in [0, 6, 255] {
+            let rating = SkillRating {
+                skill_id: "test".into(),
+                rater_pubkey: "02ab".into(),
+                score,
+                comment: None,
+                timestamp: 0,
+            };
+            assert!(!rating.is_valid());
+        }
+    }
+
+    #[test]
+    fn skill_rating_comment_skipped_when_none() {
+        let rating = SkillRating {
+            skill_id: "test".into(),
+            rater_pubkey: "02ab".into(),
+            score: 4,
+            comment: None,
+            timestamp: 100,
+        };
+        let json = serde_json::to_string(&rating).unwrap();
+        assert!(!json.contains("comment"));
+    }
+
+    #[test]
+    fn skill_announcement_serialization() {
+        let ann = SkillAnnouncement {
+            skill: sample_descriptor(),
+            is_update: false,
+        };
+        let json = serde_json::to_string(&ann).unwrap();
+        let deserialized: SkillAnnouncement = serde_json::from_str(&json).unwrap();
+        assert_eq!(ann, deserialized);
+        assert!(!deserialized.is_update);
+    }
+
+    #[test]
+    fn skill_announcement_update() {
+        let ann = SkillAnnouncement {
+            skill: sample_descriptor(),
+            is_update: true,
+        };
+        let json = serde_json::to_string(&ann).unwrap();
+        let deserialized: SkillAnnouncement = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_update);
+    }
+}

--- a/crates/logos-messaging-a2a-core/src/skill_registry.rs
+++ b/crates/logos-messaging-a2a-core/src/skill_registry.rs
@@ -1,0 +1,398 @@
+//! Skill registry trait for on-chain skill registration and rating.
+//!
+//! The [`SkillRegistry`] trait defines a persistent store for skill
+//! descriptors and ratings. The primary implementation target is a LEZ
+//! program, but any persistent store can implement this trait.
+
+use crate::skill::{SkillDescriptor, SkillRating};
+use std::fmt;
+
+/// Errors returned by skill registry operations.
+#[derive(Debug)]
+pub enum SkillRegistryError {
+    /// Skill with this ID is not registered.
+    NotFound(String),
+    /// Only the original author can update a skill.
+    Unauthorized(String),
+    /// Skill with this ID and version is already registered.
+    AlreadyRegistered(String),
+    /// Rating validation failed (e.g. score out of range).
+    InvalidRating(String),
+    /// Network or backend failure.
+    Backend(String),
+}
+
+impl fmt::Display for SkillRegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(id) => write!(f, "skill not found: {}", id),
+            Self::Unauthorized(msg) => write!(f, "unauthorized: {}", msg),
+            Self::AlreadyRegistered(id) => write!(f, "skill already registered: {}", id),
+            Self::InvalidRating(msg) => write!(f, "invalid rating: {}", msg),
+            Self::Backend(msg) => write!(f, "skill registry backend error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for SkillRegistryError {}
+
+/// Persistent skill registry for on-chain or off-chain skill management.
+#[async_trait::async_trait]
+pub trait SkillRegistry: Send + Sync {
+    /// Register a new skill. Returns error if already registered.
+    async fn register(&self, skill: SkillDescriptor) -> Result<(), SkillRegistryError>;
+
+    /// Update an existing skill (new version). Only the original author may update.
+    async fn update(&self, skill: SkillDescriptor) -> Result<(), SkillRegistryError>;
+
+    /// Remove a skill from the registry.
+    async fn deregister(&self, skill_id: &str) -> Result<(), SkillRegistryError>;
+
+    /// Look up a skill by ID.
+    async fn get(&self, skill_id: &str) -> Result<SkillDescriptor, SkillRegistryError>;
+
+    /// List all registered skills.
+    async fn list(&self) -> Result<Vec<SkillDescriptor>, SkillRegistryError>;
+
+    /// Search skills by tag.
+    async fn find_by_tag(&self, tag: &str) -> Result<Vec<SkillDescriptor>, SkillRegistryError>;
+
+    /// Submit a rating for a skill. One rating per (skill_id, rater_pubkey) —
+    /// latest wins.
+    async fn rate(&self, rating: SkillRating) -> Result<(), SkillRegistryError>;
+
+    /// Get all ratings for a skill.
+    async fn get_ratings(
+        &self,
+        skill_id: &str,
+    ) -> Result<Vec<SkillRating>, SkillRegistryError>;
+}
+
+/// In-memory skill registry for testing and local development.
+pub struct InMemorySkillRegistry {
+    skills: std::sync::RwLock<std::collections::HashMap<String, SkillDescriptor>>,
+    /// Ratings keyed by (skill_id, rater_pubkey).
+    ratings: std::sync::RwLock<std::collections::HashMap<(String, String), SkillRating>>,
+}
+
+impl InMemorySkillRegistry {
+    pub fn new() -> Self {
+        Self {
+            skills: std::sync::RwLock::new(std::collections::HashMap::new()),
+            ratings: std::sync::RwLock::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemorySkillRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl SkillRegistry for InMemorySkillRegistry {
+    async fn register(&self, skill: SkillDescriptor) -> Result<(), SkillRegistryError> {
+        let mut skills = self.skills.write().unwrap();
+        if skills.contains_key(&skill.skill_id) {
+            return Err(SkillRegistryError::AlreadyRegistered(skill.skill_id));
+        }
+        skills.insert(skill.skill_id.clone(), skill);
+        Ok(())
+    }
+
+    async fn update(&self, skill: SkillDescriptor) -> Result<(), SkillRegistryError> {
+        let mut skills = self.skills.write().unwrap();
+        match skills.get(&skill.skill_id) {
+            None => return Err(SkillRegistryError::NotFound(skill.skill_id)),
+            Some(existing) if existing.author_pubkey != skill.author_pubkey => {
+                return Err(SkillRegistryError::Unauthorized(
+                    "only the original author can update".into(),
+                ));
+            }
+            _ => {}
+        }
+        skills.insert(skill.skill_id.clone(), skill);
+        Ok(())
+    }
+
+    async fn deregister(&self, skill_id: &str) -> Result<(), SkillRegistryError> {
+        let mut skills = self.skills.write().unwrap();
+        skills
+            .remove(skill_id)
+            .ok_or_else(|| SkillRegistryError::NotFound(skill_id.to_string()))?;
+        Ok(())
+    }
+
+    async fn get(&self, skill_id: &str) -> Result<SkillDescriptor, SkillRegistryError> {
+        let skills = self.skills.read().unwrap();
+        skills
+            .get(skill_id)
+            .cloned()
+            .ok_or_else(|| SkillRegistryError::NotFound(skill_id.to_string()))
+    }
+
+    async fn list(&self) -> Result<Vec<SkillDescriptor>, SkillRegistryError> {
+        let skills = self.skills.read().unwrap();
+        Ok(skills.values().cloned().collect())
+    }
+
+    async fn find_by_tag(&self, tag: &str) -> Result<Vec<SkillDescriptor>, SkillRegistryError> {
+        let skills = self.skills.read().unwrap();
+        Ok(skills
+            .values()
+            .filter(|s| s.tags.iter().any(|t| t == tag))
+            .cloned()
+            .collect())
+    }
+
+    async fn rate(&self, rating: SkillRating) -> Result<(), SkillRegistryError> {
+        if !rating.is_valid() {
+            return Err(SkillRegistryError::InvalidRating(format!(
+                "score {} out of range 1..=5",
+                rating.score
+            )));
+        }
+        // Skill must exist.
+        {
+            let skills = self.skills.read().unwrap();
+            if !skills.contains_key(&rating.skill_id) {
+                return Err(SkillRegistryError::NotFound(rating.skill_id.clone()));
+            }
+        }
+        let key = (rating.skill_id.clone(), rating.rater_pubkey.clone());
+        let mut ratings = self.ratings.write().unwrap();
+        ratings.insert(key, rating);
+        Ok(())
+    }
+
+    async fn get_ratings(
+        &self,
+        skill_id: &str,
+    ) -> Result<Vec<SkillRating>, SkillRegistryError> {
+        let ratings = self.ratings.read().unwrap();
+        Ok(ratings
+            .values()
+            .filter(|r| r.skill_id == skill_id)
+            .cloned()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_skill(id: &str, author: &str) -> SkillDescriptor {
+        SkillDescriptor {
+            skill_id: id.into(),
+            content_hash: "bafytest".into(),
+            author_pubkey: author.into(),
+            version: "1.0.0".into(),
+            description: format!("{} skill", id),
+            tags: vec!["test".into()],
+            timestamp: 1000,
+        }
+    }
+
+    #[tokio::test]
+    async fn register_and_get() {
+        let reg = InMemorySkillRegistry::new();
+        let skill = sample_skill("sum", "02aa");
+        reg.register(skill.clone()).await.unwrap();
+        let got = reg.get("sum").await.unwrap();
+        assert_eq!(got, skill);
+    }
+
+    #[tokio::test]
+    async fn register_duplicate_fails() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("sum", "02aa")).await.unwrap();
+        let err = reg.register(sample_skill("sum", "02aa")).await.unwrap_err();
+        assert!(matches!(err, SkillRegistryError::AlreadyRegistered(_)));
+    }
+
+    #[tokio::test]
+    async fn update_by_author_succeeds() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("sum", "02aa")).await.unwrap();
+        let mut updated = sample_skill("sum", "02aa");
+        updated.version = "2.0.0".into();
+        reg.update(updated).await.unwrap();
+        let got = reg.get("sum").await.unwrap();
+        assert_eq!(got.version, "2.0.0");
+    }
+
+    #[tokio::test]
+    async fn update_by_different_author_fails() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("sum", "02aa")).await.unwrap();
+        let err = reg
+            .update(sample_skill("sum", "02bb"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SkillRegistryError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn update_nonexistent_fails() {
+        let reg = InMemorySkillRegistry::new();
+        let err = reg
+            .update(sample_skill("ghost", "02aa"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SkillRegistryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn deregister_removes() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("sum", "02aa")).await.unwrap();
+        reg.deregister("sum").await.unwrap();
+        assert!(reg.get("sum").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn find_by_tag() {
+        let reg = InMemorySkillRegistry::new();
+        let mut s1 = sample_skill("a", "02aa");
+        s1.tags = vec!["nlp".into()];
+        let mut s2 = sample_skill("b", "02bb");
+        s2.tags = vec!["code".into()];
+        let mut s3 = sample_skill("c", "02cc");
+        s3.tags = vec!["nlp".into(), "code".into()];
+        reg.register(s1).await.unwrap();
+        reg.register(s2).await.unwrap();
+        reg.register(s3).await.unwrap();
+
+        let nlp = reg.find_by_tag("nlp").await.unwrap();
+        assert_eq!(nlp.len(), 2);
+        let code = reg.find_by_tag("code").await.unwrap();
+        assert_eq!(code.len(), 2);
+        let none = reg.find_by_tag("missing").await.unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rate_and_get_ratings() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("sum", "02aa")).await.unwrap();
+
+        let r1 = SkillRating {
+            skill_id: "sum".into(),
+            rater_pubkey: "02bb".into(),
+            score: 5,
+            comment: Some("great".into()),
+            timestamp: 2000,
+        };
+        let r2 = SkillRating {
+            skill_id: "sum".into(),
+            rater_pubkey: "02cc".into(),
+            score: 3,
+            comment: None,
+            timestamp: 2001,
+        };
+        reg.rate(r1).await.unwrap();
+        reg.rate(r2).await.unwrap();
+
+        let ratings = reg.get_ratings("sum").await.unwrap();
+        assert_eq!(ratings.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rate_replaces_previous() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("sum", "02aa")).await.unwrap();
+
+        let r1 = SkillRating {
+            skill_id: "sum".into(),
+            rater_pubkey: "02bb".into(),
+            score: 2,
+            comment: None,
+            timestamp: 1000,
+        };
+        let r2 = SkillRating {
+            skill_id: "sum".into(),
+            rater_pubkey: "02bb".into(),
+            score: 5,
+            comment: None,
+            timestamp: 2000,
+        };
+        reg.rate(r1).await.unwrap();
+        reg.rate(r2).await.unwrap();
+
+        let ratings = reg.get_ratings("sum").await.unwrap();
+        assert_eq!(ratings.len(), 1);
+        assert_eq!(ratings[0].score, 5);
+    }
+
+    #[tokio::test]
+    async fn rate_invalid_score_fails() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("sum", "02aa")).await.unwrap();
+
+        let bad = SkillRating {
+            skill_id: "sum".into(),
+            rater_pubkey: "02bb".into(),
+            score: 0,
+            comment: None,
+            timestamp: 1000,
+        };
+        let err = reg.rate(bad).await.unwrap_err();
+        assert!(matches!(err, SkillRegistryError::InvalidRating(_)));
+    }
+
+    #[tokio::test]
+    async fn rate_nonexistent_skill_fails() {
+        let reg = InMemorySkillRegistry::new();
+        let bad = SkillRating {
+            skill_id: "ghost".into(),
+            rater_pubkey: "02bb".into(),
+            score: 3,
+            comment: None,
+            timestamp: 1000,
+        };
+        let err = reg.rate(bad).await.unwrap_err();
+        assert!(matches!(err, SkillRegistryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn list_skills() {
+        let reg = InMemorySkillRegistry::new();
+        reg.register(sample_skill("a", "02aa")).await.unwrap();
+        reg.register(sample_skill("b", "02bb")).await.unwrap();
+        let all = reg.list().await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn error_display() {
+        assert_eq!(
+            SkillRegistryError::NotFound("x".into()).to_string(),
+            "skill not found: x"
+        );
+        assert_eq!(
+            SkillRegistryError::Unauthorized("u".into()).to_string(),
+            "unauthorized: u"
+        );
+        assert_eq!(
+            SkillRegistryError::AlreadyRegistered("a".into()).to_string(),
+            "skill already registered: a"
+        );
+        assert_eq!(
+            SkillRegistryError::InvalidRating("bad".into()).to_string(),
+            "invalid rating: bad"
+        );
+        assert_eq!(
+            SkillRegistryError::Backend("err".into()).to_string(),
+            "skill registry backend error: err"
+        );
+    }
+
+    #[test]
+    fn default_creates_empty() {
+        let reg = InMemorySkillRegistry::default();
+        let skills = reg.skills.read().unwrap();
+        assert!(skills.is_empty());
+    }
+}

--- a/crates/logos-messaging-a2a-core/src/topics.rs
+++ b/crates/logos-messaging-a2a-core/src/topics.rs
@@ -8,6 +8,10 @@ pub const DISCOVERY: &str = "/waku-a2a/1/discovery/proto";
 /// All agents subscribe on startup to discover live peers.
 pub const PRESENCE: &str = "/lmao/1/presence/proto";
 
+/// Well-known topic for skill marketplace announcements.
+/// Agents subscribe here to discover new and updated skills.
+pub const SKILLS: &str = "/lmao/1/skills/proto";
+
 /// Returns the Waku content topic where a specific agent receives tasks.
 ///
 /// Each agent listens on a topic derived from its compressed secp256k1
@@ -44,6 +48,11 @@ mod tests {
     #[test]
     fn test_presence_topic() {
         assert_eq!(PRESENCE, "/lmao/1/presence/proto");
+    }
+
+    #[test]
+    fn test_skills_topic() {
+        assert_eq!(SKILLS, "/lmao/1/skills/proto");
     }
 
     #[test]

--- a/crates/logos-messaging-a2a-node/src/lib.rs
+++ b/crates/logos-messaging-a2a-node/src/lib.rs
@@ -14,6 +14,8 @@ pub mod payment;
 pub mod presence;
 pub mod retry;
 pub mod session;
+/// Decentralized skill marketplace — publish, discover, rank, auto-adopt.
+pub mod skills;
 pub mod storage;
 mod streaming;
 mod tasks;

--- a/crates/logos-messaging-a2a-node/src/skills.rs
+++ b/crates/logos-messaging-a2a-node/src/skills.rs
@@ -1,0 +1,449 @@
+//! Decentralized skill marketplace — publish, discover, rank, auto-adopt.
+//!
+//! This module adds skill marketplace capabilities to [`WakuA2ANode`]:
+//!
+//! - **Publish**: upload a skill bundle to Logos Storage and announce it.
+//! - **Discover**: subscribe to skill announcements and query the registry.
+//! - **Rank**: compute subjective skill rankings using a per-agent trust set.
+//! - **Auto-adopt**: monitor rankings and adopt skills that cross a threshold.
+
+use logos_messaging_a2a_core::skill::{SkillAnnouncement, SkillDescriptor, SkillRating};
+use logos_messaging_a2a_core::skill_registry::SkillRegistry;
+use logos_messaging_a2a_core::{topics, A2AEnvelope};
+use logos_messaging_a2a_transport::Transport;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use crate::metrics::Metrics;
+use crate::{NodeError, Result, WakuA2ANode};
+
+/// Configuration for the skill marketplace on a node.
+pub struct SkillMarketplaceConfig {
+    /// Minimum effective rank (1.0–5.0) for auto-adoption.
+    pub auto_adopt_threshold: f64,
+    /// Whether transitive trust is enabled ("trust friends of friends").
+    pub transitive_trust: bool,
+    /// Decay weight for transitive trust (0.0–1.0). Applied multiplicatively
+    /// for each hop.
+    pub transitive_decay: f64,
+}
+
+impl Default for SkillMarketplaceConfig {
+    fn default() -> Self {
+        Self {
+            auto_adopt_threshold: 4.0,
+            transitive_trust: false,
+            transitive_decay: 0.5,
+        }
+    }
+}
+
+/// Per-agent skill marketplace state.
+///
+/// Tracks the trust set, known skills, and locally installed skills.
+/// Ranking is subjective — each agent computes its own effective rank
+/// based only on ratings from trusted peers.
+pub struct SkillMarketplace {
+    /// Agent pubkeys whose ratings this agent trusts.
+    trust_set: std::sync::RwLock<HashSet<String>>,
+    /// Known skill descriptors, keyed by skill_id.
+    known_skills: std::sync::RwLock<HashMap<String, SkillDescriptor>>,
+    /// Locally installed skill IDs.
+    installed_skills: std::sync::RwLock<HashSet<String>>,
+    /// Cached ratings keyed by skill_id.
+    cached_ratings: std::sync::RwLock<HashMap<String, Vec<SkillRating>>>,
+    /// Optional skill registry (LEZ on-chain).
+    registry: Option<Arc<dyn SkillRegistry>>,
+    /// Marketplace configuration.
+    pub config: SkillMarketplaceConfig,
+}
+
+impl SkillMarketplace {
+    /// Create a new skill marketplace with default configuration.
+    pub fn new() -> Self {
+        Self {
+            trust_set: std::sync::RwLock::new(HashSet::new()),
+            known_skills: std::sync::RwLock::new(HashMap::new()),
+            installed_skills: std::sync::RwLock::new(HashSet::new()),
+            cached_ratings: std::sync::RwLock::new(HashMap::new()),
+            registry: None,
+            config: SkillMarketplaceConfig::default(),
+        }
+    }
+
+    /// Create with a skill registry backend.
+    pub fn with_registry(mut self, registry: Arc<dyn SkillRegistry>) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// Create with custom configuration.
+    pub fn with_config(mut self, config: SkillMarketplaceConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    // ── Trust set management ───────────────────────────────────────
+
+    /// Add an agent to the trust set.
+    pub fn trust(&self, pubkey: &str) {
+        self.trust_set.write().unwrap().insert(pubkey.to_string());
+    }
+
+    /// Remove an agent from the trust set.
+    pub fn untrust(&self, pubkey: &str) {
+        self.trust_set.write().unwrap().remove(pubkey);
+    }
+
+    /// Check if an agent is trusted.
+    pub fn is_trusted(&self, pubkey: &str) -> bool {
+        self.trust_set.read().unwrap().contains(pubkey)
+    }
+
+    /// Get the current trust set.
+    pub fn trust_set(&self) -> HashSet<String> {
+        self.trust_set.read().unwrap().clone()
+    }
+
+    // ── Skill tracking ─────────────────────────────────────────────
+
+    /// Record a discovered skill.
+    pub fn track_skill(&self, skill: SkillDescriptor) {
+        self.known_skills
+            .write()
+            .unwrap()
+            .insert(skill.skill_id.clone(), skill);
+    }
+
+    /// Get a known skill by ID.
+    pub fn get_skill(&self, skill_id: &str) -> Option<SkillDescriptor> {
+        self.known_skills.read().unwrap().get(skill_id).cloned()
+    }
+
+    /// List all known skills.
+    pub fn known_skills(&self) -> Vec<SkillDescriptor> {
+        self.known_skills.read().unwrap().values().cloned().collect()
+    }
+
+    /// Mark a skill as locally installed.
+    pub fn mark_installed(&self, skill_id: &str) {
+        self.installed_skills
+            .write()
+            .unwrap()
+            .insert(skill_id.to_string());
+    }
+
+    /// Check if a skill is installed.
+    pub fn is_installed(&self, skill_id: &str) -> bool {
+        self.installed_skills.read().unwrap().contains(skill_id)
+    }
+
+    // ── Rating & ranking ───────────────────────────────────────────
+
+    /// Cache ratings for a skill.
+    pub fn cache_ratings(&self, skill_id: &str, ratings: Vec<SkillRating>) {
+        self.cached_ratings
+            .write()
+            .unwrap()
+            .insert(skill_id.to_string(), ratings);
+    }
+
+    /// Compute the effective rank of a skill using only trusted ratings.
+    ///
+    /// Returns `None` if no trusted ratings exist.
+    pub fn effective_rank(&self, skill_id: &str) -> Option<f64> {
+        let ratings = self.cached_ratings.read().unwrap();
+        let trust = self.trust_set.read().unwrap();
+
+        let trusted_ratings: Vec<&SkillRating> = ratings
+            .get(skill_id)
+            .map(|rs| {
+                rs.iter()
+                    .filter(|r| trust.contains(&r.rater_pubkey))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if trusted_ratings.is_empty() {
+            return None;
+        }
+
+        let sum: f64 = trusted_ratings.iter().map(|r| r.score as f64).sum();
+        Some(sum / trusted_ratings.len() as f64)
+    }
+
+    /// Return skill IDs whose effective rank meets or exceeds the
+    /// auto-adopt threshold and are not yet installed.
+    pub fn adoption_candidates(&self) -> Vec<String> {
+        let known = self.known_skills.read().unwrap();
+        let installed = self.installed_skills.read().unwrap();
+        let threshold = self.config.auto_adopt_threshold;
+
+        known
+            .keys()
+            .filter(|id| !installed.contains(id.as_str()))
+            .filter(|id| {
+                self.effective_rank(id)
+                    .map(|r| r >= threshold)
+                    .unwrap_or(false)
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Access the optional skill registry.
+    pub fn registry(&self) -> Option<&Arc<dyn SkillRegistry>> {
+        self.registry.as_ref()
+    }
+}
+
+impl Default for SkillMarketplace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Node integration ───────────────────────────────────────────────
+
+impl<T: Transport> WakuA2ANode<T> {
+    /// Publish a skill announcement on the skills topic.
+    ///
+    /// Broadcasts the skill descriptor so subscribed agents can discover it.
+    pub async fn announce_skill(&self, skill: SkillDescriptor, is_update: bool) -> Result<()> {
+        let announcement = SkillAnnouncement { skill, is_update };
+        let envelope = A2AEnvelope::SkillAnnouncement(announcement);
+        let payload = serde_json::to_vec(&envelope)?;
+        self.channel
+            .transport()
+            .publish(topics::SKILLS, &payload)
+            .await?;
+        Metrics::inc(&self.metrics.messages_published);
+        tracing::info!(pubkey = %self.pubkey(), "Skill announced");
+        Ok(())
+    }
+
+    /// Discover skills by subscribing to the skills topic and draining messages.
+    ///
+    /// Returns all skill announcements received since the last call.
+    pub async fn discover_skills(&self) -> Result<Vec<SkillAnnouncement>> {
+        let mut rx = self
+            .channel
+            .transport()
+            .subscribe(topics::SKILLS)
+            .await?;
+
+        let mut announcements = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let Ok(A2AEnvelope::SkillAnnouncement(ann)) = serde_json::from_slice(&msg) {
+                announcements.push(ann);
+            }
+        }
+
+        let _ = self
+            .channel
+            .transport()
+            .unsubscribe(topics::SKILLS)
+            .await;
+        Ok(announcements)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logos_messaging_a2a_core::skill::{SkillDescriptor, SkillRating};
+    use logos_messaging_a2a_core::skill_registry::InMemorySkillRegistry;
+
+    fn sample_skill(id: &str) -> SkillDescriptor {
+        SkillDescriptor {
+            skill_id: id.into(),
+            content_hash: "bafytest".into(),
+            author_pubkey: "02author".into(),
+            version: "1.0.0".into(),
+            description: format!("{} skill", id),
+            tags: vec!["test".into()],
+            timestamp: 1000,
+        }
+    }
+
+    fn rating(skill_id: &str, rater: &str, score: u8) -> SkillRating {
+        SkillRating {
+            skill_id: skill_id.into(),
+            rater_pubkey: rater.into(),
+            score,
+            comment: None,
+            timestamp: 2000,
+        }
+    }
+
+    #[test]
+    fn trust_set_management() {
+        let mp = SkillMarketplace::new();
+        assert!(!mp.is_trusted("02aa"));
+        mp.trust("02aa");
+        assert!(mp.is_trusted("02aa"));
+        mp.untrust("02aa");
+        assert!(!mp.is_trusted("02aa"));
+    }
+
+    #[test]
+    fn track_and_get_skill() {
+        let mp = SkillMarketplace::new();
+        let skill = sample_skill("sum");
+        mp.track_skill(skill.clone());
+        assert_eq!(mp.get_skill("sum"), Some(skill));
+        assert_eq!(mp.get_skill("missing"), None);
+    }
+
+    #[test]
+    fn known_skills_lists_all() {
+        let mp = SkillMarketplace::new();
+        mp.track_skill(sample_skill("a"));
+        mp.track_skill(sample_skill("b"));
+        assert_eq!(mp.known_skills().len(), 2);
+    }
+
+    #[test]
+    fn installed_tracking() {
+        let mp = SkillMarketplace::new();
+        assert!(!mp.is_installed("sum"));
+        mp.mark_installed("sum");
+        assert!(mp.is_installed("sum"));
+    }
+
+    #[test]
+    fn effective_rank_no_ratings() {
+        let mp = SkillMarketplace::new();
+        assert_eq!(mp.effective_rank("sum"), None);
+    }
+
+    #[test]
+    fn effective_rank_no_trusted_ratings() {
+        let mp = SkillMarketplace::new();
+        mp.cache_ratings("sum", vec![rating("sum", "02aa", 5)]);
+        // 02aa is not in trust set
+        assert_eq!(mp.effective_rank("sum"), None);
+    }
+
+    #[test]
+    fn effective_rank_with_trusted_ratings() {
+        let mp = SkillMarketplace::new();
+        mp.trust("02aa");
+        mp.trust("02bb");
+        mp.cache_ratings(
+            "sum",
+            vec![
+                rating("sum", "02aa", 5),
+                rating("sum", "02bb", 3),
+                rating("sum", "02cc", 1), // untrusted, ignored
+            ],
+        );
+        let rank = mp.effective_rank("sum").unwrap();
+        assert!((rank - 4.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn adoption_candidates_above_threshold() {
+        let mp = SkillMarketplace::new();
+        mp.trust("02aa");
+        mp.track_skill(sample_skill("good"));
+        mp.track_skill(sample_skill("bad"));
+        mp.track_skill(sample_skill("installed"));
+
+        mp.cache_ratings("good", vec![rating("good", "02aa", 5)]);
+        mp.cache_ratings("bad", vec![rating("bad", "02aa", 2)]);
+        mp.cache_ratings("installed", vec![rating("installed", "02aa", 5)]);
+        mp.mark_installed("installed");
+
+        let candidates = mp.adoption_candidates();
+        assert_eq!(candidates, vec!["good".to_string()]);
+    }
+
+    #[test]
+    fn adoption_candidates_empty_when_all_installed() {
+        let mp = SkillMarketplace::new();
+        mp.trust("02aa");
+        mp.track_skill(sample_skill("sum"));
+        mp.cache_ratings("sum", vec![rating("sum", "02aa", 5)]);
+        mp.mark_installed("sum");
+
+        assert!(mp.adoption_candidates().is_empty());
+    }
+
+    #[test]
+    fn default_config() {
+        let config = SkillMarketplaceConfig::default();
+        assert!((config.auto_adopt_threshold - 4.0).abs() < f64::EPSILON);
+        assert!(!config.transitive_trust);
+        assert!((config.transitive_decay - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn with_registry() {
+        let registry = Arc::new(InMemorySkillRegistry::new());
+        let mp = SkillMarketplace::new().with_registry(registry);
+        assert!(mp.registry().is_some());
+    }
+
+    #[test]
+    fn with_config() {
+        let config = SkillMarketplaceConfig {
+            auto_adopt_threshold: 3.0,
+            transitive_trust: true,
+            transitive_decay: 0.8,
+        };
+        let mp = SkillMarketplace::new().with_config(config);
+        assert!((mp.config.auto_adopt_threshold - 3.0).abs() < f64::EPSILON);
+        assert!(mp.config.transitive_trust);
+    }
+
+    #[tokio::test]
+    async fn announce_and_discover_skills() {
+        use logos_messaging_a2a_transport::memory::InMemoryTransport;
+
+        let transport = InMemoryTransport::new();
+        let node_a = WakuA2ANode::new("a", "agent a", vec![], transport.clone());
+        let node_b = WakuA2ANode::new("b", "agent b", vec![], transport.clone());
+
+        // B subscribes first, then A announces
+        let mut rx = transport.subscribe(topics::SKILLS).await.unwrap();
+        let skill = sample_skill("test-skill");
+        node_a.announce_skill(skill.clone(), false).await.unwrap();
+
+        // Verify the message was published
+        let msg = rx.try_recv().unwrap();
+        let envelope: A2AEnvelope = serde_json::from_slice(&msg).unwrap();
+        if let A2AEnvelope::SkillAnnouncement(ann) = envelope {
+            assert_eq!(ann.skill.skill_id, "test-skill");
+            assert!(!ann.is_update);
+        } else {
+            panic!("expected SkillAnnouncement envelope");
+        }
+    }
+
+    #[test]
+    fn trust_set_returns_clone() {
+        let mp = SkillMarketplace::new();
+        mp.trust("02aa");
+        mp.trust("02bb");
+        let set = mp.trust_set();
+        assert_eq!(set.len(), 2);
+        assert!(set.contains("02aa"));
+        assert!(set.contains("02bb"));
+    }
+
+    #[test]
+    fn track_skill_overwrites_on_same_id() {
+        let mp = SkillMarketplace::new();
+        let mut s1 = sample_skill("sum");
+        s1.version = "1.0.0".into();
+        mp.track_skill(s1);
+
+        let mut s2 = sample_skill("sum");
+        s2.version = "2.0.0".into();
+        mp.track_skill(s2);
+
+        assert_eq!(mp.get_skill("sum").unwrap().version, "2.0.0");
+        assert_eq!(mp.known_skills().len(), 1);
+    }
+}

--- a/crates/logos-messaging-a2a-storage/Cargo.toml
+++ b/crates/logos-messaging-a2a-storage/Cargo.toml
@@ -9,6 +9,7 @@ default = ["rest"]
 rest = ["reqwest"]
 logos-core = ["base64"]
 libstorage = ["dep:storage-bindings", "dep:tempfile"]
+storage-module = ["dep:storage-bindings", "dep:tempfile"]
 
 [dependencies]
 tokio = { workspace = true }
@@ -23,6 +24,7 @@ base64 = { version = "0.22", optional = true }
 # Libstorage native backend
 storage-bindings = { version = "0.2", optional = true }
 tempfile = { version = "3", optional = true }
+
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/logos-messaging-a2a-storage/src/lib.rs
+++ b/crates/logos-messaging-a2a-storage/src/lib.rs
@@ -7,6 +7,7 @@
 //! |---------|-------------|-------------|
 //! | [`LogosStorageRest`] | `rest` (default) | Standalone processes talking to a Codex REST API |
 //! | `LogosCoreStorageBackend` | `logos-core` | Inside a Logos Core host process (desktop client) |
+//! | `StorageModuleClient` | `storage-module` | Managed logos-storage-module instance (headless, throttled) |
 //!
 //! # Example (REST)
 //!
@@ -38,6 +39,11 @@ pub use logos_core_backend::LogosCoreStorageBackend;
 mod libstorage_backend;
 #[cfg(feature = "libstorage")]
 pub use libstorage_backend::LibstorageBackend;
+
+#[cfg(feature = "storage-module")]
+mod storage_module_client;
+#[cfg(feature = "storage-module")]
+pub use storage_module_client::StorageModuleClient;
 
 use std::fmt;
 

--- a/crates/logos-messaging-a2a-storage/src/storage_module_client.rs
+++ b/crates/logos-messaging-a2a-storage/src/storage_module_client.rs
@@ -1,0 +1,253 @@
+//! [`StorageBackend`] implementation matching the logos-storage-module API.
+//!
+//! Provides a `StorageModuleClient` that follows the logos-co/logos-storage-module
+//! v0.3.2 lifecycle: `init(config) → start() → upload_file / download_cid`.
+//!
+//! Built on top of `storage-bindings` (the same `libstorage` FFI that
+//! `logos-storage-module` uses internally), this backend can be swapped in as a
+//! drop-in replacement for the lower-level [`LibstorageBackend`] with a
+//! higher-level, module-oriented API.
+
+use crate::{StorageBackend, StorageError};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use storage_bindings::{
+    download_stream, upload_file, DownloadStreamOptions, LogLevel, StorageConfig, StorageNode,
+    UploadOptions,
+};
+
+/// Configuration for [`StorageModuleClient`].
+///
+/// Mirrors the configuration surface of `logos-storage-module`:
+/// headless mode, throttle controls, discovery port, storage quota.
+pub struct StorageModuleClientConfig {
+    /// UDP port for peer discovery (`None` uses the default).
+    pub discovery_port: Option<u16>,
+    /// Maximum bytes the node may store (`None` for unlimited).
+    pub storage_quota: Option<u64>,
+    /// Log level for the embedded storage node.
+    pub log_level: LogLevel,
+}
+
+impl Default for StorageModuleClientConfig {
+    fn default() -> Self {
+        Self {
+            discovery_port: None,
+            storage_quota: None,
+            log_level: LogLevel::Warn,
+        }
+    }
+}
+
+impl StorageModuleClientConfig {
+    /// Set the discovery port.
+    pub fn discovery_port(mut self, port: u16) -> Self {
+        self.discovery_port = Some(port);
+        self
+    }
+
+    /// Set the storage quota in bytes.
+    pub fn storage_quota(mut self, quota: u64) -> Self {
+        self.storage_quota = Some(quota);
+        self
+    }
+}
+
+/// Storage backend using the logos-storage-module API pattern.
+///
+/// Manages a full storage node in-process following the
+/// `init(config) → start() → upload_file / download_cid` lifecycle.
+///
+/// Call [`StorageModuleClient::shutdown`] to stop gracefully (consumes self).
+///
+/// # Example
+///
+/// ```no_run
+/// use logos_messaging_a2a_storage::StorageModuleClient;
+/// use logos_messaging_a2a_storage::StorageBackend;
+///
+/// # async fn example() -> Result<(), logos_messaging_a2a_storage::StorageError> {
+/// let client = StorageModuleClient::new("/tmp/storage-data").await?;
+///
+/// let cid = client.upload(b"hello".to_vec()).await?;
+/// let data = client.download(&cid).await?;
+///
+/// client.shutdown().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct StorageModuleClient {
+    node: Arc<StorageNode>,
+    scratch: PathBuf,
+}
+
+impl StorageModuleClient {
+    /// Initialise and start a storage module with default settings.
+    ///
+    /// Equivalent to `StorageModule::init(default_config).start()` in
+    /// logos-storage-module.
+    ///
+    /// * `data_dir` — persistent storage directory
+    pub async fn new(data_dir: impl AsRef<Path>) -> Result<Self, StorageError> {
+        Self::with_config(data_dir, StorageModuleClientConfig::default()).await
+    }
+
+    /// Initialise and start with explicit configuration.
+    ///
+    /// * `data_dir` — persistent storage directory
+    /// * `config`   — module configuration
+    pub async fn with_config(
+        data_dir: impl AsRef<Path>,
+        config: StorageModuleClientConfig,
+    ) -> Result<Self, StorageError> {
+        let data_dir = data_dir.as_ref();
+        let scratch = data_dir.join("scratch");
+        std::fs::create_dir_all(&scratch).map_err(|e| StorageError::Http(e.to_string()))?;
+
+        let mut sc = StorageConfig::new()
+            .log_level(config.log_level)
+            .data_dir(data_dir);
+
+        if let Some(port) = config.discovery_port {
+            sc = sc.discovery_port(port);
+        }
+        if let Some(quota) = config.storage_quota {
+            sc = sc.storage_quota(quota);
+        }
+
+        // init
+        let node = StorageNode::new(sc)
+            .await
+            .map_err(|e| StorageError::Http(format!("failed to init storage module: {e}")))?;
+
+        // start
+        node.start()
+            .await
+            .map_err(|e| StorageError::Http(format!("failed to start storage module: {e}")))?;
+
+        Ok(Self {
+            node: Arc::new(node),
+            scratch,
+        })
+    }
+
+    /// Stop the storage module gracefully (consumes self).
+    pub async fn shutdown(self) -> Result<(), StorageError> {
+        let node = Arc::try_unwrap(self.node).map_err(|_| {
+            StorageError::Http("cannot shutdown: other references to module exist".into())
+        })?;
+        node.stop()
+            .await
+            .map_err(|e| StorageError::Http(format!("failed to stop storage module: {e}")))?;
+        node.destroy()
+            .await
+            .map_err(|e| StorageError::Http(format!("failed to destroy storage module: {e}")))?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageBackend for StorageModuleClient {
+    async fn upload(&self, data: Vec<u8>) -> Result<String, StorageError> {
+        let tmp = tempfile::NamedTempFile::new_in(&self.scratch)
+            .map_err(|e| StorageError::Http(format!("temp file creation failed: {e}")))?;
+
+        std::fs::write(tmp.path(), &data)
+            .map_err(|e| StorageError::Http(format!("temp file write failed: {e}")))?;
+
+        let opts = UploadOptions::new().filepath(tmp.path());
+
+        let result = upload_file(&self.node, opts)
+            .await
+            .map_err(|e| StorageError::Http(format!("upload failed: {e}")))?;
+
+        Ok(result.cid.to_string())
+    }
+
+    async fn download(&self, cid: &str) -> Result<Vec<u8>, StorageError> {
+        let download_path = self.scratch.join(format!("dl-{cid}"));
+
+        let opts = DownloadStreamOptions::new(cid).filepath(&download_path);
+
+        download_stream(&self.node, cid, opts)
+            .await
+            .map_err(|e| StorageError::Http(format!("download failed: {e}")))?;
+
+        let data = std::fs::read(&download_path)
+            .map_err(|e| StorageError::Http(format!("reading downloaded file failed: {e}")))?;
+
+        let _ = std::fs::remove_file(&download_path);
+
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::StorageBackend;
+    use std::sync::atomic::{AtomicU16, Ordering};
+
+    static NEXT_PORT: AtomicU16 = AtomicU16::new(19200);
+
+    async fn make_client() -> (StorageModuleClient, tempfile::TempDir) {
+        let port = NEXT_PORT.fetch_add(1, Ordering::Relaxed);
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let config = StorageModuleClientConfig::default().discovery_port(port);
+        let client = StorageModuleClient::with_config(tmp.path(), config)
+            .await
+            .expect("failed to create StorageModuleClient");
+        (client, tmp)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn roundtrip_upload_download() {
+        let (client, _tmp) = make_client().await;
+
+        let data = b"hello storage module client".to_vec();
+        let cid = client.upload(data.clone()).await.expect("upload failed");
+        assert!(!cid.is_empty());
+
+        let downloaded = client.download(&cid).await.expect("download failed");
+        assert_eq!(data, downloaded);
+
+        client.shutdown().await.expect("shutdown failed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn download_unknown_cid_fails() {
+        let (client, _tmp) = make_client().await;
+
+        let result = client.download("zNonexistentCid123456789").await;
+        assert!(result.is_err());
+
+        client.shutdown().await.expect("shutdown failed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn multiple_uploads_produce_different_cids() {
+        let (client, _tmp) = make_client().await;
+
+        let cid_a = client.upload(b"alpha".to_vec()).await.expect("upload A");
+        let cid_b = client.upload(b"beta".to_vec()).await.expect("upload B");
+        assert_ne!(cid_a, cid_b);
+
+        client.shutdown().await.expect("shutdown failed");
+    }
+
+    #[test]
+    fn default_config_values() {
+        let config = StorageModuleClientConfig::default();
+        assert!(config.discovery_port.is_none());
+        assert!(config.storage_quota.is_none());
+    }
+
+    #[test]
+    fn config_builder_methods() {
+        let config = StorageModuleClientConfig::default()
+            .discovery_port(9000)
+            .storage_quota(1024 * 1024);
+        assert_eq!(config.discovery_port, Some(9000));
+        assert_eq!(config.storage_quota, Some(1024 * 1024));
+    }
+}

--- a/crates/logos-messaging-a2a-transport/src/lib.rs
+++ b/crates/logos-messaging-a2a-transport/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! Provides a unified [`Transport`] trait with multiple backend implementations:
 //!
+//! - **Logos Core** (`logos-core` feature): primary transport for Logos Core integration — uses the
+//!   real `logos-co/logos-delivery-module` via QtRO inter-module IPC (issue #143).
 //! - **REST** (`rest` feature): nwaku REST API transport for communicating with a running nwaku node.
-//! - **Logos Core** (`logos-core` feature): native IPC transport via the Logos Core `delivery_module` plugin.
 //! - **Native Waku** (`native-waku` feature): libwaku FFI transport via the `waku-bindings` crate.
 //! - **In-memory**: zero-dependency mock transport for testing (`memory` module, always available).
 //!

--- a/crates/logos-messaging-a2a-transport/src/logos_core_transport.rs
+++ b/crates/logos-messaging-a2a-transport/src/logos_core_transport.rs
@@ -1,8 +1,10 @@
 //! Logos Core delivery-module transport — native IPC via `logos_core_call_plugin_method_async`.
 //!
-//! Communicates with the `delivery_module` plugin through Logos Core's C IPC layer
-//! instead of the nwaku REST API. Requires the `logos-core` feature and linking
-//! against `liblogos_core`.
+//! Primary transport for running inside Logos Core (issue #143). Communicates with
+//! the real `logos-co/logos-delivery-module` plugin through Logos Core's C IPC layer
+//! using QtRO inter-module calls, replacing the nwaku REST API.
+//!
+//! Requires the `logos-core` feature and linking against `liblogos_core`.
 
 use crate::logos_core;
 use crate::Transport;
@@ -29,10 +31,12 @@ fn params_json(pairs: &[(&str, &str)]) -> String {
     format!("[{}]", entries.join(","))
 }
 
-/// Transport implementation backed by Logos Core IPC to the `delivery_module` plugin.
+/// Transport implementation backed by Logos Core IPC to the real `logos-co/logos-delivery-module`.
 ///
+/// This is the primary transport when running as a Logos Core plugin (issue #143).
 /// Uses `logos_core_call_plugin_method_async` for publish/subscribe/unsubscribe and
 /// `logos_core_register_event_listener` for receiving messages via the `messageReceived` event.
+/// The A2A message envelope format is preserved — only the transport layer is swapped.
 pub struct LogosCoreDeliveryTransport {
     subscriptions: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>>,
     /// Keep the event listener state alive so the FFI callback pointer stays valid.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,9 +75,9 @@
 │  │                                                         │         │
 │  ├─────────────────────────────────────────────────────────┤         │
 │  │                                                         │         │
-│  │  NwakuRestTransport        LogosDeliveryTransport       │         │
-│  │  (v0.1 — REST fallback)    (planned — issue #57)        │         │
-│  │  http://localhost:8645     logos-delivery-rust-bindings  │         │
+│  │  NwakuRestTransport        LogosCoreDeliveryTransport   │         │
+│  │  (default — REST)          (logos-core feature, #143)    │         │
+│  │  http://localhost:8645     delivery_module IPC (QtRO)    │         │
 │  │                                                         │         │
 │  └─────────────────────────┬──────────────────────────────┘         │
 │                            │                                         │

--- a/docs/logos-native-runtime-research.md
+++ b/docs/logos-native-runtime-research.md
@@ -1,0 +1,259 @@
+# Research: Logos-Native Agent Runtime
+
+Issue: #51 — Replacing OpenClaw with a Logos Core module
+
+## Executive Summary
+
+LMAO already has most building blocks for a Logos-native agent runtime. The gap
+is not infrastructure — it is the **agent lifecycle layer** (tool execution,
+memory, heartbeats, scheduling) that OpenClaw provides today. This document maps
+what exists, what is missing, and recommends a phased approach.
+
+## Current State (what LMAO already provides)
+
+| Capability | LMAO Crate | Status |
+|---|---|---|
+| Agent identity (secp256k1) | `lmao-core` | Done |
+| Agent discovery (Waku broadcast + presence) | `lmao-node` (discovery/presence) | Done |
+| Agent-to-agent messaging | `lmao-node` (send_task/respond) | Done |
+| E2E encryption | `lmao-crypto` (X25519+ChaCha20) | Done |
+| Reliable delivery (full SDS) | `lmao-transport` (bloom filter, causal ordering, batch ACK) | Done |
+| Task delegation (4 strategies) | `lmao-node` (FirstAvailable, CapabilityMatch, BroadcastCollect, RoundRobin) | Done |
+| Task streaming | `lmao-node` | Done |
+| On-chain registration | `lmao-execution` (StatusNetwork) | Done |
+| On-chain payments (x402) | `lmao-execution` (StatusNetwork) | Done |
+| ZK execution (LEZ) | `lmao-execution` (lez module) | Stub |
+| CID payload offloading | `lmao-storage` (Codex REST + LogosCore IPC) | Done |
+| Logos Core IPC transport | `lmao-transport` (logos-core feature) | Done |
+| Logos Core UI plugin | `logos-core-module/` (IComponent + QML UI) | Done (PR #43) |
+| MCP bridge (Claude/Cursor) | `lmao-mcp` | Done |
+| C FFI bindings | `lmao-ffi` + `logos-messaging-a2a-ffi` | Done |
+| CLI with JSON output | `lmao-cli` (info, health, sessions, completions) | Done |
+| Observability | `lmao-node` (metrics counters) | Done |
+| Message retry with backoff | `lmao-node` (RetryLayer) | Done |
+
+## What OpenClaw provides that LMAO does not
+
+| OpenClaw Feature | Logos-Native Equivalent | Gap |
+|---|---|---|
+| Telegram bridge | Logos Messaging (Waku) | Waku works for A2A; no human chat UI yet |
+| File-based memory | Logos Storage (Codex CID) | `StorageBackend` trait exists, Codex + LogosCore impl done |
+| Cron scheduling | Waku-triggered events | No scheduler in LMAO — needs new component |
+| Tool execution sandbox | — | Not in LMAO at all |
+| Browser automation | — | Not in LMAO at all |
+| Heartbeat system | `lmao-node` presence module | Done (PeerMap + signed broadcasts + TTL expiry) |
+| LLM API calls | — | Anthropic API (unavoidable for now) |
+| Agent spawn/lifecycle | Logos Core module loading | Partial — load module, but no spawn API |
+
+### Critical Gaps
+
+1. **Agent Lifecycle Manager** — start, stop, restart, health-check agents.
+   Today the Logos Core module can load LMAO, but there is no API to spawn a
+   *new* agent instance with its own identity and config.
+
+2. **Scheduler / Trigger System** — OpenClaw uses cron. A Logos-native approach
+   would use Waku content-topic triggers or on-chain events. Neither exists in
+   LMAO today.
+
+3. **Tool Execution Sandbox** — OpenClaw has shell execution, browser control,
+   file I/O. A Logos-native agent would need a sandboxed execution environment
+   (WASM? Nix sandbox?). This is the hardest gap to close.
+
+4. **LLM Integration Layer** — LMAO has no concept of "call an LLM". The agent
+   runtime needs a trait for LLM backends (Anthropic today, local models later).
+
+5. **Human-Facing Comms** — Waku works for machine-to-machine. Humans use
+   Telegram/Discord today. Until Logos Messaging has a consumer chat client, the
+   Telegram bridge remains necessary.
+
+## Architecture: Proposed Runtime Layer
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Agent Runtime (NEW)                     │
+│                                                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  │
+│  │ Lifecycle Mgr │  │  Scheduler   │  │  Tool Runner │  │
+│  │ spawn/stop/   │  │ cron/waku    │  │  sandboxed   │  │
+│  │ health-check  │  │ triggers     │  │  execution   │  │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘  │
+│         │                 │                  │           │
+│  ┌──────┴─────────────────┴──────────────────┴───────┐  │
+│  │              LLM Integration Trait                 │  │
+│  │  AnthropicBackend | LocalModelBackend | ...        │  │
+│  └──────────────────────┬────────────────────────────┘  │
+│                         │                                │
+├─────────────────────────┼────────────────────────────────┤
+│              LMAO (existing infrastructure)               │
+│                                                          │
+│  WakuA2ANode ─── transport, crypto, storage, execution   │
+│  ├── SdsTransport (bloom filter dedup, causal ordering)  │
+│  ├── PeerMap (signed presence, capability match)         │
+│  ├── Delegation (4 strategies incl. RoundRobin)          │
+│  ├── RetryLayer (exponential backoff + jitter)           │
+│  ├── Metrics (observability counters)                    │
+│  └── MCP Bridge (Claude/Cursor integration)              │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│              Logos Core (host)                            │
+│  IComponent plugin loading                               │
+│  delivery_module IPC (pub/sub)                           │
+│  storage_module IPC (CID upload/download)                │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Existing Integration Points (code audit)
+
+### Transport: Two production-ready paths
+
+1. **NwakuRestTransport** — REST API to external nwaku node (`http://localhost:8645`)
+2. **LogosCoreDeliveryTransport** — Native IPC via `delivery_module` plugin
+
+Both implement `WakuTransport { publish, subscribe, poll }`. The Logos Core
+transport is already battle-tested in the e2e demo (`demos/logos-core-e2e/`).
+
+### Storage: CID-addressed with auto-offload
+
+```
+StorageBackend { upload(data) → CID, download(CID) → data }
+├── LogosStorageRest        — Codex REST API (standalone processes)
+├── LogosCoreStorageBackend — storage_module IPC (inside Logos Core)
+└── LibstorageBackend       — Direct FFI (future)
+```
+
+Payloads > 100 KB are auto-offloaded to storage via `maybe_offload()`. This
+means agent memory/context could use CID-addressed blobs with zero new code.
+
+### Execution: On-chain agent economy
+
+```
+ExecutionBackend { register_agent, pay, balance, verify_transfer }
+├── StatusNetworkBackend — EVM/gasless (AgentRegistry at 0x438bB48f...)
+└── LezExecutionBackend  — ZK-verified (stub, tracking issue #4)
+```
+
+The x402 payment flow already enables pay-per-task agent economics.
+
+### FFI: Three layers deep
+
+```
+Logos Core Qt App
+  → LmaoComponent (IComponent C++ plugin)
+    → LmaoBackend (QObject, calls C FFI)
+      → lmao-ffi (Rust cdylib, JSON in/out)
+        → WakuA2ANode (full async Rust stack)
+```
+
+Key FFI functions: `lmao_discover_agents()`, `lmao_send_task()`,
+`lmao_get_agent_card()`. All return `{"success": bool, ...}` JSON.
+
+## Phased Approach
+
+### Phase 1: Hybrid (recommended NOW)
+
+Keep OpenClaw for human-facing operations. Use LMAO for agent-to-agent
+coordination underneath.
+
+- OpenClaw handles: Telegram, crons, memory, tool execution
+- LMAO handles: agent discovery, A2A messaging, on-chain identity/payments
+- Bridge: MCP server (`lmao-mcp`) connects Claude <-> LMAO agents
+
+**Already possible today.** The MCP bridge and FFI bindings enable this.
+
+**Concrete integration path:**
+1. OpenClaw agent registers on-chain via `lmao-execution` (StatusNetwork)
+2. OpenClaw agent announces presence via `lmao-node` (Waku broadcast)
+3. Other LMAO agents discover it and send tasks via A2A protocol
+4. OpenClaw processes tasks using its existing tool execution pipeline
+5. Results flow back through LMAO transport
+
+### Phase 2: Agent Lifecycle in Logos Core
+
+Add a new crate `logos-messaging-a2a-runtime` that provides:
+
+```rust
+/// Trait for agent runtime backends.
+#[async_trait]
+pub trait AgentRuntime: Send + Sync {
+    /// Spawn a new agent with the given config.
+    async fn spawn(&self, config: AgentConfig) -> Result<AgentHandle>;
+    /// Stop a running agent.
+    async fn stop(&self, id: &AgentId) -> Result<()>;
+    /// List running agents with status.
+    async fn list(&self) -> Result<Vec<AgentStatus>>;
+    /// Health check a specific agent.
+    async fn health(&self, id: &AgentId) -> Result<HealthStatus>;
+}
+
+pub struct AgentConfig {
+    pub name: String,
+    pub capabilities: Vec<String>,
+    pub llm_backend: LlmBackendConfig,
+    pub triggers: Vec<TriggerConfig>,
+    pub tools: Vec<ToolConfig>,
+    pub storage_backend: StorageBackendConfig,
+}
+
+/// Trait for LLM backends (Anthropic today, local models later).
+#[async_trait]
+pub trait LlmBackend: Send + Sync {
+    async fn complete(&self, messages: Vec<Message>) -> Result<Message>;
+    async fn complete_stream(&self, messages: Vec<Message>) -> Result<MessageStream>;
+}
+```
+
+This enables "spin up agent = load a module" in Basecamp.
+
+**Prerequisite:** Logos Core module loading stabilizes for production workloads.
+
+### Phase 3: Full Logos-Native
+
+Replace OpenClaw entirely when:
+
+- [ ] Logos Messaging has a human-facing chat client (Telegram replacement)
+- [ ] LEZ execution backend is production-ready (issue #4)
+- [ ] Tool execution sandbox exists (WASM or Nix-based)
+- [ ] Logos Storage (Codex) is reliable for agent memory persistence
+- [ ] Logos Core supports long-running module processes with restart policies
+
+This is the LP-0008 end state.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| Logos Core instability | Agent crashes, data loss | Medium | Phase 1 hybrid keeps OpenClaw as fallback |
+| No human chat replacement | Can't drop Telegram bridge | High | Keep Telegram bridge until Status Chat/Waku consumer client |
+| LLM vendor lock-in | Anthropic dependency | Low (acceptable) | LLM trait allows swapping backends later |
+| Tool sandbox complexity | Months of work | High | Start with simple subprocess isolation, not full WASM |
+| LEZ delays | No ZK-verified execution | Medium | StatusNetwork EVM works today as bridge |
+
+## Recommendations
+
+1. **Do NOT replace OpenClaw now.** The hybrid approach (Phase 1) gives immediate
+   value without risk.
+
+2. **Next concrete step:** Create `logos-messaging-a2a-runtime` crate with the
+   `AgentRuntime` and `LlmBackend` traits and a basic in-process implementation.
+   This is the foundation for Phase 2.
+
+3. **Leverage what exists:** The delegation system (4 strategies including
+   RoundRobin) already supports orchestrator patterns. An OpenClaw agent could
+   act as orchestrator, delegating subtasks to specialized LMAO agents.
+
+4. **Track blockers externally:**
+   - Logos Core production stability -> Logos team
+   - LEZ SDK availability -> LEZ team
+   - Logos Messaging consumer client -> Status/Waku team
+
+5. **The MCP bridge is the most underrated piece.** It already lets any
+   MCP-compatible AI (Claude, Cursor) use LMAO agents as tools. This is the
+   practical integration point for Phase 1.
+
+## Related Issues & PRs
+
+- PR #43 — Logos Core IComponent module (done)
+- Issue #5 — Package as .lgx (done)
+- Issue #4 — LEZ agent registry (stub exists)
+- LP-0008 spec — Full Logos-native runtime (end state)
+- AgentRegistry contract: `0x438bB48f...` on SN testnet

--- a/logos-core-module/CMakeLists.txt
+++ b/logos-core-module/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(${MODULE_TARGET} SHARED
     src/LmaoComponent.cpp
     src/LmaoBackend.cpp
     src/AgentListModel.cpp
+    src/DeliveryTransport.cpp
     qml/qml.qrc
 )
 

--- a/logos-core-module/flake.nix
+++ b/logos-core-module/flake.nix
@@ -24,6 +24,9 @@
           };
         };
         buildAndTestSubdir = "crates/lmao-ffi";
+        # Enable logos-core feature so the FFI uses LogosCoreDeliveryTransport
+        # (delivery_module IPC) instead of nwaku REST when running as a Logos Core plugin.
+        buildFeatures = [ "logos-core" ];
         # We only need the cdylib, skip tests (they need network).
         doCheck = false;
         postInstall = ''

--- a/logos-core-module/flake.nix
+++ b/logos-core-module/flake.nix
@@ -4,12 +4,20 @@
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nixpkgs.follows = "logos-module-builder/nixpkgs";
+    logos-delivery-module = {
+      url = "github:logos-co/logos-delivery-module";
+      inputs.logos-module-builder.follows = "logos-module-builder";
+    };
   };
 
-  outputs = { self, logos-module-builder, nixpkgs }:
+  outputs = { self, logos-module-builder, nixpkgs, logos-delivery-module }:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
+
+      # Real delivery_module plugin from logos-co/logos-delivery-module.
+      # Provides liblogosdelivery (Waku transport) as a Logos Core module.
+      delivery-module = logos-delivery-module.packages.${system}.default;
 
       # Build the lmao-ffi Rust crate from the parent workspace.
       lmao-ffi = pkgs.rustPlatform.buildRustPackage {
@@ -49,6 +57,7 @@
               qt6.qtdeclarative
               qt6.qtquick3d
               lmao-ffi
+              delivery-module
             ];
             cmakeFlags = [
               "-DLMAO_FFI_LIB=${lmao-ffi}/lib"

--- a/logos-core-module/module.yaml
+++ b/logos-core-module/module.yaml
@@ -4,7 +4,8 @@ type: core
 category: network
 description: "LMAO — A2A agent discovery and task communication over Waku"
 
-dependencies: []
+dependencies:
+  - delivery_module
 
 nix_packages:
   build: []
@@ -22,3 +23,4 @@ cmake:
   extra_sources:
     - src/AgentListModel.cpp
     - src/LmaoBackend.cpp
+    - src/DeliveryTransport.cpp

--- a/logos-core-module/qml/DashboardView.qml
+++ b/logos-core-module/qml/DashboardView.qml
@@ -1,0 +1,269 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+/**
+ * DashboardView — agent status, identity, topics, and encryption overview.
+ *
+ * Context properties (injected by LmaoComponent):
+ *   - lmaoModule     : LmaoBackend*
+ *   - lmaoAgentModel : AgentListModel*
+ */
+Item {
+    id: root
+
+    property var infoData: ({})
+    property bool loaded: false
+    property string errorMsg: ""
+
+    function refresh() {
+        errorMsg = ""
+        var result = lmaoModule.getInfo()
+        try {
+            var obj = JSON.parse(result)
+            if (obj.success) {
+                infoData = obj
+                loaded = true
+            } else {
+                errorMsg = obj.error || "Unknown error"
+            }
+        } catch (e) {
+            errorMsg = "Failed to parse info response"
+        }
+    }
+
+    Component.onCompleted: refresh()
+
+    Flickable {
+        anchors.fill: parent
+        contentHeight: col.implicitHeight + Theme.spacing.large * 2
+        clip: true
+
+        ColumnLayout {
+            id: col
+            anchors {
+                left: parent.left; right: parent.right
+                top: parent.top
+                margins: Theme.spacing.large
+            }
+            spacing: Theme.spacing.medium
+
+            // ── Status banner ──
+            Rectangle {
+                Layout.fillWidth: true
+                height: 56
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundSecondary
+
+                RowLayout {
+                    anchors { fill: parent; margins: Theme.spacing.medium }
+                    spacing: Theme.spacing.medium
+
+                    Rectangle {
+                        width: 10; height: 10; radius: 5
+                        color: root.loaded ? Theme.palette.success : Theme.palette.error
+                    }
+
+                    Text {
+                        text: root.loaded ? "Agent Online" : "Initializing…"
+                        color: Theme.palette.text
+                        font { pixelSize: 15; bold: true; family: "monospace" }
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    Text {
+                        visible: lmaoAgentModel.count > 0
+                        text: lmaoAgentModel.count + " peers"
+                        color: Theme.palette.textSecondary
+                        font.pixelSize: 12
+                    }
+
+                    Button {
+                        text: "↻"
+                        onClicked: root.refresh()
+                        width: 32; height: 32
+                        contentItem: Text {
+                            text: parent.text
+                            color: Theme.palette.primary
+                            font.pixelSize: 16
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        background: Rectangle {
+                            color: parent.hovered ? Theme.palette.backgroundTertiary : "transparent"
+                            radius: Theme.spacing.tiny
+                        }
+                    }
+                }
+            }
+
+            // ── Error display ──
+            Text {
+                visible: root.errorMsg.length > 0
+                text: "⚠ " + root.errorMsg
+                color: Theme.palette.error
+                font.pixelSize: 12
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+            }
+
+            // ── Identity card ──
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: identityCol.implicitHeight + Theme.spacing.large * 2
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundTertiary
+                border { color: Theme.palette.borderSecondary; width: 1 }
+
+                ColumnLayout {
+                    id: identityCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.large
+                    }
+                    spacing: Theme.spacing.small
+
+                    Text {
+                        text: "Identity"
+                        color: Theme.palette.text
+                        font { pixelSize: 14; bold: true }
+                    }
+
+                    InfoRow { label: "Public Key"; value: infoData.public_key || "—"; mono: true; copyable: true }
+                    InfoRow { label: "Encryption"; value: infoData.encryption ? "Enabled" : "Disabled"; statusColor: infoData.encryption ? Theme.palette.success : Theme.palette.textTertiary }
+                }
+            }
+
+            // ── Waku Topics card ──
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: topicsCol.implicitHeight + Theme.spacing.large * 2
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundTertiary
+                border { color: Theme.palette.borderSecondary; width: 1 }
+
+                ColumnLayout {
+                    id: topicsCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.large
+                    }
+                    spacing: Theme.spacing.small
+
+                    Text {
+                        text: "Waku Topics"
+                        color: Theme.palette.text
+                        font { pixelSize: 14; bold: true }
+                    }
+
+                    InfoRow { label: "Task"; value: infoData.task_topic || "—"; mono: true }
+                    InfoRow { label: "Discovery"; value: infoData.discovery_topic || "—"; mono: true }
+                    InfoRow { label: "Presence"; value: infoData.presence_topic || "—"; mono: true }
+                }
+            }
+
+            // ── Transport card ──
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: transportCol.implicitHeight + Theme.spacing.large * 2
+                radius: Theme.spacing.radiusLarge
+                color: Theme.palette.backgroundTertiary
+                border { color: Theme.palette.borderSecondary; width: 1 }
+
+                ColumnLayout {
+                    id: transportCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.large
+                    }
+                    spacing: Theme.spacing.small
+
+                    Text {
+                        text: "Transport"
+                        color: Theme.palette.text
+                        font { pixelSize: 14; bold: true }
+                    }
+
+                    InfoRow {
+                        label: "QtRO Delivery"
+                        value: lmaoModule.hasDeliveryTransport ? "Connected" : "Unavailable"
+                        statusColor: lmaoModule.hasDeliveryTransport ? Theme.palette.success : Theme.palette.textTertiary
+                    }
+                }
+            }
+        }
+    }
+
+    // ── InfoRow helper component ──
+    component InfoRow: RowLayout {
+        property string label: ""
+        property string value: ""
+        property bool mono: false
+        property bool copyable: false
+        property color statusColor: "transparent"
+
+        Layout.fillWidth: true
+        spacing: Theme.spacing.small
+
+        Text {
+            text: label
+            color: Theme.palette.textSecondary
+            font.pixelSize: 12
+            Layout.preferredWidth: 100
+        }
+
+        Rectangle {
+            visible: statusColor != "transparent"
+            width: 8; height: 8; radius: 4
+            color: statusColor
+        }
+
+        Text {
+            text: {
+                if (!mono) return value
+                if (value.length > 48)
+                    return value.substring(0, 20) + "…" + value.slice(-12)
+                return value
+            }
+            color: Theme.palette.text
+            font { pixelSize: 12; family: mono ? "monospace" : "sans-serif" }
+            Layout.fillWidth: true
+            elide: Text.ElideRight
+
+            MouseArea {
+                anchors.fill: parent
+                visible: copyable
+                cursorShape: copyable ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: {
+                    // Copy full value to clipboard
+                    clipHelper.text = value
+                    clipHelper.selectAll()
+                    clipHelper.copy()
+                    copiedTip.visible = true
+                    copiedTimer.restart()
+                }
+            }
+        }
+
+        Text {
+            id: copiedTip
+            visible: false
+            text: "Copied!"
+            color: Theme.palette.success
+            font.pixelSize: 10
+
+            Timer {
+                id: copiedTimer
+                interval: 1500
+                onTriggered: copiedTip.visible = false
+            }
+        }
+    }
+
+    // Hidden TextInput for clipboard support
+    TextInput {
+        id: clipHelper
+        visible: false
+    }
+}

--- a/logos-core-module/qml/LmaoView.qml
+++ b/logos-core-module/qml/LmaoView.qml
@@ -3,15 +3,17 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 /**
- * LmaoView — basic fleet view for A2A agent discovery and task sending.
+ * LmaoView — main tabbed view for LMAO agent dashboard.
  *
  * Context properties (injected by LmaoComponent):
  *   - lmaoAgentModel : AgentListModel*
  *   - lmaoModule     : LmaoBackend*
+ *   - lmaoDelivery   : DeliveryTransport*
  */
 Item {
     id: root
 
+    property int currentTab: 0
     property bool discovering: false
     property string lastError: ""
     property string lastResult: ""
@@ -25,232 +27,276 @@ Item {
     Rectangle {
         id: header
         anchors { left: parent.left; right: parent.right; top: parent.top }
-        height: 56
+        height: 44
         color: Theme.palette.backgroundSecondary
 
         RowLayout {
-            anchors { fill: parent; leftMargin: Theme.spacing.large; rightMargin: Theme.spacing.large }
-            spacing: 10
+            anchors { fill: parent; leftMargin: Theme.spacing.medium; rightMargin: Theme.spacing.medium }
+            spacing: 0
 
             Text {
-                text: "LMAO Fleet"
+                text: "LMAO"
                 color: Theme.palette.primary
-                font { pixelSize: 18; bold: true; family: "monospace" }
+                font { pixelSize: 15; bold: true; family: "monospace" }
+                Layout.rightMargin: Theme.spacing.medium
             }
 
-            // ── Status indicator ──
-            Rectangle {
-                width: 8; height: 8; radius: 4
-                color: Theme.palette.success
-            }
-            Text {
-                text: "Online"
-                color: Theme.palette.success
-                font.pixelSize: 11
-            }
+            Repeater {
+                model: ["Dashboard", "Fleet", "Metrics", "History"]
+                delegate: Rectangle {
+                    Layout.preferredHeight: 44
+                    Layout.preferredWidth: tabLabel.implicitWidth + Theme.spacing.large * 2
+                    color: "transparent"
 
-            // ── Peer count ──
-            Rectangle {
-                visible: lmaoAgentModel.count > 0
-                width: countText.implicitWidth + Theme.spacing.medium
-                height: 20
-                radius: 10
-                color: Theme.palette.backgroundSecondary
+                    Rectangle {
+                        anchors { bottom: parent.bottom; left: parent.left; right: parent.right }
+                        height: 2
+                        color: Theme.palette.primary
+                        visible: root.currentTab === index
+                    }
 
-                Text {
-                    id: countText
-                    anchors.centerIn: parent
-                    text: lmaoAgentModel.count + " peers"
-                    color: Theme.palette.textSecondary
-                    font.pixelSize: 11
+                    Text {
+                        id: tabLabel
+                        anchors.centerIn: parent
+                        text: modelData
+                        color: root.currentTab === index ? Theme.palette.primary : Theme.palette.textSecondary
+                        font { pixelSize: 12; bold: root.currentTab === index }
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.currentTab = index
+                    }
                 }
             }
 
             Item { Layout.fillWidth: true }
 
-            BusyIndicator {
-                running: root.discovering
-                width: 20; height: 20
-                visible: root.discovering
-            }
-
-            Button {
-                text: "Discover"
-                enabled: !root.discovering
-                onClicked: {
-                    root.discovering = true
-                    root.lastError = ""
-                    var result = lmaoModule.discoverAgents("5000")
-                    lmaoAgentModel.loadFromJson(result)
-                    root.discovering = false
-                }
-                contentItem: Text {
-                    text: parent.text
-                    color: Theme.palette.primary
-                    font.pixelSize: 13
-                    horizontalAlignment: Text.AlignHCenter
-                }
-                background: Rectangle {
-                    color: parent.hovered ? Theme.palette.backgroundSecondary : "transparent"
-                    radius: Theme.spacing.tiny
-                    border { color: Theme.palette.primary; width: 1 }
-                }
-                height: 30
+            // Online indicator
+            Rectangle {
+                width: 6; height: 6; radius: 3
+                color: Theme.palette.success
             }
         }
     }
 
-    // ── Body ────────────────────────────────────────────────────────────
-    ColumnLayout {
+    // ── Tab Content ────────────────────────────────────────────────────
+    StackLayout {
         anchors {
             left: parent.left; right: parent.right
             top: header.bottom; bottom: parent.bottom
-            margins: Theme.spacing.medium
         }
-        spacing: Theme.spacing.medium
+        currentIndex: root.currentTab
 
-        // ── Agent List ──────────────────────────────────────────────────
-        ListView {
-            id: agentList
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            spacing: Theme.spacing.small
-            clip: true
-            model: lmaoAgentModel
+        // Tab 0: Dashboard
+        DashboardView {}
 
-            ScrollBar.vertical: ScrollBar {}
-
-            delegate: AgentCard {
-                width: agentList.width
-                agentName:    model.name       || ""
-                agentDesc:    model.description || ""
-                agentPubkey:  model.pubkey      || ""
-                agentVersion: model.version     || ""
-
-                onSendTaskRequested: function(pubkey) {
-                    taskPubkeyField.text = pubkey
-                }
-            }
-
-            // Empty state
-            Column {
-                anchors.centerIn: parent
-                spacing: Theme.spacing.medium
-                visible: lmaoAgentModel.count === 0 && !root.discovering
-
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: "No agents discovered"
-                    color: Theme.palette.textTertiary
-                    font.pixelSize: 15
-                }
-                Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: "Click Discover to search the Waku network"
-                    color: Theme.palette.textTertiary
-                    font.pixelSize: 12
-                }
-            }
-        }
-
-        // ── Send Task Form ──────────────────────────────────────────────
-        Rectangle {
-            Layout.fillWidth: true
-            height: sendColumn.implicitHeight + Theme.spacing.large * 2
-            radius: Theme.spacing.radiusLarge
-            color: Theme.palette.backgroundTertiary
-            border { color: Theme.palette.borderSecondary; width: 1 }
-
+        // Tab 1: Fleet (discovery + task sending)
+        Item {
             ColumnLayout {
-                id: sendColumn
                 anchors {
-                    left: parent.left; right: parent.right
-                    top: parent.top
-                    margins: Theme.spacing.large
+                    fill: parent
+                    margins: Theme.spacing.medium
                 }
-                spacing: Theme.spacing.small
+                spacing: Theme.spacing.medium
 
-                Text {
-                    text: "Send Test Task"
-                    color: Theme.palette.text
-                    font { pixelSize: 14; bold: true }
-                }
-
-                TextField {
-                    id: taskPubkeyField
-                    Layout.fillWidth: true
-                    placeholderText: "Agent public key"
-                    color: Theme.palette.text
-                    font.pixelSize: 12
-                    background: Rectangle {
-                        color: Theme.palette.background
-                        border { color: Theme.palette.borderSecondary; width: 1 }
-                        radius: Theme.spacing.tiny
-                    }
-                }
-
-                TextField {
-                    id: taskTextField
-                    Layout.fillWidth: true
-                    placeholderText: "Task text"
-                    color: Theme.palette.text
-                    font.pixelSize: 12
-                    background: Rectangle {
-                        color: Theme.palette.background
-                        border { color: Theme.palette.borderSecondary; width: 1 }
-                        radius: Theme.spacing.tiny
-                    }
-                }
-
+                // ── Fleet header ──
                 RowLayout {
+                    Layout.fillWidth: true
                     spacing: Theme.spacing.small
 
+                    Text {
+                        text: "Fleet Discovery"
+                        color: Theme.palette.text
+                        font { pixelSize: 16; bold: true }
+                    }
+
+                    Text {
+                        visible: lmaoAgentModel.count > 0
+                        text: lmaoAgentModel.count + " peers"
+                        color: Theme.palette.textSecondary
+                        font.pixelSize: 12
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    BusyIndicator {
+                        running: root.discovering
+                        width: 20; height: 20
+                        visible: root.discovering
+                    }
+
                     Button {
-                        text: "Send"
-                        enabled: taskPubkeyField.text.length > 0 && taskTextField.text.length > 0
+                        text: "Discover"
+                        enabled: !root.discovering
                         onClicked: {
-                            var result = lmaoModule.sendTask(taskPubkeyField.text, taskTextField.text)
-                            root.lastResult = result
-                            taskTextField.text = ""
+                            root.discovering = true
+                            root.lastError = ""
+                            var result = lmaoModule.discoverAgents("5000")
+                            lmaoAgentModel.loadFromJson(result)
+                            root.discovering = false
                         }
                         contentItem: Text {
                             text: parent.text
-                            color: parent.enabled ? "#FFFFFF" : Theme.palette.textTertiary
+                            color: Theme.palette.primary
                             font.pixelSize: 13
                             horizontalAlignment: Text.AlignHCenter
                         }
                         background: Rectangle {
-                            color: parent.enabled ? Theme.palette.primary : Theme.palette.backgroundSecondary
+                            color: parent.hovered ? Theme.palette.backgroundSecondary : "transparent"
                             radius: Theme.spacing.tiny
+                            border { color: Theme.palette.primary; width: 1 }
                         }
-                        height: 32
-                        width: 80
+                        height: 30
+                    }
+                }
+
+                // ── Agent List ──
+                ListView {
+                    id: agentList
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    spacing: Theme.spacing.small
+                    clip: true
+                    model: lmaoAgentModel
+
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: AgentCard {
+                        width: agentList.width
+                        agentName:    model.name       || ""
+                        agentDesc:    model.description || ""
+                        agentPubkey:  model.pubkey      || ""
+                        agentVersion: model.version     || ""
+
+                        onSendTaskRequested: function(pubkey) {
+                            taskPubkeyField.text = pubkey
+                        }
                     }
 
-                    Text {
-                        visible: root.lastResult.length > 0
-                        text: {
-                            if (root.lastResult.length > 60)
-                                return root.lastResult.substring(0, 60) + "\u2026"
-                            return root.lastResult
+                    // Empty state
+                    Column {
+                        anchors.centerIn: parent
+                        spacing: Theme.spacing.medium
+                        visible: lmaoAgentModel.count === 0 && !root.discovering
+
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: "No agents discovered"
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 15
                         }
-                        color: Theme.palette.textSecondary
-                        font.pixelSize: 11
-                        Layout.fillWidth: true
-                        elide: Text.ElideRight
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: "Click Discover to search the Waku network"
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 12
+                        }
+                    }
+                }
+
+                // ── Send Task Form ──
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: sendColumn.implicitHeight + Theme.spacing.large * 2
+                    radius: Theme.spacing.radiusLarge
+                    color: Theme.palette.backgroundTertiary
+                    border { color: Theme.palette.borderSecondary; width: 1 }
+
+                    ColumnLayout {
+                        id: sendColumn
+                        anchors {
+                            left: parent.left; right: parent.right
+                            top: parent.top
+                            margins: Theme.spacing.large
+                        }
+                        spacing: Theme.spacing.small
+
+                        Text {
+                            text: "Send Task"
+                            color: Theme.palette.text
+                            font { pixelSize: 14; bold: true }
+                        }
+
+                        TextField {
+                            id: taskPubkeyField
+                            Layout.fillWidth: true
+                            placeholderText: "Agent public key"
+                            color: Theme.palette.text
+                            font.pixelSize: 12
+                            background: Rectangle {
+                                color: Theme.palette.background
+                                border { color: Theme.palette.borderSecondary; width: 1 }
+                                radius: Theme.spacing.tiny
+                            }
+                        }
+
+                        TextField {
+                            id: taskTextField
+                            Layout.fillWidth: true
+                            placeholderText: "Task text"
+                            color: Theme.palette.text
+                            font.pixelSize: 12
+                            background: Rectangle {
+                                color: Theme.palette.background
+                                border { color: Theme.palette.borderSecondary; width: 1 }
+                                radius: Theme.spacing.tiny
+                            }
+                        }
+
+                        RowLayout {
+                            spacing: Theme.spacing.small
+
+                            Button {
+                                text: "Send"
+                                enabled: taskPubkeyField.text.length > 0 && taskTextField.text.length > 0
+                                onClicked: {
+                                    var result = lmaoModule.sendTask(taskPubkeyField.text, taskTextField.text)
+                                    root.lastResult = result
+                                    // Record in task history
+                                    if (historyView.item)
+                                        historyView.item.addTask(taskPubkeyField.text, taskTextField.text, "sent", result)
+                                    taskTextField.text = ""
+                                }
+                                contentItem: Text {
+                                    text: parent.text
+                                    color: parent.enabled ? "#FFFFFF" : Theme.palette.textTertiary
+                                    font.pixelSize: 13
+                                    horizontalAlignment: Text.AlignHCenter
+                                }
+                                background: Rectangle {
+                                    color: parent.enabled ? Theme.palette.primary : Theme.palette.backgroundSecondary
+                                    radius: Theme.spacing.tiny
+                                }
+                                height: 32
+                                width: 80
+                            }
+
+                            Text {
+                                visible: root.lastResult.length > 0
+                                text: {
+                                    if (root.lastResult.length > 60)
+                                        return root.lastResult.substring(0, 60) + "\u2026"
+                                    return root.lastResult
+                                }
+                                color: Theme.palette.textSecondary
+                                font.pixelSize: 11
+                                Layout.fillWidth: true
+                                elide: Text.ElideRight
+                            }
+                        }
                     }
                 }
             }
         }
 
-        // ── Last task info ──
-        Text {
-            visible: root.lastResult.length > 0
-            text: "Last result: " + root.lastResult
-            color: Theme.palette.textTertiary
-            font.pixelSize: 10
-            Layout.fillWidth: true
-            elide: Text.ElideRight
+        // Tab 2: Metrics
+        MetricsView {}
+
+        // Tab 3: Task History
+        TaskHistoryView {
+            id: historyView
         }
     }
 }

--- a/logos-core-module/qml/LmaoView.qml
+++ b/logos-core-module/qml/LmaoView.qml
@@ -252,7 +252,7 @@ Item {
                                 text: "Send"
                                 enabled: taskPubkeyField.text.length > 0 && taskTextField.text.length > 0
                                 onClicked: {
-                                    var result = lmaoModule.sendTask(taskPubkeyField.text, taskTextField.text)
+                                    var result = lmaoModule.sendTaskViaDelivery(taskPubkeyField.text, taskTextField.text)
                                     root.lastResult = result
                                     // Record in task history
                                     if (historyView.item)

--- a/logos-core-module/qml/MetricsView.qml
+++ b/logos-core-module/qml/MetricsView.qml
@@ -1,0 +1,230 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+/**
+ * MetricsView — operational metrics counters from the LMAO node.
+ *
+ * Context properties (injected by LmaoComponent):
+ *   - lmaoModule : LmaoBackend*
+ */
+Item {
+    id: root
+
+    property var metricsData: ({})
+    property bool loaded: false
+    property string errorMsg: ""
+
+    function refresh() {
+        errorMsg = ""
+        var result = lmaoModule.getMetrics()
+        try {
+            var obj = JSON.parse(result)
+            if (obj.success) {
+                metricsData = obj
+                loaded = true
+            } else {
+                errorMsg = obj.error || "Unknown error"
+            }
+        } catch (e) {
+            errorMsg = "Failed to parse metrics response"
+        }
+    }
+
+    // Auto-refresh every 5 seconds
+    Timer {
+        id: autoRefresh
+        interval: 5000
+        running: true
+        repeat: true
+        onTriggered: root.refresh()
+    }
+
+    Component.onCompleted: refresh()
+
+    Flickable {
+        anchors.fill: parent
+        contentHeight: col.implicitHeight + Theme.spacing.large * 2
+        clip: true
+
+        ColumnLayout {
+            id: col
+            anchors {
+                left: parent.left; right: parent.right
+                top: parent.top
+                margins: Theme.spacing.large
+            }
+            spacing: Theme.spacing.medium
+
+            // ── Header ──
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacing.small
+
+                Text {
+                    text: "Metrics"
+                    color: Theme.palette.text
+                    font { pixelSize: 16; bold: true }
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Text {
+                    visible: root.loaded
+                    text: "Auto-refresh: 5s"
+                    color: Theme.palette.textTertiary
+                    font.pixelSize: 10
+                }
+
+                Button {
+                    text: "↻"
+                    onClicked: root.refresh()
+                    width: 32; height: 32
+                    contentItem: Text {
+                        text: parent.text
+                        color: Theme.palette.primary
+                        font.pixelSize: 16
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? Theme.palette.backgroundTertiary : "transparent"
+                        radius: Theme.spacing.tiny
+                    }
+                }
+            }
+
+            // ── Error display ──
+            Text {
+                visible: root.errorMsg.length > 0
+                text: "⚠ " + root.errorMsg
+                color: Theme.palette.error
+                font.pixelSize: 12
+                Layout.fillWidth: true
+            }
+
+            // ── Tasks section ──
+            MetricSection {
+                title: "Tasks"
+                metrics: [
+                    { label: "Sent",     value: metricsData.tasks_sent || 0 },
+                    { label: "Received", value: metricsData.tasks_received || 0 },
+                    { label: "Failed",   value: metricsData.tasks_failed || 0,
+                      highlight: (metricsData.tasks_failed || 0) > 0 }
+                ]
+            }
+
+            // ── Messages section ──
+            MetricSection {
+                title: "Messages"
+                metrics: [
+                    { label: "Published", value: metricsData.messages_published || 0 },
+                    { label: "Received",  value: metricsData.messages_received || 0 },
+                    { label: "Responses",  value: metricsData.responses_sent || 0 }
+                ]
+            }
+
+            // ── Discovery section ──
+            MetricSection {
+                title: "Discovery"
+                metrics: [
+                    { label: "Discoveries",   value: metricsData.discoveries || 0 },
+                    { label: "Announcements",  value: metricsData.announcements_sent || 0 },
+                    { label: "Peers Found",    value: metricsData.peers_discovered || 0 }
+                ]
+            }
+
+            // ── Sessions & Encryption section ──
+            MetricSection {
+                title: "Sessions & Encryption"
+                metrics: [
+                    { label: "Sessions",    value: metricsData.sessions_created || 0 },
+                    { label: "Encryptions", value: metricsData.encryptions || 0 },
+                    { label: "Decryptions", value: metricsData.decryptions || 0 }
+                ]
+            }
+
+            // ── Streaming section ──
+            MetricSection {
+                title: "Streaming & Delegation"
+                metrics: [
+                    { label: "Chunks Sent",     value: metricsData.stream_chunks_sent || 0 },
+                    { label: "Chunks Received", value: metricsData.stream_chunks_received || 0 },
+                    { label: "Delegations",     value: metricsData.delegations_sent || 0 }
+                ]
+            }
+
+            // ── Retries section ──
+            MetricSection {
+                title: "Retries"
+                metrics: [
+                    { label: "Attempts",  value: metricsData.retry_attempts || 0 },
+                    { label: "Exhausted", value: metricsData.retries_exhausted || 0,
+                      highlight: (metricsData.retries_exhausted || 0) > 0 }
+                ]
+            }
+        }
+    }
+
+    // ── MetricSection helper component ──
+    component MetricSection: Rectangle {
+        property string title: ""
+        property var metrics: []
+
+        Layout.fillWidth: true
+        implicitHeight: sectionCol.implicitHeight + Theme.spacing.medium * 2
+        radius: Theme.spacing.radiusLarge
+        color: Theme.palette.backgroundTertiary
+        border { color: Theme.palette.borderSecondary; width: 1 }
+
+        ColumnLayout {
+            id: sectionCol
+            anchors {
+                left: parent.left; right: parent.right; top: parent.top
+                margins: Theme.spacing.medium
+            }
+            spacing: Theme.spacing.tiny
+
+            Text {
+                text: title
+                color: Theme.palette.textSecondary
+                font { pixelSize: 11; bold: true; letterSpacing: 1 }
+            }
+
+            // Counter tiles row
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacing.small
+
+                Repeater {
+                    model: metrics
+                    delegate: Rectangle {
+                        Layout.fillWidth: true
+                        height: 56
+                        radius: Theme.spacing.tiny
+                        color: Theme.palette.backgroundSecondary
+
+                        ColumnLayout {
+                            anchors.centerIn: parent
+                            spacing: 2
+
+                            Text {
+                                text: modelData.value !== undefined ? modelData.value.toString() : "0"
+                                color: (modelData.highlight) ? Theme.palette.error : Theme.palette.primary
+                                font { pixelSize: 20; bold: true; family: "monospace" }
+                                Layout.alignment: Qt.AlignHCenter
+                            }
+
+                            Text {
+                                text: modelData.label || ""
+                                color: Theme.palette.textTertiary
+                                font.pixelSize: 10
+                                Layout.alignment: Qt.AlignHCenter
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/logos-core-module/qml/TaskHistoryView.qml
+++ b/logos-core-module/qml/TaskHistoryView.qml
@@ -1,0 +1,248 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+/**
+ * TaskHistoryView — list of recent tasks sent/received.
+ *
+ * Context properties (injected by LmaoComponent):
+ *   - lmaoModule     : LmaoBackend*
+ *   - lmaoAgentModel : AgentListModel*
+ */
+Item {
+    id: root
+
+    // In-memory task history (most recent first)
+    property var taskHistory: []
+    property int selectedIndex: -1
+
+    function addTask(peer, text, direction, resultJson) {
+        var entry = {
+            timestamp: new Date().toISOString(),
+            peer: peer,
+            text: text,
+            direction: direction,  // "sent" or "received"
+            status: "unknown",
+            taskId: "",
+            duration: 0
+        }
+
+        try {
+            var obj = JSON.parse(resultJson)
+            entry.status = obj.success ? "ok" : "failed"
+            entry.taskId = obj.task_id || ""
+            if (obj.error) entry.text = obj.error
+        } catch (e) {
+            entry.status = "error"
+        }
+
+        var updated = [entry].concat(taskHistory)
+        // Keep max 50 entries
+        if (updated.length > 50) updated = updated.slice(0, 50)
+        taskHistory = updated
+    }
+
+    ColumnLayout {
+        anchors {
+            fill: parent
+            margins: Theme.spacing.large
+        }
+        spacing: Theme.spacing.medium
+
+        // ── Header ──
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing.small
+
+            Text {
+                text: "Task History"
+                color: Theme.palette.text
+                font { pixelSize: 16; bold: true }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            Text {
+                text: taskHistory.length + " tasks"
+                color: Theme.palette.textTertiary
+                font.pixelSize: 12
+            }
+
+            Button {
+                text: "Clear"
+                visible: taskHistory.length > 0
+                onClicked: {
+                    taskHistory = []
+                    selectedIndex = -1
+                }
+                contentItem: Text {
+                    text: parent.text
+                    color: Theme.palette.error
+                    font.pixelSize: 11
+                    horizontalAlignment: Text.AlignHCenter
+                }
+                background: Rectangle {
+                    color: parent.hovered ? Theme.palette.backgroundSecondary : "transparent"
+                    radius: Theme.spacing.tiny
+                    border { color: Theme.palette.error; width: 1 }
+                }
+                height: 26
+            }
+        }
+
+        // ── Task List ──
+        ListView {
+            id: historyList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: Theme.spacing.tiny
+            clip: true
+            model: taskHistory.length
+
+            ScrollBar.vertical: ScrollBar {}
+
+            delegate: Rectangle {
+                width: historyList.width
+                height: taskCol.implicitHeight + Theme.spacing.medium * 2
+                radius: Theme.spacing.radiusLarge
+                color: index === root.selectedIndex
+                       ? Theme.palette.backgroundSecondary
+                       : Theme.palette.backgroundTertiary
+                border {
+                    color: index === root.selectedIndex
+                           ? Theme.palette.primary
+                           : Theme.palette.borderSecondary
+                    width: 1
+                }
+
+                property var task: taskHistory[index] || ({})
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        root.selectedIndex = (root.selectedIndex === index) ? -1 : index
+                    }
+                }
+
+                ColumnLayout {
+                    id: taskCol
+                    anchors {
+                        left: parent.left; right: parent.right; top: parent.top
+                        margins: Theme.spacing.medium
+                    }
+                    spacing: Theme.spacing.tiny
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.spacing.small
+
+                        // Direction indicator
+                        Rectangle {
+                            width: 6; height: 6; radius: 3
+                            color: task.direction === "sent" ? Theme.palette.primary : Theme.palette.success
+                        }
+
+                        Text {
+                            text: task.direction === "sent" ? "→" : "←"
+                            color: Theme.palette.textSecondary
+                            font { pixelSize: 12; family: "monospace" }
+                        }
+
+                        Text {
+                            text: {
+                                var p = task.peer || ""
+                                if (p.length > 16)
+                                    return p.substring(0, 8) + "…" + p.slice(-6)
+                                return p || "(unknown)"
+                            }
+                            color: Theme.palette.text
+                            font { pixelSize: 13; family: "monospace" }
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                        }
+
+                        // Status badge
+                        Rectangle {
+                            width: statusText.implicitWidth + 12
+                            height: 18
+                            radius: 9
+                            color: task.status === "ok" ? "#1B5E20"
+                                 : task.status === "failed" ? "#B71C1C"
+                                 : Theme.palette.backgroundSecondary
+
+                            Text {
+                                id: statusText
+                                anchors.centerIn: parent
+                                text: task.status || "?"
+                                color: "#FFFFFF"
+                                font.pixelSize: 10
+                            }
+                        }
+
+                        Text {
+                            text: {
+                                if (!task.timestamp) return ""
+                                var d = new Date(task.timestamp)
+                                return Qt.formatTime(d, "HH:mm:ss")
+                            }
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 11
+                        }
+                    }
+
+                    // ── Expanded details ──
+                    ColumnLayout {
+                        visible: index === root.selectedIndex
+                        Layout.fillWidth: true
+                        spacing: 2
+
+                        Text {
+                            visible: (task.text || "").length > 0
+                            text: "Text: " + task.text
+                            color: Theme.palette.textSecondary
+                            font.pixelSize: 11
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+
+                        Text {
+                            visible: (task.taskId || "").length > 0
+                            text: "Task ID: " + task.taskId
+                            color: Theme.palette.textTertiary
+                            font { pixelSize: 11; family: "monospace" }
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                        }
+
+                        Text {
+                            text: "Timestamp: " + (task.timestamp || "—")
+                            color: Theme.palette.textTertiary
+                            font.pixelSize: 11
+                        }
+                    }
+                }
+            }
+
+            // ── Empty state ──
+            Column {
+                anchors.centerIn: parent
+                spacing: Theme.spacing.medium
+                visible: taskHistory.length === 0
+
+                Text {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: "No tasks yet"
+                    color: Theme.palette.textTertiary
+                    font.pixelSize: 15
+                }
+                Text {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: "Tasks will appear here as you send and receive them"
+                    color: Theme.palette.textTertiary
+                    font.pixelSize: 12
+                }
+            }
+        }
+    }
+}

--- a/logos-core-module/qml/qml.qrc
+++ b/logos-core-module/qml/qml.qrc
@@ -5,5 +5,8 @@
     <file>Theme.qml</file>
     <file>LmaoView.qml</file>
     <file>AgentCard.qml</file>
+    <file>DashboardView.qml</file>
+    <file>MetricsView.qml</file>
+    <file>TaskHistoryView.qml</file>
   </qresource>
 </RCC>

--- a/logos-core-module/src/DeliveryTransport.cpp
+++ b/logos-core-module/src/DeliveryTransport.cpp
@@ -1,0 +1,164 @@
+#include "DeliveryTransport.h"
+
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QMetaObject>
+#include <QVariant>
+
+DeliveryTransport::DeliveryTransport(QObject* parent)
+    : QObject(parent)
+{
+}
+
+bool DeliveryTransport::init(LogosAPI* logosAPI)
+{
+    if (!logosAPI) {
+        qWarning() << "DeliveryTransport::init — logosAPI is null";
+        return false;
+    }
+
+    // logosAPI is a QObject-derived class from the Logos SDK.
+    // Use QMetaObject::invokeMethod to call getClient("delivery_module")
+    // without needing the full LogosAPI header at compile time.
+    auto* apiObj = reinterpret_cast<QObject*>(logosAPI);
+
+    QObject* client = nullptr;
+    bool ok = QMetaObject::invokeMethod(
+        apiObj,
+        "getClient",
+        Qt::DirectConnection,
+        Q_RETURN_ARG(QObject*, client),
+        Q_ARG(QString, QStringLiteral("delivery_module")));
+
+    if (!ok || !client) {
+        qWarning() << "DeliveryTransport::init — failed to get delivery_module client"
+                    << "(invokeMethod returned" << ok << ")";
+        return false;
+    }
+
+    m_client = client;
+    qDebug() << "DeliveryTransport::init — connected to delivery_module";
+
+    // Connect the messageReceived event from the delivery_module replica.
+    // The delivery_module emits: void eventReceived(const QString& name, const QString& data)
+    connect(m_client, SIGNAL(eventReceived(QString, QString)),
+            this, SLOT(onDeliveryEvent(QString, QString)));
+
+    emit connectedChanged();
+    return true;
+}
+
+void DeliveryTransport::onDeliveryEvent(const QString& eventName, const QString& eventData)
+{
+    if (eventName != QLatin1String("messageReceived"))
+        return;
+
+    QJsonDocument doc = QJsonDocument::fromJson(eventData.toUtf8());
+    if (!doc.isObject())
+        return;
+
+    QJsonObject obj = doc.object();
+    QString topic = obj.value(QLatin1String("contentTopic")).toString();
+    QString payloadB64 = obj.value(QLatin1String("payload")).toString();
+    QByteArray payload = QByteArray::fromBase64(payloadB64.toUtf8());
+
+    emit messageReceived(topic, payload);
+}
+
+QString DeliveryTransport::callMethod(const QString& method, const QVariantList& args)
+{
+    if (!m_client) {
+        qWarning() << "DeliveryTransport::callMethod — not connected";
+        return {};
+    }
+
+    // Build the Logos Core params JSON array:
+    // [{"name":"key","value":"val","type":"string"}, ...]
+    QJsonArray params;
+    for (int i = 0; i + 1 < args.size(); i += 2) {
+        QJsonObject param;
+        param[QLatin1String("name")] = args[i].toString();
+        param[QLatin1String("value")] = args[i + 1].toString();
+        param[QLatin1String("type")] = QStringLiteral("string");
+        params.append(param);
+    }
+
+    QString paramsJson = QString::fromUtf8(
+        QJsonDocument(params).toJson(QJsonDocument::Compact));
+
+    QString result;
+    bool ok = QMetaObject::invokeMethod(
+        m_client,
+        "callMethod",
+        Qt::DirectConnection,
+        Q_RETURN_ARG(QString, result),
+        Q_ARG(QString, method),
+        Q_ARG(QString, paramsJson));
+
+    if (!ok) {
+        qWarning() << "DeliveryTransport::callMethod — invokeMethod failed for" << method;
+        return {};
+    }
+
+    return result;
+}
+
+bool DeliveryTransport::createNode(const QString& configJson)
+{
+    QString result = callMethod(QStringLiteral("createNode"),
+                                {QStringLiteral("cfg"), configJson});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::createNode failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::start()
+{
+    // start takes no params — pass empty list
+    QString result = callMethod(QStringLiteral("start"), {});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::start failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::send(const QString& contentTopic, const QByteArray& payload)
+{
+    QString payloadB64 = QString::fromLatin1(payload.toBase64());
+    QString result = callMethod(QStringLiteral("send"),
+                                {QStringLiteral("contentTopic"), contentTopic,
+                                 QStringLiteral("payload"), payloadB64});
+
+    if (result.startsWith(QLatin1String("error"), Qt::CaseInsensitive)) {
+        qWarning() << "DeliveryTransport::send failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::subscribe(const QString& contentTopic)
+{
+    QString result = callMethod(QStringLiteral("subscribe"),
+                                {QStringLiteral("contentTopic"), contentTopic});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::subscribe failed:" << result;
+        return false;
+    }
+    return true;
+}
+
+bool DeliveryTransport::unsubscribe(const QString& contentTopic)
+{
+    QString result = callMethod(QStringLiteral("unsubscribe"),
+                                {QStringLiteral("contentTopic"), contentTopic});
+    if (result != QLatin1String("true")) {
+        qWarning() << "DeliveryTransport::unsubscribe failed:" << result;
+        return false;
+    }
+    return true;
+}

--- a/logos-core-module/src/DeliveryTransport.h
+++ b/logos-core-module/src/DeliveryTransport.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QByteArray>
+
+class LogosAPI;
+
+/**
+ * DeliveryTransport — QtRO bridge to the delivery_module Logos Core module.
+ *
+ * Obtains a QtRO replica of delivery_module via logosAPI->getClient() and
+ * exposes send/subscribe/unsubscribe as Q_INVOKABLE methods.
+ *
+ * This follows the same pattern used by logos-kv-module and lez-multisig-module.
+ */
+class DeliveryTransport : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool connected READ isConnected NOTIFY connectedChanged)
+
+public:
+    explicit DeliveryTransport(QObject* parent = nullptr);
+    ~DeliveryTransport() override = default;
+
+    /// Acquire the delivery_module replica from logosAPI.
+    /// Returns true if the client was obtained successfully.
+    bool init(LogosAPI* logosAPI);
+
+    bool isConnected() const { return m_client != nullptr; }
+
+    /// Send a payload to a content topic via delivery_module.
+    Q_INVOKABLE bool send(const QString& contentTopic, const QByteArray& payload);
+
+    /// Subscribe to a content topic.
+    Q_INVOKABLE bool subscribe(const QString& contentTopic);
+
+    /// Unsubscribe from a content topic.
+    Q_INVOKABLE bool unsubscribe(const QString& contentTopic);
+
+    /// Initialize the delivery node with a configuration JSON string.
+    Q_INVOKABLE bool createNode(const QString& configJson);
+
+    /// Start the delivery node.
+    Q_INVOKABLE bool start();
+
+signals:
+    void connectedChanged();
+    void messageReceived(const QString& contentTopic, const QByteArray& payload);
+
+private slots:
+    void onDeliveryEvent(const QString& eventName, const QString& eventData);
+
+private:
+    /// Call a method on the delivery_module replica via QMetaObject::invokeMethod.
+    /// Returns the result string, or an empty string on failure.
+    QString callMethod(const QString& method, const QVariantList& args);
+
+    QObject* m_client = nullptr;
+};

--- a/logos-core-module/src/LmaoBackend.cpp
+++ b/logos-core-module/src/LmaoBackend.cpp
@@ -54,11 +54,35 @@ QString LmaoBackend::sendTask(const QString& agentPubkey, const QString& taskTex
 {
     qDebug() << "LmaoBackend::sendTask to=" << agentPubkey;
 
+    // Build the task envelope via FFI (creates Task, A2AEnvelope, base64 payload).
     QJsonObject obj;
     obj[QLatin1String("agent_pubkey")] = agentPubkey;
     obj[QLatin1String("task_text")] = taskText;
     const QByteArray argsUtf8 = QJsonDocument(obj).toJson(QJsonDocument::Compact);
 
+    // If QtRO delivery transport is available, use it as the primary path.
+    // This sends via the real logos-delivery-module inter-module call (issue #143).
+    if (m_delivery && m_delivery->isConnected()) {
+        const QString envelopeResult = callFfiStr(lmao_build_task_envelope(argsUtf8.constData()));
+        QJsonDocument envDoc = QJsonDocument::fromJson(envelopeResult.toUtf8());
+        QJsonObject envObj = envDoc.object();
+
+        if (envObj.value(QLatin1String("success")).toBool()) {
+            const QString topic = envObj.value(QLatin1String("topic")).toString();
+            const QString payloadB64 = envObj.value(QLatin1String("payload_b64")).toString();
+            const QByteArray payload = QByteArray::fromBase64(payloadB64.toUtf8());
+
+            qDebug() << "LmaoBackend::sendTask — sending via QtRO delivery_module";
+            if (m_delivery->send(topic, payload)) {
+                emit taskSent(envelopeResult);
+                return envelopeResult;
+            }
+            qWarning() << "LmaoBackend::sendTask — QtRO send failed, falling back to FFI";
+        }
+    }
+
+    // Fallback: send via Rust FFI transport (nwaku REST or logos-core C API).
+    qDebug() << "LmaoBackend::sendTask — sending via FFI transport";
     const QString result = callFfiStr(lmao_send_task(argsUtf8.constData()));
     emit taskSent(result);
     return result;
@@ -98,41 +122,7 @@ bool LmaoBackend::deliverySend(const QString& contentTopic, const QByteArray& pa
 
 QString LmaoBackend::sendTaskViaDelivery(const QString& agentPubkey, const QString& taskText)
 {
-    qDebug() << "LmaoBackend::sendTaskViaDelivery to=" << agentPubkey;
-
-    // Build the task envelope via FFI (creates Task, A2AEnvelope, base64 payload).
-    QJsonObject obj;
-    obj[QLatin1String("agent_pubkey")] = agentPubkey;
-    obj[QLatin1String("task_text")] = taskText;
-    const QByteArray argsUtf8 = QJsonDocument(obj).toJson(QJsonDocument::Compact);
-
-    const QString envelopeResult = callFfiStr(lmao_build_task_envelope(argsUtf8.constData()));
-    QJsonDocument envDoc = QJsonDocument::fromJson(envelopeResult.toUtf8());
-    QJsonObject envObj = envDoc.object();
-
-    if (!envObj.value(QLatin1String("success")).toBool()) {
-        emit errorOccurred(envObj.value(QLatin1String("error")).toString());
-        return envelopeResult;
-    }
-
-    // If QtRO delivery transport is available, send via delivery_module directly.
-    if (m_delivery && m_delivery->isConnected()) {
-        const QString topic = envObj.value(QLatin1String("topic")).toString();
-        const QString payloadB64 = envObj.value(QLatin1String("payload_b64")).toString();
-        const QByteArray payload = QByteArray::fromBase64(payloadB64.toUtf8());
-
-        qDebug() << "LmaoBackend::sendTaskViaDelivery — sending via QtRO delivery_module";
-        bool ok = m_delivery->send(topic, payload);
-        if (ok) {
-            emit taskSent(envelopeResult);
-            return envelopeResult;
-        }
-        qWarning() << "LmaoBackend::sendTaskViaDelivery — QtRO send failed, falling back to FFI";
-    }
-
-    // Fallback: send via Rust FFI transport (nwaku REST or logos-core C API).
-    qDebug() << "LmaoBackend::sendTaskViaDelivery — sending via FFI transport";
-    const QString result = callFfiStr(lmao_send_task(argsUtf8.constData()));
-    emit taskSent(result);
-    return result;
+    // Deprecated: sendTask() now automatically prefers the QtRO delivery transport.
+    // This method is kept for backwards compatibility with existing QML code.
+    return sendTask(agentPubkey, taskText);
 }

--- a/logos-core-module/src/LmaoBackend.cpp
+++ b/logos-core-module/src/LmaoBackend.cpp
@@ -70,6 +70,18 @@ QString LmaoBackend::getAgentCard()
     return callFfiStr(lmao_get_agent_card());
 }
 
+QString LmaoBackend::getInfo()
+{
+    qDebug() << "LmaoBackend::getInfo";
+    return callFfiStr(lmao_get_info());
+}
+
+QString LmaoBackend::getMetrics()
+{
+    qDebug() << "LmaoBackend::getMetrics";
+    return callFfiStr(lmao_get_metrics());
+}
+
 bool LmaoBackend::deliverySend(const QString& contentTopic, const QByteArray& payload)
 {
     if (!m_delivery) {

--- a/logos-core-module/src/LmaoBackend.cpp
+++ b/logos-core-module/src/LmaoBackend.cpp
@@ -1,4 +1,5 @@
 #include "LmaoBackend.h"
+#include "DeliveryTransport.h"
 
 #include <QDebug>
 #include <QJsonDocument>
@@ -13,9 +14,15 @@ extern "C" {
 }
 #endif
 
-LmaoBackend::LmaoBackend(QObject* parent)
+LmaoBackend::LmaoBackend(DeliveryTransport* delivery, QObject* parent)
     : QObject(parent)
+    , m_delivery(delivery)
 {
+    if (m_delivery) {
+        qDebug() << "LmaoBackend: using QtRO delivery transport";
+    } else {
+        qDebug() << "LmaoBackend: no QtRO transport — using FFI only";
+    }
 }
 
 /*static*/
@@ -61,4 +68,18 @@ QString LmaoBackend::getAgentCard()
 {
     qDebug() << "LmaoBackend::getAgentCard";
     return callFfiStr(lmao_get_agent_card());
+}
+
+bool LmaoBackend::deliverySend(const QString& contentTopic, const QByteArray& payload)
+{
+    if (!m_delivery) {
+        qDebug() << "LmaoBackend::deliverySend — no QtRO transport available";
+        return false;
+    }
+
+    bool ok = m_delivery->send(contentTopic, payload);
+    if (!ok) {
+        emit errorOccurred(QStringLiteral("delivery_module send failed via QtRO"));
+    }
+    return ok;
 }

--- a/logos-core-module/src/LmaoBackend.cpp
+++ b/logos-core-module/src/LmaoBackend.cpp
@@ -95,3 +95,44 @@ bool LmaoBackend::deliverySend(const QString& contentTopic, const QByteArray& pa
     }
     return ok;
 }
+
+QString LmaoBackend::sendTaskViaDelivery(const QString& agentPubkey, const QString& taskText)
+{
+    qDebug() << "LmaoBackend::sendTaskViaDelivery to=" << agentPubkey;
+
+    // Build the task envelope via FFI (creates Task, A2AEnvelope, base64 payload).
+    QJsonObject obj;
+    obj[QLatin1String("agent_pubkey")] = agentPubkey;
+    obj[QLatin1String("task_text")] = taskText;
+    const QByteArray argsUtf8 = QJsonDocument(obj).toJson(QJsonDocument::Compact);
+
+    const QString envelopeResult = callFfiStr(lmao_build_task_envelope(argsUtf8.constData()));
+    QJsonDocument envDoc = QJsonDocument::fromJson(envelopeResult.toUtf8());
+    QJsonObject envObj = envDoc.object();
+
+    if (!envObj.value(QLatin1String("success")).toBool()) {
+        emit errorOccurred(envObj.value(QLatin1String("error")).toString());
+        return envelopeResult;
+    }
+
+    // If QtRO delivery transport is available, send via delivery_module directly.
+    if (m_delivery && m_delivery->isConnected()) {
+        const QString topic = envObj.value(QLatin1String("topic")).toString();
+        const QString payloadB64 = envObj.value(QLatin1String("payload_b64")).toString();
+        const QByteArray payload = QByteArray::fromBase64(payloadB64.toUtf8());
+
+        qDebug() << "LmaoBackend::sendTaskViaDelivery — sending via QtRO delivery_module";
+        bool ok = m_delivery->send(topic, payload);
+        if (ok) {
+            emit taskSent(envelopeResult);
+            return envelopeResult;
+        }
+        qWarning() << "LmaoBackend::sendTaskViaDelivery — QtRO send failed, falling back to FFI";
+    }
+
+    // Fallback: send via Rust FFI transport (nwaku REST or logos-core C API).
+    qDebug() << "LmaoBackend::sendTaskViaDelivery — sending via FFI transport";
+    const QString result = callFfiStr(lmao_send_task(argsUtf8.constData()));
+    emit taskSent(result);
+    return result;
+}

--- a/logos-core-module/src/LmaoBackend.h
+++ b/logos-core-module/src/LmaoBackend.h
@@ -3,22 +3,36 @@
 #include <QObject>
 #include <QString>
 
+class DeliveryTransport;
+
 /**
  * LmaoBackend — QObject wrapper around lmao-ffi for QML integration.
  *
  * Exposes agent discovery, task sending, and agent card retrieval
  * as Q_INVOKABLE methods callable from QML.
+ *
+ * When a DeliveryTransport (QtRO) is available, message sending uses
+ * the delivery_module via QtRO inter-module calls (issue #77).
+ * Falls back to Rust FFI transport when QtRO is unavailable.
  */
 class LmaoBackend : public QObject {
     Q_OBJECT
+    Q_PROPERTY(bool hasDeliveryTransport READ hasDeliveryTransport CONSTANT)
 
 public:
-    explicit LmaoBackend(QObject* parent = nullptr);
+    explicit LmaoBackend(DeliveryTransport* delivery = nullptr,
+                         QObject* parent = nullptr);
     ~LmaoBackend() override = default;
+
+    bool hasDeliveryTransport() const { return m_delivery != nullptr; }
 
     Q_INVOKABLE QString discoverAgents(const QString& timeoutMs);
     Q_INVOKABLE QString sendTask(const QString& agentPubkey, const QString& taskText);
     Q_INVOKABLE QString getAgentCard();
+
+    /// Send raw bytes to a content topic via QtRO delivery transport.
+    /// Returns true if sent via QtRO, false if QtRO unavailable (caller should fall back).
+    Q_INVOKABLE bool deliverySend(const QString& contentTopic, const QByteArray& payload);
 
 signals:
     void agentsDiscovered(const QString& json);
@@ -27,4 +41,5 @@ signals:
 
 private:
     static QString callFfiStr(char* raw);
+    DeliveryTransport* m_delivery = nullptr;
 };

--- a/logos-core-module/src/LmaoBackend.h
+++ b/logos-core-module/src/LmaoBackend.h
@@ -36,6 +36,10 @@ public:
     /// Returns true if sent via QtRO, false if QtRO unavailable (caller should fall back).
     Q_INVOKABLE bool deliverySend(const QString& contentTopic, const QByteArray& payload);
 
+    /// Send a task via QtRO delivery transport if available, falling back to FFI.
+    /// This is the preferred path when running inside Logos Core (issue #143).
+    Q_INVOKABLE QString sendTaskViaDelivery(const QString& agentPubkey, const QString& taskText);
+
 signals:
     void agentsDiscovered(const QString& json);
     void taskSent(const QString& json);

--- a/logos-core-module/src/LmaoBackend.h
+++ b/logos-core-module/src/LmaoBackend.h
@@ -29,6 +29,8 @@ public:
     Q_INVOKABLE QString discoverAgents(const QString& timeoutMs);
     Q_INVOKABLE QString sendTask(const QString& agentPubkey, const QString& taskText);
     Q_INVOKABLE QString getAgentCard();
+    Q_INVOKABLE QString getInfo();
+    Q_INVOKABLE QString getMetrics();
 
     /// Send raw bytes to a content topic via QtRO delivery transport.
     /// Returns true if sent via QtRO, false if QtRO unavailable (caller should fall back).

--- a/logos-core-module/src/LmaoBackend.h
+++ b/logos-core-module/src/LmaoBackend.h
@@ -11,9 +11,10 @@ class DeliveryTransport;
  * Exposes agent discovery, task sending, and agent card retrieval
  * as Q_INVOKABLE methods callable from QML.
  *
- * When a DeliveryTransport (QtRO) is available, message sending uses
- * the delivery_module via QtRO inter-module calls (issue #77).
- * Falls back to Rust FFI transport when QtRO is unavailable.
+ * When a DeliveryTransport (QtRO) is available, all message sending
+ * automatically uses the real logos-delivery-module via QtRO inter-module
+ * calls (issue #77, #143). Falls back to Rust FFI transport when QtRO
+ * is unavailable.
  */
 class LmaoBackend : public QObject {
     Q_OBJECT
@@ -36,8 +37,8 @@ public:
     /// Returns true if sent via QtRO, false if QtRO unavailable (caller should fall back).
     Q_INVOKABLE bool deliverySend(const QString& contentTopic, const QByteArray& payload);
 
-    /// Send a task via QtRO delivery transport if available, falling back to FFI.
-    /// This is the preferred path when running inside Logos Core (issue #143).
+    /// Deprecated: sendTask() now automatically uses QtRO delivery when available.
+    /// Kept for backwards compatibility with existing QML code.
     Q_INVOKABLE QString sendTaskViaDelivery(const QString& agentPubkey, const QString& taskText);
 
 signals:

--- a/logos-core-module/src/LmaoComponent.cpp
+++ b/logos-core-module/src/LmaoComponent.cpp
@@ -1,6 +1,7 @@
 #include "LmaoComponent.h"
 #include "LmaoBackend.h"
 #include "AgentListModel.h"
+#include "DeliveryTransport.h"
 
 #include <QQuickWidget>
 #include <QQmlContext>
@@ -52,15 +53,27 @@ void LmaoComponent::initialize()
     m_initialized = true;
 }
 
-QWidget* LmaoComponent::createWidget(LogosAPI* /*logosAPI*/)
+QWidget* LmaoComponent::createWidget(LogosAPI* logosAPI)
 {
     initialize();
+
+    // Store logosAPI and set up QtRO delivery transport (issue #77).
+    m_logosAPI = logosAPI;
+    if (logosAPI && !m_delivery) {
+        m_delivery = new DeliveryTransport(this);
+        if (m_delivery->init(logosAPI)) {
+            qDebug() << "LmaoComponent: delivery transport connected via QtRO";
+        } else {
+            qWarning() << "LmaoComponent: delivery transport init failed — "
+                           "falling back to FFI transport";
+        }
+    }
 
     auto* widget = new QQuickWidget();
     widget->setMinimumSize(500, 400);
     widget->setResizeMode(QQuickWidget::SizeRootObjectToView);
 
-    auto* backend = new LmaoBackend();
+    auto* backend = new LmaoBackend(m_delivery);
     backend->setParent(widget);
 
     auto* model = new AgentListModel();
@@ -68,6 +81,7 @@ QWidget* LmaoComponent::createWidget(LogosAPI* /*logosAPI*/)
 
     widget->rootContext()->setContextProperty("lmaoModule", backend);
     widget->rootContext()->setContextProperty("lmaoAgentModel", model);
+    widget->rootContext()->setContextProperty("lmaoDelivery", m_delivery);
     widget->setSource(QUrl("qrc:/lmao/LmaoView.qml"));
 
     return widget;

--- a/logos-core-module/src/LmaoComponent.h
+++ b/logos-core-module/src/LmaoComponent.h
@@ -5,11 +5,13 @@
 #include <QString>
 
 class LmaoBackend;
+class DeliveryTransport;
 
 /**
  * LmaoComponent — Logos Core IComponent plugin for LMAO (A2A over Waku).
  *
  * Provides agent discovery and task sending over the Waku network.
+ * Uses QtRO to call delivery_module for message transport (issue #77).
  */
 class LmaoComponent : public QObject, public IComponent {
     Q_OBJECT
@@ -31,4 +33,6 @@ public:
 
 private:
     bool m_initialized = false;
+    LogosAPI* m_logosAPI = nullptr;
+    DeliveryTransport* m_delivery = nullptr;
 };

--- a/logos-core-module/src/lmao_ffi.h
+++ b/logos-core-module/src/lmao_ffi.h
@@ -27,6 +27,16 @@ char *lmao_discover_agents(const char *args_json);
 char *lmao_send_task(const char *args_json);
 
 /**
+ * Build a task envelope without sending it — for use with external transports (QtRO).
+ *
+ * args_json: { "agent_pubkey": "02...", "task_text": "Hello" }
+ *
+ * Returns: { "success": true, "task_id": "...", "topic": "/lmao/1/task/...",
+ *            "payload_b64": "<base64-encoded A2A envelope>" }
+ */
+char *lmao_build_task_envelope(const char *args_json);
+
+/**
  * Get this agent's card as JSON.
  *
  * Returns: { "success": true, "card": { "name": "...", ... } }

--- a/logos-core-module/src/lmao_ffi.h
+++ b/logos-core-module/src/lmao_ffi.h
@@ -34,6 +34,21 @@ char *lmao_send_task(const char *args_json);
 char *lmao_get_agent_card(void);
 
 /**
+ * Get agent info: identity, topics, and encryption status.
+ *
+ * Returns: { "success": true, "public_key": "02...", "task_topic": "...",
+ *            "discovery_topic": "...", "presence_topic": "...", "encryption": false }
+ */
+char *lmao_get_info(void);
+
+/**
+ * Get operational metrics counters.
+ *
+ * Returns: { "success": true, "tasks_sent": 0, "tasks_received": 0, ... }
+ */
+char *lmao_get_metrics(void);
+
+/**
  * Free a string returned by any lmao_* function.
  */
 void lmao_free_string(char *s);


### PR DESCRIPTION
## Summary

Implements the core infrastructure for a decentralized skill marketplace (LMAO #140):

- **Core types**: `SkillDescriptor`, `SkillRating`, `SkillAnnouncement` in `logos-messaging-a2a-core`
- **Skill registry**: `SkillRegistry` trait + `InMemorySkillRegistry` with tag search, rating management, and author-only updates
- **Wire protocol**: New `A2AEnvelope::SkillAnnouncement` variant and `/lmao/1/skills/proto` topic
- **Node marketplace**: `SkillMarketplace` struct with trust set management, subjective ranking via trusted peers, auto-adopt candidate detection, and pub/sub skill announcements over Waku

### Architecture
- **Publish**: Agents announce skill bundles (pinned to Codex content hashes) on the skills topic
- **Discover**: Agents subscribe to skill announcements and query the registry by tag
- **Rank**: Each agent maintains a trust set; effective rank = average of ratings from trusted peers only (no global authority)
- **Auto-adopt**: `adoption_candidates()` returns skills above a configurable threshold that aren't yet installed

## Test plan

- [x] All existing workspace tests pass (`cargo test --workspace`)
- [x] New unit tests for `SkillDescriptor`, `SkillRating`, `SkillAnnouncement` serialization
- [x] New unit tests for `InMemorySkillRegistry` (register, update, deregister, find_by_tag, rate, get_ratings)
- [x] New unit tests for `SkillMarketplace` (trust set, ranking, adoption candidates, announce/discover)
- [x] Envelope variant produces distinct `skill_announcement` type tag

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)